### PR TITLE
dim is now copied over when it is found in mnigrid instead of grid.

### DIFF
--- a/ft_prepare_sourcemodel.m
+++ b/ft_prepare_sourcemodel.m
@@ -637,7 +637,7 @@ if basedonmni
   else
     grid.pos = ft_warp_apply(inv(normalise.initial), ft_warp_apply(normalise.params, mnigrid.pos, 'sn2individual'));
   end
-  if isfield(grid, 'dim')
+  if isfield(mnigrid, 'dim')
     grid.dim     = mnigrid.dim;
   end
   grid.unit    = mnigrid.unit;


### PR DESCRIPTION
the fix 2548 is supposed to copy over the dim field only when it existed. the submitted solution is flawed in that it never copies over the dim field, even if it existed in the mnigrid structure. the proposed patch solves the issue.
