### PR TITLE
DOC

### DIFF
--- a/utilities/ft_selectdata_new.m
+++ b/utilities/ft_selectdata_new.m
@@ -8,7 +8,8 @@ function [varargout] = ft_selectdata_new(cfg, varargin)
 %  [data] = ft_selectdata_new(cfg, data, ...)
 %
 % Valid cfg field are:
-%   cfg.trials  = 1xN, trial indices to keep (can be 'all', [] removes all trials)
+%   cfg.trials  = 1xN, trial indices to keep. It can be 'all'. You can use
+%                 logical indexing, where false(1,N) removes all the trials) 
 % For data with a time-dimension possible specifications are
 %   cfg.latency = value     -> can be 'all'
 %   cfg.latency = [beg end]


### PR DESCRIPTION
Clarify how to use cfg.trials and use logical indexing to remove all trials. 
The doc of the current version says that cfg.trials = [] removes the trials but it does not work (because of ft_getopt). Only with false(numel(data.trial),1) can you remove them all.
