### PR TITLE
ft_trialfun now exits if ft_read_event fails and rethrows the error.

### DIFF
--- a/trialfun/ft_trialfun_general.m
+++ b/trialfun/ft_trialfun_general.m
@@ -81,9 +81,10 @@ else
   try
     fprintf('reading the events from ''%s''\n', cfg.headerfile);
     event = ft_read_event(cfg.headerfile, 'headerformat', cfg.headerformat, 'eventformat', cfg.eventformat, 'dataformat', cfg.dataformat);
-  catch
+  catch e
     % ensure that it has the correct fields, even if it is empty
     event = struct('type', {}, 'value', {}, 'sample', {}, 'offset', {}, 'duration', {});
+    rethrow(e);
   end
 end
 


### PR DESCRIPTION
if ft_read_event would fail with an error, ft_trialfun_general would continue running without even showing the error. i suggest that in the case of ft_read_event throwing an error, the execution of the trialfun should be stopped and the error propagated to the user.