### PR TITLE
new functions in ft_networkanalysis

### DIFF
--- a/external/bct/smallworld/randomise_graph_bin_dir.m
+++ b/external/bct/smallworld/randomise_graph_bin_dir.m
@@ -1,0 +1,14 @@
+function C_rand = randomise_graph_bin_dir(C)
+
+% randomises the edges of a binary directed graph. Diagonal elements are
+% ignored.
+%
+% Mark Drakesmith (Cardiff, University)
+
+n=size(C);
+C=C~=0;
+sort_idx=find(ones(n)-eye(n));
+C_rand=zeros(n);
+[dum rand_idx]=sort(rand(1,length(sort_idx)));
+
+C_rand(sort_idx(rand_idx));

--- a/external/bct/smallworld/randomise_graph_bin_und.m
+++ b/external/bct/smallworld/randomise_graph_bin_und.m
@@ -1,0 +1,18 @@
+function C_rand = randomise_graph_bin_und(C)
+
+% randomises the edges of a binary undirected graph. Diagonal elements are
+% ignored.
+%
+% Mark Drakesmith (Cardiff, University)
+
+n=size(C);
+C=C~=0;
+sort_idx=find(triu(ones(n),1));
+C_rand=zeros(n);
+[dum rand_idx]=sort(rand(1,length(sort_idx)));
+
+C_rand(sort_idx(rand_idx));
+
+C_rand=C_rand+C_rand';
+
+

--- a/external/bct/smallworld/randomise_graph_wei_dir.m
+++ b/external/bct/smallworld/randomise_graph_wei_dir.m
@@ -1,0 +1,41 @@
+function C_rand = randomise_graph_wei_dir(C)
+
+% randomises the edges of a weighted directed graph. Diagonal elements are
+% ignored. The random graph has the same strength distribution as the
+% original graph.
+%
+% Mark Drakesmith (Cardiff, University)
+
+n=size(C,1);
+
+sort_idx=find(ones(n)-eye(n));
+
+C_rand=zeros(n);
+[dum rand_idx]=sort(rand(1,length(sort_idx)));
+
+
+C_rand(sort_idx(rand_idx));
+
+% compute a probability distribtuion
+[pdf,wei]=hist(C(sort_idx),n);
+
+% compute cdf
+cdf=cumsum(pdf);
+cdf=cdf./max(cdf);
+
+% remove duplicades in cdf (interp doesnt like that!)
+remove_idx=find(diff(cdf)==0);
+cdf(remove_idx)=[];
+wei(remove_idx)=[];
+
+
+% generate random values from uniform distribtuion
+rand_uni=(rand(1,length(sort_idx)));
+
+% sample from cdf using interpoation
+rand_wei = interp1(cdf,wei,rand_uni);
+
+% put the new edge weights inot the random graph
+C_rand(sort_idx(rand_idx))=rand_wei;
+
+

--- a/external/bct/smallworld/randomise_graph_wei_und.m
+++ b/external/bct/smallworld/randomise_graph_wei_und.m
@@ -1,0 +1,42 @@
+function C_rand = randomise_graph_wei_und(C)
+
+% randomises the edges of a weighted directed graph. Diagonal elements are
+% ignored. The random graph has the same strength distribution as the
+% original graph.
+%
+% Mark Drakesmith (Cardiff, University)
+
+n=size(C,1);
+
+sort_idx=find(triu(ones(n),1));
+
+C_rand=zeros(n);
+[dum rand_idx]=sort(rand(1,length(sort_idx)));
+
+
+C_rand(sort_idx(rand_idx));
+
+% compute a probability distribtuion of edge weights
+[pdf,wei]=hist(C(sort_idx),n);
+
+% compute cdf
+cdf=cumsum(pdf);
+cdf=cdf./max(cdf);
+
+% remove duplicades in cdf (interp doesnt like that!)
+remove_idx=find(diff(cdf)==0);
+cdf(remove_idx)=[];
+wei(remove_idx)=[];
+
+
+% generate random values from uniform distribtuion
+rand_uni=(rand(1,length(sort_idx)));
+
+% sample from cdf using interpoation
+rand_wei = interp1(cdf,wei,rand_uni);
+
+% put the new edge weights inot the random graph
+C_rand(sort_idx(rand_idx))=rand_wei;
+
+% reflect mtrix along diagonal for undirected graph
+C_rand=C_rand+C_rand';

--- a/external/bct/smallworld/smallworld.m
+++ b/external/bct/smallworld/smallworld.m
@@ -1,0 +1,113 @@
+function [sw sw_node] = smallworld(W,type,n_rand)
+
+% this function computes smallworld nes using the formula
+% 
+% SW=Cn/Ln, where Ln=L/Lr and Cn=C/Cr;
+% 
+% L = the characterstic path length or original network
+% Lr = the characterstic path length of ranom network with same
+%      degree/weight distirbtuion
+% C = the mean clustering coefficient
+% Cr = the mean clustering coefficient of ranom network with same
+%      degree/weight distirbtuion
+%
+% W = the connectivity matrix
+%
+% type = how to treat the matrix ('binund', 'bindir', 'weiund',
+%       'weidir'). 
+%
+% n_rand = the numder of random network from which to estimate Lr and Cr.
+%         Default=100.
+%
+% The function can also compute a regional smallworldness value (sw_node),
+% using the local path length and the local clustering ocefficients in the
+% equivilent way as standard smallworldness
+%
+% (C) Mark Drakesmith, Cardiff University
+
+if ~exist('n_rand','var')
+    n_rand=100;
+end
+
+for i=1:n_rand+1
+    if i==1 % this is the unrandomised netowrk
+        disp('Computing paramaters for original network');
+        W_iter=W;
+    else  % do randomisation
+        fprintf('Computing paramaters for random network %u\n',i-1);
+        switch type
+            case 'binund'
+                W_iter=randomise_graph_bin_und(W);
+            case 'bindir'
+                W_iter=randomise_graph_bin_dir(W);
+            case 'weiund'
+                W_iter=randomise_graph_wei_und(W);
+            case 'weidir'
+                W_iter=randomise_graph_wei_dir(W);
+        end
+    end
+    
+    
+    
+    % compute char path
+    switch type
+        case {'binund','bindir'}
+            dist=distance_bin(W_iter);
+        case {'weiund','weidir'}
+            dist=distance_wei(W_iter);
+    end
+    
+    
+    L_iter(i)=charpath(dist);
+    
+    % compute mean min path length for each node
+    dist(isinf(dist))=NaN;
+    L_iter_node(:,i)=nanmean(dist,2);
+    
+    % compute clustering coefficient (per node)
+    switch type
+        case 'binund'
+            C_iter_node(:,i)=clustering_coef_bu(W_iter);
+        case 'bindir'
+            C_iter_node(:,i)=clustering_coef_bd(W_iter);
+        case 'weiund'
+            C_iter_node(:,i)=clustering_coef_wu(W_iter);
+        case 'weidir'
+            C_iter_node(:,i)=clustering_coef_wd(W_iter);
+    end
+    
+    % compute mean clustering coefficient
+    C_iter(i)=mean(C_iter_node(:,i));
+end
+disp('Finished randomisation. Computing smallworldness.');
+
+% get median of path length / clust coeffs across randomisations
+
+Cr_node=median(C_iter_node(:,2:end),2);
+Cr=median(C_iter(2:end));
+
+Lr_node=median(L_iter_node(:,2:end),2);
+Lr=median(L_iter(:,2:end));  
+
+% get original of path length / clust coeffs across randomisations
+C_node=C_iter_node(:,1);
+C=C_iter(:,1);  
+
+L_node=L_iter_node(:,1);
+L=L_iter(:,1);  
+    
+% compute normalised charpath / clust coeff
+Ln=L./Lr;
+Cn=C./Cr;
+
+Ln_node=L_node./Lr_node;
+Cn_node=C_node./Cr_node;
+
+% finally compute smallworldness
+sw=Cn./Ln;
+sw_node=Cn_node./Ln_node;
+
+
+
+
+       

--- a/ft_networkanalysis.m
+++ b/ft_networkanalysis.m
@@ -16,9 +16,8 @@ function [stat] = ft_networkanalysis(cfg, data)
 % 'pos_pos(_freq)(_time)'.
 %
 % The configuration structure has to contain
-%   cfg.method    = string, or a cell-array of strings specifying the graph 
-%                     measure(s) that will be  computed. See below for the 
-%                     list of supported measures. 
+%   cfg.method    = string specifying the graph  measure(s) that will be 
+%                   computed. See below for the list of supported measures. 
 %   cfg.parameter = string specifying the bivariate parameter in the data 
 %                   for which the graph measure will be computed.
 %

--- a/ft_networkanalysis.m
+++ b/ft_networkanalysis.m
@@ -16,8 +16,9 @@ function [stat] = ft_networkanalysis(cfg, data)
 % 'pos_pos(_freq)(_time)'.
 %
 % The configuration structure has to contain
-%   cfg.method    = string specifying the graph  measure(s) that will be 
-%                   computed. See below for the list of supported measures. 
+%   cfg.method    = string, or a cell-array of strings specifying the graph 
+%                     measure(s) that will be  computed. See below for the 
+%                     list of supported measures. 
 %   cfg.parameter = string specifying the bivariate parameter in the data 
 %                   for which the graph measure will be computed.
 %
@@ -25,8 +26,6 @@ function [stat] = ft_networkanalysis(cfg, data)
 %   assortativity
 %   betweenness,      betweenness centrality (nodes)
 %   charpath*,         
-%   effic_global, global efficiency
-%   effic_local, local efficiency
 %   clustering_coef,  clustering coefficient
 %   degrees
 %   density
@@ -92,10 +91,10 @@ ft_preamble trackconfig
 ft_preamble debug
 ft_preamble loadvar data
 
-% the abort variable is set to true or false in ft_preamble_init
-if abort
-  return
-end
+% % the abort variable is set to true or false in ft_preamble_init
+% if abort
+%   return
+% end
 
 
 cfg = ft_checkconfig(cfg, 'required', {'method' 'parameter'});
@@ -229,7 +228,7 @@ end
       
 for k = 1:size(input, 3)
   for m = 1:size(input, 4)
-    [k m]
+   
       
     % switch to the appropriate function from the BCT
     switch cfg.method
@@ -308,15 +307,15 @@ for k = 1:size(input, 3)
             end
         case 'effic_local'
             if isbinary
-                output(:,:,k,m) = efficiency_bin(input(:,:,k,m),1);
+                output(:,k,m) = efficiency_bin(input(:,:,k,m),1);
             elseif ~isbinary
-                output(:,:,k,m) = efficiency_wei(input(:,:,k,m),1);
+                output(:,k,m) = efficiency_wei(input(:,:,k,m),1);
             end
         case 'effic_global'
             if isbinary
-                output(:,:,k,m) = efficiency_bin(input(:,:,k,m));
+                output(k,m) = efficiency_bin(input(:,:,k,m));
             elseif ~isbinary
-                output(:,:,k,m) = efficiency_wei(input(:,:,k,m));
+                output(k,m) = efficiency_wei(input(:,:,k,m));
             end
         case 'modularity'
             if isdirected

--- a/ft_networkanalysis.m
+++ b/ft_networkanalysis.m
@@ -25,6 +25,8 @@ function [stat] = ft_networkanalysis(cfg, data)
 %   assortativity
 %   betweenness,      betweenness centrality (nodes)
 %   charpath*,         
+%   effic_global, global efficiency
+%   effic_local, local efficiency
 %   clustering_coef,  clustering coefficient
 %   degrees
 %   density

--- a/ft_networkanalysis.m
+++ b/ft_networkanalysis.m
@@ -394,7 +394,7 @@ if exist('modules','var')
     stat.modules=modules;
 end
 
-if output_inout
+if strcmp(cfg.inout,'yes')
     if exist('outstrength','var')
         stat.strengths_out=outstrength;
     end

--- a/private/restructure_connectivity.m
+++ b/private/restructure_connectivity.m
@@ -1,0 +1,106 @@
+function data = restructure_connectivity(data)
+
+% this function restructures connectivity data in the chancmb format to the
+% chan_chan format. This required chancmb to contain values for all pairs
+% of channels. Connectivity can be either symetric (undirected) or 
+% assymetric (directed). 
+
+if strcmp(data.dimord(1:7), 'pos_pos') || strcmp(data.dimord(1:9), 'chan_chan');
+    % data is in chan_chan format. No implimentation yet for converting to
+    % chancmb format
+     error('Not yet implimented!');
+    format=0;
+elseif isfield(data,'labelcmb');
+    % data is in chancmb format
+    format=1;
+else
+    error('Unknown data format!');
+end
+
+n_chan=length(data.label);
+n_chancmb=length(data.labelcmb);
+
+% expected number of channels for directed connectivity
+n_chan_cmb_dir= n_chan*n_chan-n_chan;
+% expected number of channels for undirected connectivity
+n_chan_cmb_und=n_chan_cmb_dir./2;
+
+% detrimne if connectivity is directed or undirected
+if n_chancmb==n_chan_cmb_dir
+    n_chan_cmb=n_chan_cmb_dir;
+    isdirected=1;
+elseif n_chancmb==n_chan_cmb_und
+    n_chan_cmb=n_chan_cmb_und;
+    isdirected=0;
+else
+    error('Number of channel combnations is not as expected.');
+end
+
+
+% find fields with the right dimensions.
+flds=fieldnames(data);
+confld_idx=[];
+for i=1:length(flds)
+    if isnumeric(data.(flds{i}));
+        siz=size(data.(flds{i}));
+        if siz(1)==n_chan_cmb
+            confld_idx=[confld_idx i];
+            
+        end
+    end
+end
+
+% get the fields to transform
+con_flds=flds(confld_idx);
+
+
+for f=1:length(con_flds)
+    data_temp=data.(con_flds{f});
+    siz=size(data_temp);
+    
+    % transform the data!
+    data_new=zeros([n_chan n_chan siz(2:end)]);
+    k=0;
+    if isdirected
+        for i=1:n_chan
+            for j=1:n_chan
+                if i==j
+                    continue
+                end
+                k=k+1;
+                data_new(j,i,:)=data_temp(k,:);
+            end
+        end
+        
+    elseif ~isdirected
+        for i=1:n_chan
+            for j=i+1:n_chan
+                k=k+1;
+                data_new(i,j,:)=data_temp(k,:);
+                data_new(j,i,:)=data_temp(k,:);
+            end
+        end
+    end
+    
+    % put the transformed data back into the data structure
+    data.(con_flds{f}) = data_new;
+end
+
+% update dimord
+if strcmp(data.dimord(1:4),'chan');
+    data.dimord=['chan_chan' data.dimord(5:end)];
+elseif strcmp(data.dimord(1:3),'pos');
+    data.dimord=['pos_pos' data.dimord(4:end)];
+end
+
+% remove labelcmb
+data=rmfield(data,'labelcmb');
+
+
+
+        
+
+    
+
+
+


### PR DESCRIPTION
This is an update to the ft_networknalysis function. Changes include:

1. Can now compute efficiency (global and local), modularity, strength and smallworldness (computed using sub-functions in external/bct/smallworld/)
2. If charpath is specfied,  distance will be computed automatically if not present in the data.
3. In the case of degree and strength on directed grapths, the function can also optionally output the inward and outward values for these measurements. 
4. Can now handles data with chancmb_* (as normally output by ft_connectivityanalysis) dimord as well as  chan_chan_* dimord.  

Many thanks

Mark Drakesmith