### PR TITLE
bugfix - corrected computation of ppc1 and ppc2

### DIFF
--- a/contrib/spike/ft_spiketriggeredspectrum_stat.m
+++ b/contrib/spike/ft_spiketriggeredspectrum_stat.m
@@ -239,14 +239,6 @@ if strcmp(cfg.timwin,'all')
           % compute PPC 1.0 and 2.0 according to Vinck et al. (2011) using summation per trial
           if strcmp(cfg.method,'ppc1')
             if ~isempty(spc)
-              m = nanmean(spc,1); % no problem with NaN
-              hasNum = ~isnan(m);
-              S(hasNum)  = S(hasNum)  + m(hasNum); % add the imaginary and real components
-              SS(hasNum) = SS(hasNum) + m(hasNum).*conj(m(hasNum));
-              dof(hasNum) = dof(hasNum) + 1; % dof needs to be kept per frequency
-            end
-          elseif strcmp(cfg.method,'ppc2')
-            if ~isempty(spc)
                n      = sum(~isnan(spc),1);
                m      = nansum(spc,1); 
                hasNum = ~isnan(m);    
@@ -254,7 +246,15 @@ if strcmp(cfg.timwin,'all')
                SS(hasNum)    = SS(hasNum) + m(hasNum).*conj(m(hasNum));
                dof(hasNum)   = dof(hasNum)  + n(hasNum);
                dofSS(hasNum) = dofSS(hasNum) + n(hasNum).^2;
-            end                              
+            end
+          elseif strcmp(cfg.method,'ppc2')                              
+            if ~isempty(spc)
+              m = nanmean(spc,1); % no problem with NaN
+              hasNum = ~isnan(m);
+              S(hasNum)  = S(hasNum)  + m(hasNum); % add the imaginary and real components
+              SS(hasNum) = SS(hasNum) + m(hasNum).*conj(m(hasNum));
+              dof(hasNum) = dof(hasNum) + 1; % dof needs to be kept per frequency
+            end
           end
       end
 


### PR DESCRIPTION
I was consulting the FieldTrip code while implementing these statistics myself, and this looked wrong to me; `ppc1` was being computed based on `dofSS`, but `dofSS` was all zeros for `ppc1` and only computed for `ppc2`. I rederived the per-trial summation formula from the pairwise formula in Vinck et al. (2012) and it looks like the prior code was almost right, but the code within the loop was transposed for the two estimators.
