### PR TITLE
add cfg.plotselection to only plot those trials present in cfg.trials

### DIFF
--- a/contrib/spike/ft_spike_plot_raster.m
+++ b/contrib/spike/ft_spike_plot_raster.m
@@ -31,6 +31,7 @@ function [cfg] = ft_spike_plot_raster(cfg, spike, timelock)
 %                           subsequent rows representing trials (row-unit is 1).
 %   cfg.trialborders     =  'yes' or 'no'. If 'yes', borders of trials are
 %                           plotted
+%   cfg.plotselection	 =  'yes' or 'no' (default). If yes plot Y axis only for selection in cfg.trials
 %   cfg.topplotsize      =  number ranging from 0 to 1, indicating the proportion of the
 %                           rasterplot that the top plot will take (e.g., with 0.7 the top
 %                           plot will be 70% of the rasterplot in size). Default = 0.5.
@@ -56,17 +57,18 @@ ft_preamble trackconfig
 spike = ft_checkdata(spike,'datatype', 'spike', 'feedback', 'yes'); % converts raw as well
 
 % get the default options
-cfg.spikechannel = ft_getopt(cfg,'spikechannel', 'all');
-cfg.trials       = ft_getopt(cfg,'trials', 'all');
-cfg.latency      = ft_getopt(cfg,'latency','maxperiod');
-cfg.linewidth    = ft_getopt(cfg,'linewidth', 1);
-cfg.cmapneurons  = ft_getopt(cfg,'cmapneurons', 'auto');
-cfg.spikelength  = ft_getopt(cfg,'spikelength', 0.9);
-cfg.topplotsize  = ft_getopt(cfg,'topplotsize', 0.5);
-cfg.topplotfunc  = ft_getopt(cfg,'topplotfunc', 'bar');
-cfg.errorbars    = ft_getopt(cfg,'errorbars', 'sem');
-cfg.trialborders = ft_getopt(cfg,'trialborders','yes');
-cfg.interactive  = ft_getopt(cfg,'interactive','yes');
+cfg.spikechannel	= ft_getopt(cfg,'spikechannel', 'all');
+cfg.trials			= ft_getopt(cfg,'trials', 'all');
+cfg.latency			= ft_getopt(cfg,'latency','maxperiod');
+cfg.linewidth		= ft_getopt(cfg,'linewidth', 1);
+cfg.cmapneurons	= ft_getopt(cfg,'cmapneurons', 'auto');
+cfg.spikelength	= ft_getopt(cfg,'spikelength', 0.9);
+cfg.topplotsize	= ft_getopt(cfg,'topplotsize', 0.5);
+cfg.topplotfunc	= ft_getopt(cfg,'topplotfunc', 'bar');
+cfg.errorbars		= ft_getopt(cfg,'errorbars', 'sem');
+cfg.trialborders	= ft_getopt(cfg,'trialborders','yes');
+cfg.plotselection = ft_getopt(cfg,'plotselection','no');
+cfg.interactive	= ft_getopt(cfg,'interactive','yes');
 
 % ensure that the options are valid
 cfg = ft_checkopt(cfg,'spikechannel',{'cell', 'char', 'double'});
@@ -79,9 +81,11 @@ cfg = ft_checkopt(cfg,'topplotsize', 'doublescalar');
 cfg = ft_checkopt(cfg,'topplotfunc', 'char', {'bar', 'line'});
 cfg = ft_checkopt(cfg,'errorbars', 'char', {'sem', 'std', 'conf95%', 'no', 'var'});
 cfg = ft_checkopt(cfg,'trialborders', 'char', {'yes', 'no'});
+cfg = ft_checkopt(cfg,'plotselection', 'char', {'yes', 'no'});
 cfg = ft_checkopt(cfg,'interactive', 'char', {'yes', 'no'});
 
-cfg = ft_checkconfig(cfg, 'allowed', {'spikechannel', 'latency', 'trials', 'linewidth', 'cmapneurons', 'spikelength', 'topplotsize', 'topplotfunc', 'errorbars', 'trialborders', 'interactive', 'warning'});
+cfg = ft_checkconfig(cfg, 'allowed', {'spikechannel', 'latency', 'trials', 'linewidth', 'cmapneurons',...
+ 'spikelength', 'topplotsize', 'topplotfunc', 'errorbars', 'trialborders', 'plotselection', 'interactive', 'warning'});
 
 % check if a third input is present, and check if it's a timelock structure
 if nargin==3
@@ -102,12 +106,14 @@ if nUnits==0, error('No spikechannel selected by means of cfg.spikechannel'); en
 
 % get the number of trials and set the cfg.trials field
 nTrialsOrig = size(spike.trialtime,1);
+nTrialsShown = nTrialsOrig;
 if  strcmp(cfg.trials,'all')
   cfg.trials = 1:nTrialsOrig;
 elseif islogical(cfg.trials)
   cfg.trials = find(cfg.trials);
 end
 cfg.trials = sort(cfg.trials(:));
+
 if max(cfg.trials)>nTrialsOrig, 
   error('maximum trial number in cfg.trials should not exceed length of spike.trial')
 end
@@ -152,6 +158,16 @@ for iUnit = 1:nUnits
   isInTrials     = ismember(spike.trial{unitIndx},cfg.trials);
   unitX{iUnit}   = spike.time{unitIndx}(isInTrials(:) & latencySel(:));
   unitY{iUnit}   = spike.trial{unitIndx}(isInTrials(:) & latencySel(:));
+  if strcmp(cfg.plotselection,'yes')
+	  tempY{iUnit} = zeros(size(unitY{iUnit}));
+	  u = unique(unitY{iUnit});
+	  for i = 1:length(u)
+		  idx = find(unitY{iUnit} == u(i));
+		  tempY{iUnit}(idx) = i;
+	  end
+	  nTrialsShown = length(u); 
+	  unitY{iUnit} = tempY{iUnit};
+  end
 end
 
 % some error checks on spike length
@@ -216,7 +232,7 @@ for iUnit = 1:nUnits
   end
   
   % make the raster plot and hold on for the next plots
-  rasterHdl = plot(x, y,'linewidth', cfg.linewidth,'Color', color);
+  rasterHdl = line(x, y,'LineWidth', cfg.linewidth,'Color', color);
   cfg.hdl.raster = rasterHdl;
   set(ax(1),'NextPlot', 'add')
   set(ax(1),'Box', 'off')
@@ -358,6 +374,9 @@ if doTopData
       if yl>0, yl = 0; end
     end
     ylim(2) = yl;
+	 if ylim(2) == ylim(1) %if the plot is empty
+		 ylim(2)=ylim(1)+1; %be nice to set
+	 end
     set(gca,'YLim', ylim)
   end    
   
@@ -381,7 +400,8 @@ end
 
 % set the limits for the axis
 set(ax,'XLim', [cfg.latency])
-set(ax(1), 'YLim', [0.5 nTrialsOrig+0.5]); % number of trials
+if nTrialsShown==0; nTrialsShown = 1; end %
+set(ax(1), 'YLim', [0.5 nTrialsShown+0.5]); % number of trials
 set(ax,'TickDir','out') % put the tickmarks outside
 
 % now link the axes, constrain zooming and keep ticks intact
@@ -394,6 +414,15 @@ if ~iscell(limY), limY = {limY}; end
 if strcmp(cfg.interactive,'yes')
   set(zoom,'ActionPostCallback',{@mypostcallback,ax,limX,limY});
   set(pan,'ActionPostCallback',{@mypostcallback,ax,limX,limY});
+end
+
+% pass positions and axis handles so downstream
+% functions can respect the positions set here.
+cfg.pos.posRaster = posRaster;
+cfg.hdl.axRaster = ax(1);
+if doTopData
+	cfg.pos.posTopPlot = posTopPlot;
+	cfg.hdl.axTopPlot = ax(2);
 end
 
 % do the general cleanup and bookkeeping at the end of the function


### PR DESCRIPTION
I consider this a bug, but i've wrapped this in a new cfg setting to not alter default behaviour. Currently ft_spike_plot_raster.m plots a position for all trials on the y-axis, including those that have been excluded using cfg.trials. This means if you have 320 trials but only select 20 trials you still have a y-axis for 320 trials and a useless raster plot. If you set cfg.plotselection to 'yes', then the y-axis is scaled to the number of trials in cfg.trials and a normal raster plot is produced.

http://bugzilla.fcdonders.nl/show_bug.cgi?id=2533
