### PR TITLE
Added new event field Trigger that represents the accumulated analogue t...

### DIFF
--- a/fileio/ft_read_event.m
+++ b/fileio/ft_read_event.m
@@ -20,8 +20,7 @@ function [event] = ft_read_event(filename, varargin)
 %   'blocking'      wait for the selected number of events (default = 'no')
 %   'timeout'       amount of time in seconds to wait when blocking (default = 5)
 %   'tolerance'     tolerance in samples when merging analogue trigger
-%                   channels, only for Neuromag using the '_v2'
-%                   experimental versions at the moment (default = 1,
+%                   channels, only for Neuromag (default = 1,
 %                   meaning that an offset of one sample in both directions
 %                   is compensated for)
 %


### PR DESCRIPTION
This patch adds a new event field for neuromag machines. Instead of using the provided accumulated digital trigger channel, it calculates its own value using the individual binary channels. This is safer as the builtin methods sometimes fails when two binary channels have a slight delay.
The commit only adds code and leaves the rest untouched.
See also: http://bugzilla.fcdonders.nl/show_bug.cgi?id=1867
