### PR TITLE
Add support for AnyWave HDF5 format

### DIFF
--- a/fileio/ft_filetype.m
+++ b/fileio/ft_filetype.m
@@ -1198,6 +1198,10 @@ elseif filetype_check_extension(filename, '.csv')
   type = 'csv';
   manufacturer = 'Generic';
   content = 'Comma-separated values, see http://en.wikipedia.org/wiki/Comma-separated_values';
+elseif filetype_check_extension(filename, '.ah5')
+    type = 'AnyWave';
+    manufacturer = 'AnyWave, http://meg.univ-amu.fr/wiki/AnyWave';
+    content = 'MEG/SEEG/EEG data';
 end
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/fileio/ft_read_data.m
+++ b/fileio/ft_read_data.m
@@ -282,7 +282,8 @@ end
 % read the data with the low-level reading function
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 switch dataformat
-  
+  case 'AnyWave'
+     dat = read_ah5_data(filename, hdr, begsample, endsample, chanindx);
   case {'4d' '4d_pdf', '4d_m4d', '4d_xyz'}
     [fid,message] = fopen(datafile,'rb','ieee-be');
     % determine the type and size of the samples

--- a/fileio/ft_read_event.m
+++ b/fileio/ft_read_event.m
@@ -410,6 +410,8 @@ switch eventformat
       event = [];
     end
     
+  case 'AnyWave'
+    event = read_ah5_markers(hdr, filename);
   case 'brainvision_vmrk'
     fid=fopen(filename,'rt');
     if fid==-1,

--- a/fileio/ft_read_header.m
+++ b/fileio/ft_read_header.m
@@ -239,6 +239,18 @@ hdr = [];
 % read the data with the low-level reading function
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 switch headerformat
+   case 'AnyWave'
+    orig = read_ahdf5_hdr(datafile);
+    hdr.orig = orig;
+    hdr.Fs = orig.channels(1).samplingRate;
+    hdr.nChans = numel(orig.channels);
+    hdr.nSamples = orig.numberOfSamples;
+    hdr.nTrials = orig.numberOfBlocks;
+    hdr.nSamplesPre = 0;
+    hdr.label = orig.label;
+    hdr.reference = orig.reference(:);
+    hdr.chanunit = orig.unit(:);
+    hdr.chantype = orig.type(:);
   case '4d'
     orig            = read_4d_hdr(datafile);
     hdr.Fs          = orig.header_data.SampleFrequency;

--- a/fileio/private/read_ah5_data.m
+++ b/fileio/private/read_ah5_data.m
@@ -1,0 +1,19 @@
+function [ data ] = read_ah5_data( filename, hdr, begsample, endsample, chanindx)
+
+offset = (begsample-1)*hdr.nChans;
+nsamples = (endsample-begsample+1);
+block = nsamples * hdr.nChans;
+
+fid = H5F.open(filename);
+dset_id = H5D.open(fid, '/Blocks/1/data');
+mem_space = H5S.create_simple(1, block, block);
+space = H5D.get_space(dset_id);
+
+H5S.select_hyperslab(space, 'H5S_SELECT_SET', offset, [], [], block);
+data = H5D.read(dset_id, 'H5ML_DEFAULT', mem_space, space, 'H5P_DEFAULT');
+data = reshape(data, hdr.nChans, nsamples);
+H5D.close(dset_id);
+H5F.close(fid);
+
+end
+

--- a/fileio/private/read_ah5_markers.m
+++ b/fileio/private/read_ah5_markers.m
@@ -1,0 +1,27 @@
+function [ event ] = read_ah5_markers(hdr, filename )
+
+if isempty(hdr)
+    orig = read_ahdf5_hdr(filename);
+    hdr.orig = orig;
+    hdr.Fs = orig.channels(1).samplingRate;
+    hdr.nChans = numel(orig.channels);
+    hdr.nSamples = orig.numberOfSamples;
+    hdr.nTrials = orig.numberOfBlocks;
+    hdr.nSamplesPre = 0;
+    hdr.label = orig.label;
+end
+    
+marks = h5read(filename, '/Blocks/1/markers');
+labels = marks.label';
+positions = marks.position';
+durations = marks.duration';
+values = marks.value';
+
+for i=1:size(labels, 1)
+    event(i).type = strcat(labels(i, 1:256));
+    event(i).value = values(i);
+    event(i).sample = positions(i) * hdr.Fs;
+    event(i).duration = durations(i) * hdr.Fs;
+end
+end
+

--- a/fileio/private/read_ahdf5_hdr.m
+++ b/fileio/private/read_ahdf5_hdr.m
@@ -1,0 +1,66 @@
+function [header] = read_ahdf5_hdr(datafile)
+
+%read header
+if nargin ~= 1
+    error('Wrong number of input arguments');
+end
+
+if ~isempty(datafile),
+ 
+  id = h5readatt(datafile, '/', 'id');
+  if ~strcmp(id, 'AnyWave')
+      error('This is not the ahf5 format.');
+  end
+  
+  ch = h5read(datafile, '/channels');
+  types = ch.type';
+  labels = ch.label';
+  units = ch.unit';
+  refs = ch.ref';
+  sr = ch.samplingRate';
+  x = ch.x';
+  y = ch.y';
+  z = ch.z';
+  ox = ch.ox';
+  oy = ch.oy';
+  oz = ch.oz';
+  
+  header.numberOfBlocks = h5readatt(datafile, '/Blocks', 'numberOfBlocks');
+  header.numberOfSamples = h5readatt(datafile, '/Blocks/1', 'numberOfSamples');
+  for i=1:size(types, 1)
+      header.channels(i).samplingRate = sr(i);
+      header.channels(i).type = strcat(types(i, 1:16));
+      switch header.channels(i).type
+          case 'SEEG'
+              header.type{i} = 'seeg';
+          case 'EEG'
+              header.type{i} = 'eeg';
+          case 'MEG'
+              header.type{i} = 'meg';
+          case 'ECG'
+            header.type{i} = 'ecg';
+          case 'EMG'
+            header.type{i} = 'emg';
+      end
+                 
+      header.channels(i).label = strcat(labels(i, 1:16));
+      header.channels(i).ref = strcat(refs(i, 1:16));
+      header.channels(i).unit = strcat(units(i, 1:4));
+      header.channels(i).x = x(i);
+      header.channels(i).y = y(i);
+      header.channels(i).z = z(i);
+      header.channels(i).ox = ox(i);
+      header.channels(i).oy = oy(i);
+      header.channels(i).oz = oz(i);     
+      % create label cell array
+      header.label{i} =  header.channels(i).label;
+      % create reference cell array
+      header.reference{i} = header.channels(i).ref;
+      % create chantype
+      if  strcmp(header.channels(i).unit, 'µV')
+          header.unit{i} = 'uV';
+      else
+          header.unit{i} = header.channels(i).unit;
+      end
+  end 
+end


### PR DESCRIPTION
Hello all,
I'm the developer of AnyWave (http://meg.univ-amu.fr/wiki/AnyWave).

This software is designed to visualize and proceed multi modal data (EEG, SEEG, MEG).
AnyWave allows exporting data to HDF5 format which we would like FT to be able to read.

A  common use could be to mark events in AnyWave (seizures, spikes, ...) and then import data and events in Fieldtrip for further processing. 

