### PR TITLE
fieldtrip2fiff converts raw, epoched, and timelocked data

### DIFF
--- a/fieldtrip2fiff.m
+++ b/fieldtrip2fiff.m
@@ -1,5 +1,4 @@
 function fieldtrip2fiff(filename, data)
-
 % FIELDTRIP2FIFF saves a FieldTrip raw data structure as a fiff-file,
 % in order to be useable by the Neuromag software, or in the MNE suite
 % software.
@@ -8,11 +7,18 @@ function fieldtrip2fiff(filename, data)
 %   fieldtrip2fiff(filename, data)
 % where filename is the name of the output file, and data is a raw
 % data structure as obtained from FT_PREPROCESSING, or a timelock
-% structure obtained from FT_TIMELOCKANALYSIS.
+% structure obtained from FT_TIMELOCKANALYSIS. If the data comes from
+% preprocessing and has only one trial, then it writes the data into raw
+% continuous format. If present in the data, the original header from
+% neuromag is reused (also removing the non-used channels). Otherwise, the
+% function tries to create a correct header, which might or might not
+% contain the correct scaling and channel location. If the data contains
+% events in the cfg structure, it writes the events in the MNE format
+% (three columns) into a file based on "filename", ending with "-eve.fif"
 %
 % See also FT_DATATYPE_RAW, FT_DATATYPE_TIMELOCK
 
-% Copyright (C) 2012, Jan-Mathijs Schoffelen
+% Copyright (C) 2012-3, Jan-Mathijs Schoffelen, Gio Piantoni
 %
 % This file is part of FieldTrip, see http://www.ru.nl/neuroimaging/fieldtrip
 % for the documentation and details.
@@ -39,12 +45,12 @@ ft_preamble help            % this will show the function help if nargin==0 and 
 ft_preamble callinfo        % this records the time and memory usage at teh beginning of the function
 
 % ensure that the filename has the correct extension
-[pathstr,name,ext] = fileparts(filename);
-if isempty(ext),
-  filename = [filename, '.fif'];
-elseif ~strcmp(ext, '.fif')
+[pathstr, name, ext] = fileparts(filename);
+if ~strcmp(ext, '.fif')
   error('if the filename is specified with extension, this should read .fif');
 end
+fifffile = [pathstr filesep name '.fif'];
+eventfile = [pathstr filesep name '-eve.fif'];
 
 % ensure the mne-toolbox to be on the path
 ft_hastoolbox('mne', 1);
@@ -52,84 +58,138 @@ ft_hastoolbox('mne', 1);
 % check the input data
 data   = ft_checkdata(data, 'datatype', {'raw', 'timelock'}, 'feedback', 'yes');
 istlck = ft_datatype(data, 'timelock');
-israw  = ft_datatype(data, 'raw');
+isepch = ft_datatype(data, 'raw');
+israw = false;
+if isepch && numel(data.trial) == 1
+  isepch = false;
+  israw = true;
+end
 
 % Create a fiff-header, or take it from the original header if possible
 if ft_senstype(data, 'neuromag') && isfield(data, 'hdr')
-  % Tune the original FIFF header to match with the data
-  info       = data.hdr.orig;
-  info.sfreq = fsample;
-  if info.nchan ~= size(dataout{1},1);
-    fprintf('WARNING: A non-matching number of channels in the FT data structure and original file header. Integrity of the data might be compromised\');
-    info.nchan = size(dataout{1},1);
-    info.chs = info.chs(1:size(dataout{1},1)); % FIXME: Terrible hack to tolerate removal of channels
-  end
-else
-  info.meas_id.version = nan;
-  info.meas_id.machid  = [nan;nan];
-  info.meas_id.secs    = nan;
-  info.meas_id.usecs   = nan;
-  info.meas_date       = [nan;nan];
+  fprintf('Using the original FIFF header, but channel locations are read \nfrom .grad and .elec in the data, if they exist\n')
+  info = data.hdr.orig;
   
-  info.nchan    = numel(data.label);
-  info.highpass = nan;
-  info.lowpass  = nan;
-  info.dev_head_t = [];
+else
+  
+  info.meas_id.version = NaN;
+  info.meas_id.machid  = [NaN;NaN];
+  info.meas_id.secs    = NaN;
+  info.meas_id.usecs   = NaN;
+  info.meas_date       = [NaN;NaN];
+  info.acq_pars = []; % needed by raw
+  info.acq_stim = []; % needed by raw
+  
+  info.highpass = NaN;
+  info.lowpass  = NaN;
+  % no strictly necessary, but the inverse functions in MNE works better if
+  % this matrix is present
+  info.dev_head_t.from = 1;
+  info.dev_head_t.to = 4;
+  info.dev_head_t.trans = eye(4);
+  
   info.ctf_head_t = [];
   info.dig      = [];
-  info.projs    = [];
-  info.comps    = [];
+  info.projs = struct('kind', {}, 'active', {}, 'desc', {}, 'data', {});
+  info.comps = struct('ctfkind', {}, 'kind', {}, 'save_calibrated', {}, ...
+    'rowcals', {}, 'colcals', {}, 'data', {});
   info.bads     = [];
-  info.ch_names = data.label(:)';
-  info.chs      = grad2fiff(data);
-  if istlck,
-    info.sfreq     = 1./mean(diff(data.time));
-    info.isaverage = 1;
-    info.isepoched = 0;
-    info.iscontinuous = 0;
-  elseif israw,
+  
+  if isepch
     info.sfreq     = 1./mean(diff(data.time{1}));
     info.isaverage = 0;
     info.isepoched = 1;
     info.iscontinuous = 0;
+    
+  elseif istlck
+    info.sfreq     = 1./mean(diff(data.time));
+    info.isaverage = 1;
+    info.isepoched = 0;
+    info.iscontinuous = 0;
+    
   end
+  
 end
 
-if istlck
-  evoked.aspect_kind = 100;
-  evoked.is_smsh     = 0;
-  evoked.nave        = max(data.dof(:));
-  evoked.first       = round(data.time(1)*info.sfreq);
-  evoked.last        = round(data.time(end)*info.sfreq);
-  evoked.times       = data.time;
-  evoked.comment     = sprintf('FieldTrip data averaged');
-  evoked.epochs      = data.avg;
-elseif israw
-  for j = 1:length(data)
-    evoked(j).aspect_kind = 100;
-    evoked(j).is_smsh     = 0; % FIXME: How could we tell?
-    evoked(j).nave        = 1; % FIXME: Use the real value
-    evoked(j).first       = round(data.time{j}(1)*info.sfreq);
-    evoked(j).last        = round(data.time{j}(end)*info.sfreq);
-    evoked(j).times       = data.time{j};
-    evoked(j).comment     = sprintf('FieldTrip data, category/trial %d', j);
-    evoked(j).epochs      = data.trial{j};
-  end  
+if israw
+  info.sfreq = data.fsample;
+elseif isepch
+  info.sfreq = 1 ./ mean(diff(data.time{1}));
+elseif istlck
+  info.sfreq = 1 ./ mean(diff(data.time));
 end
+info.ch_names = data.label(:)';
+info.chs      = sens2fiff(data);
+info.nchan    = numel(data.label);
 
-fiffdata.info   = info;
-fiffdata.evoked = evoked;
-
-fiff_write_evoked(filename, fiffdata);
+if israw
+  [outfid, cals] = fiff_start_writing_raw(fifffile, info);
+  fiff_write_raw_buffer(outfid, data.trial{1}, cals);
+  fiff_finish_writing_raw(outfid);
+  
+  % write events, if they exists
+  event = ft_findcfg(data.cfg, 'event');
+  if ~isempty(event)
+    eve = convertevent(event);
+    mne_write_events(eventfile, eve);
+    fprintf('Writing events to %s\n', eventfile)
+  end
+  
+elseif isepch || istlck
+  
+  if isepch
+    for j = 1:length(data.trial)
+      evoked(j).aspect_kind = 100;
+      evoked(j).is_smsh     = 0; % FIXME: How could we tell?
+      evoked(j).nave        = 1; % FIXME: Use the real value
+      evoked(j).first       = round(data.time{j}(1)*info.sfreq);
+      evoked(j).last        = round(data.time{j}(end)*info.sfreq);
+      evoked(j).times       = data.time{j};
+      evoked(j).comment     = sprintf('FieldTrip data, category/trial %d', j);
+      evoked(j).epochs      = data.trial{j};
+    end
+    
+  elseif istlck
+    evoked.aspect_kind = 100;
+    evoked.is_smsh     = 0;
+    evoked.nave        = max(data.dof(:));
+    evoked.first       = round(data.time(1)*info.sfreq);
+    evoked.last        = round(data.time(end)*info.sfreq);
+    evoked.times       = data.time;
+    evoked.comment     = sprintf('FieldTrip data averaged');
+    evoked.epochs      = data.avg;
+    
+  end
+  
+  fiffdata.info   = info;
+  fiffdata.evoked = evoked;
+  fiff_write_evoked(fifffile, fiffdata);
+  
+end
 
 ft_postamble callinfo         % this records the time and memory at the end of the function, prints them on screen and adds this information together with the function name and matlab version etc. to the output cfg
-ft_postamble previous datain  % this copies the datain.cfg structure into the cfg.previous field. You can also use it for multiple inputs, or for "varargin"
-ft_postamble history dataout  % this adds the local cfg structure to the output data structure, i.e. dataout.cfg = cfg
-ft_postamble savevar dataout  % this saves the output data structure to disk in case the user specified the cfg.outputfile option
+%TODO: are these three below necessary? there is no output
+% ft_postamble previous datain  % this copies the datain.cfg structure into the cfg.previous field. You can also use it for multiple inputs, or for "varargin"
+% ft_postamble history dataout  % this adds the local cfg structure to the output data structure, i.e. dataout.cfg = cfg
+% ft_postamble savevar dataout  % this saves the output data structure to disk in case the user specified the cfg.outputfile option
 
 %-------------------
 % subfunction
-function [chs] = grad2fiff(data)
+function [chs] = sens2fiff(data)
+
+% use orig information if available
+if isfield(data, 'hdr') && isfield(data.hdr, 'orig') && ...
+  isfield(data.hdr.orig, 'chs')
+
+  [dummy, i_label, i_chs] = intersect(data.label, {data.hdr.orig.chs.ch_name});
+  chs(i_label) = data.hdr.orig.chs(i_chs);
+  return
+
+end
+
+% otherwise reconstruct it
+fprintf('Reconstructing channel locations, it might be inaccurate\n')
+FIFF = fiff_define_constants; % some constants are not defined in the Matlab function
 
 if isfield(data, 'grad')
   hasgrad = true;
@@ -137,101 +197,132 @@ else
   hasgrad = false;
 end
 
-for k = 1:numel(data.label)
-  % create a struct for each channel
-  chs(1,k).scanno       = 1;
-  chs(1,k).logno        = 1;
-  chs(1,k).kind         = nan;
-  chs(1,k).range        = 1;
-  chs(1,k).cal          = 1;
-  chs(1,k).coil_type    = nan;
-  chs(1,k).loc          = zeros(12,1);
-  chs(1,k).coil_trans   = eye(4);
-  chs(1,k).eeg_loc      = [];
-  chs(1,k).coord_frame  = nan;
-  chs(1,k).unit         = nan;
-  chs(1,k).unit_mul     = 0;
-  chs(1,k).ch_name      = data.label{k};
+if isfield(data, 'elec')
+  haselec = true;
+  elec = ft_convert_units(data.elec, 'cm'); % that MNE uses cm
+else
+  haselec = false;
 end
 
-if hasgrad
-  % the position information can be recovered, too
-  [i1,i2] = match_str(data.label, data.grad.label);
-  for k = 1:numel(i1)
-    chs(1,i1(k)).kind        = 1;
-    chs(1,i1(k)).coil_type   = 3022;
-    chs(1,i1(k)).unit        = 112;
-    chs(1,i1(k)).coord_frame = int32(4); % head coordinates
-    chs(1,i1(k)).loc(1:3)    = data.grad.chanpos(i2(k),:);
-    chs(1,i1(k)).loc(4:end)  = reshape(eye(3),[9 1]);
+cnt_grad = 0;
+cnt_elec = 0;
+cnt_else = 0;
+
+for k = 1:numel(data.label)
+  % create a struct for each channel
+  chs(1,k).scanno       = k;
+  chs(1,k).ch_name      = data.label{k};
+  
+  chs(1,k).range        = 1;
+  chs(1,k).cal          = 1;
+  
+  i_grad = false;
+  i_elec = false;
+  if hasgrad
+    i_grad = strcmp(data.grad.label, data.label{k});
+  elseif haselec
+    i_elec = strcmp(elec.label, data.label{k});
+  end
+  
+  if any(i_grad)
+    chs(1,k).kind         = FIFF.FIFFV_MEG_CH;
+    cnt_grad = cnt_grad + 1;
+    chs(1,k).logno        = cnt_grad;
+    switch data.grad.chantype{i_grad}
+      case 'megmag'
+        chs(1,k).coil_type    = 3024;
+        chs(1,k).unit         = FIFF.FIFF_UNIT_T;
+      case 'megplanar'
+        chs(1,k).coil_type    = 3012;
+        chs(1,k).unit         = FIFF.FIFF_UNIT_T_M;
+      case 'meggrad'
+        chs(1,k).coil_type    = 3022;
+        chs(1,k).unit         = FIFF.FIFF_UNIT_T;
+      otherwise
+        fprintf('Unknown channel type %s, assigned to meggrad', data.grad.chantype{i_grad})
+        chs(1,k).coil_type    = 3022;
+        chs(1,k).unit         = FIFF.FIFF_UNIT_T;
+    end
+    chs(1,k).coil_trans   = eye(4);
+    chs(1,k).unit_mul     = 0;
+    chs(1,k).coord_frame  = FIFF.FIFFV_COORD_HEAD;
+    chs(1,k).eeg_loc      = [];
+    chs(1,k).loc          = [data.grad.chanpos(i_grad,:)'; reshape(eye(3),[9 1])];
+    
+  elseif any(i_elec)
+    chs(1,k).kind         = FIFF.FIFFV_EEG_CH;
+    cnt_elec = cnt_elec + 1;
+    chs(1,k).logno        = cnt_elec;
+    chs(1,k).coil_type    = NaN;
+    chs(1,k).coil_trans   = [];
+    chs(1,k).unit         = 107; % volts FIFF.FIFF_UNIT_V
+    chs(1,k).unit_mul     = -6; % micro FIFF.FIFF_UNITM_MU
+    chs(1,k).coord_frame  = FIFF.FIFFV_COORD_DEVICE;
+    chs(1,k).eeg_loc      = [elec.chanpos(i_elec,:)' zeros(3,1)] / 100;
+    chs(1,k).loc          = [chs(1,k).eeg_loc(:); 0; 1; 0; 0; 0; 1];
+    
+  else
+    chs(1,k).kind         = NaN;
+    cnt_else = cnt_else + 1;
+    chs(1,k).logno        = cnt_else;
+    chs(1,k).coil_type    = NaN;
+    chs(1,k).coil_trans   = [];
+    chs(1,k).unit         = NaN;
+    chs(1,k).unit_mul     = 0;
+    chs(1,k).coord_frame  = NaN;
+    chs(1,k).eeg_loc      = [];
+    chs(1,k).loc          = zeros(12,1);
+      
+  end
+  
+end
+
+function eve = convertevent(event)
+% tentative code, with lots of assumption
+
+%CTF should use backpanel trigger
+backpanel = strcmp({event.type}, 'backpanel trigger');
+if any(backpanel)
+  fprintf('Writing the value of the backpanel trigger into the event file\n')
+  trigger = [event(backpanel).value];
+  
+  eve = zeros(numel(trigger), 3);
+  eve(:,1) = [event(backpanel).sample];
+  eve(:,2) = [event(backpanel).value];
+  return
+end
+
+% use ev_type and ev_value
+ev_type = unique({event.type});
+% convert to cell of strings
+if any(cellfun(@isnumeric, {event.value}))
+  event_value = cellfun(@num2str, {event.value}, 'uni', false);
+else
+  event_value = {event.value};
+end
+ev_value = unique(event_value);
+
+eve = zeros(numel(event), 3);
+
+for i1 = 1:numel(ev_type)
+  for i2 = 1:numel(ev_value)
+    i_type = strcmp({event.type}, ev_type{i1});
+    i_value = strcmp(event_value, ev_value{i2});
+    marker = i1 * 10 + i2;
+    
+    if any(i_type & i_value)
+      eve(i_type & i_value, 1) = [event(i_type & i_value).sample];
+      eve(i_type & i_value, 2) = marker;
+    end
+    
   end
 end
 
-% Below the documentation to the original code contributed by Lauri
-% Parkkonen
-%
-% fieldtrip2fiff(filename, data)
-%
-% Write the data in the FieldTrip structure 'data' to a FIFF file
-% 'filename'. If an average
-%
-% Caveats:
-%
-% - the FIFF tag indicating the number of trials in average is set to unity
-%     as there is no generic way to determine a proper value.
-%
-% - the FIFF tag indicating the use of 'MaxShield' is set to 'no'.
-%
-% - if channels have been removed in FieldTrip, channel information for
-%     a matching number of channels is copied from the original FIFF
-%     header. If channels have been removed from anywhere else except from
-%     the end, this simple hack screws up the pairing of signals and channel
-%     identities. BEWARE!
-
-% (C)opyright Lauri Parkkonen, 2010 - 2011
-%
-% $Log$
-%
-
-% % Construct the evoked data aspect for each category
-% ave = isfield(data, 'average');
-% trl = isfield(data, 'trial');
-%
-% if ave && trl
-%     fprintf('WARNING: Data structure contains both an average and individual trials; writing out the average');
-%     dataout = data.average;
-% elseif ave && ~trl
-%     dataout = data.average;
-% elseif ~ave && trl
-%     dataout = data.trial;
-% else
-%     error('No average or trial data to write out');
-% end
-% 
-% % Tune the original FIFF header to match with the data
-% info = data.hdr.orig;
-% info.sfreq = data.fsample;
-% if info.nchan ~= size(dataout{1},1);
-%     fprintf('WARNING: A non-matching number of channels in the FT data structure and original file header. Integrity of the data might be compromised\');
-%     info.nchan = size(dataout{1},1);
-%     info.chs = info.chs(1:size(dataout{1},1)); % FIXME: Terrible hack to tolerate removal of channels
-% end
-% 
-% 
-% for c = 1:length(dataout)
-%     evoked(c).aspect_kind = 100;
-%     evoked(c).is_smsh = 0; % FIXME: How could we tell?
-%     evoked(c).nave = 1; % FIXME: Use the real value
-%     evoked(c).first = round(data.time{1}(1) * data.fsample);
-%     evoked(c).last = round(data.time{1}(end) * data.fsample);
-%     evoked(c).times = data.time{1};
-%     evoked(c).comment = sprintf('FieldTrip data, category/trial %d', c);
-%     evoked(c).epochs = dataout{c};
-% end
-% 
-% fiffdata.info = info;
-% fiffdata.evoked = evoked;
-% 
-% fiff_write_evoked(filename, fiffdata);
-% 
-% end
+% report event coding
+newev = unique(eve(:,2));
+fprintf('EVENTS have been coded as:\n')
+for i = 1:numel(newev)
+  i_type = floor(newev(i)/10);
+  i_value = mod(newev(i), 10);
+  fprintf('type: %s, value %s -> % 3d\n', ev_type{i_type}, ev_value{i_value}, newev(i))
+end

--- a/fileio/private/mne2grad.m
+++ b/fileio/private/mne2grad.m
@@ -217,3 +217,8 @@ elseif nPlaGrad<=122 && nMag==0
 else
   % do not specify type of acquisition system
 end
+
+% remove grad if empty
+if size(grad.label,1) == 0
+  grad = [];
+end

--- a/ft_preprocessing.m
+++ b/ft_preprocessing.m
@@ -615,6 +615,9 @@ else
     if isfield(hdr, 'grad')
       dataout.grad             = hdr.grad;             % gradiometer system in head coordinates
     end
+    if isfield(hdr, 'elec')
+      dataout.elec             = hdr.elec;             % EEG information in header (f.e. headerformat = 'neuromag_fif')
+    end
 
   end % for all channel groups
 

--- a/test/test_fieldtrip2fiff.m
+++ b/test/test_fieldtrip2fiff.m
@@ -1,0 +1,202 @@
+function test_fieldtrip2fiff()
+
+if true % TODO: use file location on Donders server
+  dataset_ctf = '/data1/projects/gosd/scripts/gosd/matlab/test_fieldtrip2fiff/Subject01/Subject01.ds';
+  dataset_neuromag = '/data1/projects/gosd/scripts/gosd/matlab/test_fieldtrip2fiff/sample_audvis_raw.fif';
+  dataset_eeg = '/data1/projects/gosd/recordings/svui/subjects/0003/eeg/raw/svui_0003_eeg_go-sd_010.raw';
+  sensfile = '/data1/toolbox/fieldtrip/template/electrode/GSN-HydroCel-257.sfp';
+  datadir = '/data1/projects/gosd/scripts/gosd/matlab/test_fieldtrip2fiff';
+  
+else 
+  dataset_ctf = dccnfilename('/home/common/matlab/fieldtrip/data/Subject01.ds');
+  dataset_neuromag = dccnfilename('?'); % MNE sample dataset
+  dataset_eeg = dccnfilename('?'); % any EEG dataset
+  datadir = dccnfilename('/home/common/matlab/fieldtrip/data/ftp/tutorial/test_fieldtrip2fiff'); % TODO: mkdir?
+  
+end
+
+%-------------------------------------%
+%-CTF: write raw
+cfg = [];
+cfg.dataset = dataset_ctf;
+cfg.trialdef.triallength = Inf;
+cfg = ft_definetrial(cfg);
+
+cfg.continuous = 'yes';
+cfg.channel = {'MEG', '-MLP31', '-MLO12'};
+data = ft_preprocessing(cfg);
+
+fifffile = [datadir filesep 'ctf_raw.fif'];
+eventfile = [datadir filesep 'ctf_raw-eve.fif'];
+fieldtrip2fiff(fifffile, data)
+
+%-----------------%
+%-read back in
+ft_read_header(fifffile);
+ft_read_data(fifffile);
+mne_read_events(eventfile); % this is simply a binary file with three columns
+%-----------------%
+%-------------------------------------%
+
+%-------------------------------------%
+%-CTF: write epoched
+cfg = [];
+cfg.dataset                 = dataset_ctf;   % name of CTF dataset  
+cfg.trialdef.eventtype      = 'backpanel trigger';
+cfg.trialdef.prestim        = 1;
+cfg.trialdef.poststim       = 2;
+cfg.trialdef.eventvalue     = 3;                    % event value of FIC
+cfg = ft_definetrial(cfg);            
+
+cfg.channel   = {'MEG', '-MLP31', '-MLO12'};        % read all MEG channels except MLP31 and MLO12
+data = ft_preprocessing(cfg);
+
+fifffile = [datadir filesep 'ctf_epch.fif'];
+fieldtrip2fiff(fifffile, data)
+
+%-----------------%
+%-read back in
+ft_read_header(fifffile);
+ft_read_data(fifffile);
+%-----------------%
+%-------------------------------------%
+
+%-------------------------------------%
+%-CTF: write time-locked
+cfg = [];
+avg = ft_timelockanalysis(cfg, data);
+
+fifffile = [datadir filesep 'ctf_avg.fif'];
+fieldtrip2fiff(fifffile, avg)
+
+%-----------------%
+%-read back in
+ft_read_header(fifffile);
+ft_read_data(fifffile);
+%-----------------%
+%-------------------------------------%
+
+%-------------------------------------%
+%-NEUROMAG: write raw
+cfg = [];
+cfg.dataset = dataset_neuromag;
+cfg.trialdef.triallength = Inf;
+cfg = ft_definetrial(cfg);
+
+cfg.channel   = {'MEG', 'EEG', '-MEG 2443'  '-EEG 053'};
+data = ft_preprocessing(cfg);
+
+fifffile = [datadir filesep 'neuromag_raw.fif'];
+eventfile = [datadir filesep 'neuromag_raw-eve.fif'];
+fieldtrip2fiff(fifffile, data)
+
+%-----------------%
+%-read back in
+ft_read_header(fifffile);
+ft_read_data(fifffile);
+mne_read_events(eventfile); % this is simply a binary file with three columns
+%-----------------%
+%-------------------------------------%
+
+%-------------------------------------%
+%-NEUROMAG: write epoched
+cfg = [];
+cfg.dataset                 = dataset_neuromag;
+cfg.trialdef.eventtype      = 'STI 014';
+cfg.trialdef.prestim        = 1;
+cfg.trialdef.poststim       = 2;
+cfg.trialdef.eventvalue     = 1;
+cfg = ft_definetrial(cfg); 
+
+cfg.channel   = {'MEG', 'EEG', '-MEG 2443'  '-EEG 053'};
+data = ft_preprocessing(cfg);
+
+fifffile = [datadir filesep 'neuromag_epch.fif'];
+fieldtrip2fiff(fifffile, data)
+
+%-----------------%
+%-read back in
+ft_read_header(fifffile);
+ft_read_data(fifffile);
+%-----------------%
+%-------------------------------------%
+
+%-------------------------------------%
+%-NEUROMAG: write time-locked
+cfg = [];
+avg = ft_timelockanalysis(cfg, data);
+
+fifffile = [datadir filesep 'neuromag_avg.fif'];
+fieldtrip2fiff(fifffile, avg)
+
+%-----------------%
+%-read back in
+ft_read_header(fifffile);
+ft_read_data(fifffile);
+%-----------------%
+%-------------------------------------%
+
+%-------------------------------------%
+%-EEG: write raw
+cfg = [];
+cfg.dataset = dataset_eeg;
+cfg.trialdef.triallength = Inf;
+cfg = ft_definetrial(cfg);
+
+cfg.channel   = {'EEG'};
+data = ft_preprocessing(cfg);
+data.elec = ft_read_sens(sensfile);
+data.elec.label{end} = 'E257'; %TODO: rename if necessary
+
+fifffile = [datadir filesep 'eeg_raw.fif'];
+eventfile = [datadir filesep 'eeg_raw-eve.fif'];
+fieldtrip2fiff(fifffile, data)
+
+%-----------------%
+%-read back in
+% This will soft-crash if EEG has more than 60 electrodes because of mne2grad,
+% l.193. fieldtrip2fiff stores the electrode locations in field
+% "chs.eeg_loc" instead of "dig"
+hdr = ft_read_header(fifffile); 
+ft_read_data(fifffile);
+mne_read_events(eventfile); % this is simply a binary file with three columns
+%-----------------%
+%-------------------------------------%
+
+%-------------------------------------%
+%-EEG: write epoched
+cfg = [];
+cfg.dataset                 = dataset_eeg;
+cfg.trialdef.eventtype      = 'trigger'; % TODO: adapt to EEG dataset
+cfg.trialdef.prestim        = .5;
+cfg.trialdef.poststim       = 1;
+cfg.trialdef.eventvalue     = 'Targ'; % TODO: adapt to EEG dataset
+cfg = ft_definetrial(cfg); 
+
+cfg.channel   = {'EEG'};
+data = ft_preprocessing(cfg);
+
+fifffile = [datadir filesep 'eeg_epch.fif'];
+fieldtrip2fiff(fifffile, data)
+
+%-----------------%
+%-read back in
+ft_read_header(fifffile);
+ft_read_data(fifffile);
+%-----------------%
+%-------------------------------------%
+
+%-------------------------------------%
+%-EEG: write time-locked
+cfg = [];
+avg = ft_timelockanalysis(cfg, data);
+
+fifffile = [datadir filesep 'eeg_avg.fif'];
+fieldtrip2fiff(fifffile, avg)
+
+%-----------------%
+%-read back in
+ft_read_header(fifffile);
+ft_read_data(fifffile);
+%-----------------%
+%-------------------------------------%


### PR DESCRIPTION
Rewritten fieldtrip2fiff, which did not seem to work properly. Now it should work with CTF, neuromag, and EEG data. It should take care of the changes to the labels, and it writes EEG locations to the FIFF as well.

I also added a test function. You should change all the paths to the files. I used the CTF example from the tutorial, the sample data from MNE, and my own EGI EEG dataset. Any EEG should work. Please, also check the TODO. In particular, line 193 of mne2grad is not compatible with the current version, because it reads from eeg_loc only if there are less than 60 electrodes. I don't think it's important.

Let me know if you have problems or if the test does not run.
