### PR TITLE
nlx event file reader bug

### DIFF
--- a/fileio/ft_read_event.m
+++ b/fileio/ft_read_event.m
@@ -1497,7 +1497,7 @@ switch eventformat
       hdr = ft_read_header(filename);
     end
     % the event file is contained in the dataset directory
-    if     exist(fullfile(filename, 'Events.Nev'))
+    if exist(fullfile(filename, 'Events.Nev'))
       filename = fullfile(filename, 'Events.Nev');
     elseif exist(fullfile(filename, 'Events.nev'))
       filename = fullfile(filename, 'Events.nev');
@@ -1507,7 +1507,13 @@ switch eventformat
       filename = fullfile(filename, 'events.nev');
     end
     % read the events, apply filter is applicable
-    nev = read_neuralynx_nev(filename, 'type', flt_type, 'value', flt_value, 'mintimestamp', flt_mintimestamp, 'maxtimestamp', flt_maxtimestamp, 'minnumber', flt_minnumber, 'maxnumber', flt_maxnumber);
+    nev = read_neuralynx_nev(filename, ...
+                             'type', flt_type, ...
+                             'value', flt_value, ...
+                             'mintimestamp', flt_mintimestamp, ...
+                             'maxtimestamp', flt_maxtimestamp, ...
+                             'minnumber', flt_minnumber, ...
+                             'maxnumber', flt_maxnumber);
     
     % the following code should only be executed if there are events,
     % otherwise there will be an error subtracting an uint64 from an []
@@ -1519,7 +1525,15 @@ switch eventformat
       type      = repmat({'trigger'},size(value));
       duration  = repmat({[]},size(value));
       offset    = repmat({[]},size(value));
+      
+      %%%% this is sooo wrong in case of non-continuous recording, e.g. with
+      %%%% pauses, I would suggest rereading one channel and to map samples to timestamps
+      %%%% I could try to correct it with your assistance. 
+      %%%% Mike from KFU, mikhail.yu.sintsov@gmail.com
       sample    = num2cell(round(double(cell2mat(timestamp) - hdr.FirstTimeStamp)/hdr.TimeStampPerSample + 1));
+      warning(['nlx event reader generates event samples automatically from timestamps, '...
+               'there is no such information about samples in nlx event file, '...      
+               'make sure your data is consistent before going further']);
       % convert it into a structure array
       event = struct('type', type, 'value', value, 'sample', sample, 'timestamp', timestamp, 'duration', duration, 'offset', offset, 'number', number);
     end

--- a/fileio/ft_read_event.m
+++ b/fileio/ft_read_event.m
@@ -1526,8 +1526,6 @@ switch eventformat
       duration  = repmat({[]},size(value));
       offset    = repmat({[]},size(value));
       
-      %%%% I think I managed to correct it
-      %%%% Mike from KFU, mikhail.yu.sintsov@gmail.com
       try
           % assume we have correct ncs files there
           lst = dir(fullfile(filename, '*.ncs'));
@@ -1542,7 +1540,7 @@ switch eventformat
           ncsTimeStamp = ncsTimeStamp(:);
           
           % sanity check
-          if max(ncsTimeStamp) < timestamp{end}
+          if max(ncsTimeStamp) < timestamp{end} || min(ncsTimeStamp) > timestamp{1}
               error(['incomplete data to produce timestamp-2-sample mapping from ' ncsfname]);
           end
           

--- a/fileio/ft_read_event.m
+++ b/fileio/ft_read_event.m
@@ -1529,15 +1529,24 @@ switch eventformat
       %%%% I think I managed to correct it
       %%%% Mike from KFU, mikhail.yu.sintsov@gmail.com
       try
-          % assume we have correct ncs file there
+          % assume we have correct ncs files there
           lst = dir(fullfile(filename, '*.ncs'));
+          
+          % lets just take first for a trial
           ncsfname = fullfile(filename, lst(1).name);
           ncs = read_neuralynx_ncs(ncsfname);
           
+          % create linearized timestamp for each sample
           ncsTimeStamp = repmat(double(ncs.TimeStamp), 512, 1) + ...
                          hdr.TimeStampPerSample*repmat([0: 511]', 1, ncs.NRecords);
           ncsTimeStamp = ncsTimeStamp(:);
           
+          % sanity check
+          if max(ncsTimeStamp) < timestamp{end}
+              error(['incomplete data to produce timestamp-2-sample mapping from ' ncsfname]);
+          end
+          
+          % mapping between timestamp and sample
           % this procedure is really slow, but it is reliable enough
           sample = cellfun(@(t) find(abs(ncsTimeStamp-double(t))==min(abs(ncsTimeStamp-double(t))), 1),...
                            timestamp, 'UniformOutput', false);     

--- a/fileio/private/read_neuralynx_ds.m
+++ b/fileio/private/read_neuralynx_ds.m
@@ -170,7 +170,10 @@ if needhdr
     hdr.nSamples           = NRecords(1) * 512;
     hdr.FirstTimeStamp     = FirstTimeStamp(1);
     hdr.LastTimeStamp      = LastTimeStamp(1);
-    hdr.TimeStampPerSample = TimeStampPerSample(1);
+    
+%     this is soooooo wrong, if you have gaps in recording
+%     hdr.TimeStampPerSample = TimeStampPerSample(1);
+    hdr.TimeStampPerSample = 10^6/hdr.Fs;
   end
 
   % remember the original header details

--- a/ft_preprocessing.m
+++ b/ft_preprocessing.m
@@ -380,8 +380,13 @@ else
   cfg = ft_checkconfig(cfg, 'renamed',    {'datatype', 'continuous'});
   cfg = ft_checkconfig(cfg, 'renamedval', {'continuous', 'continuous', 'yes'});
   
-  % read the header
-  hdr = ft_read_header(cfg.headerfile, 'headerformat', cfg.headerformat);
+  % what if we have had header already, lets inherit it
+  if isfield(cfg, 'header')
+      hdr = cfg.header;
+  else
+      % read the header otherwise
+      hdr = ft_read_header(cfg.headerfile, 'headerformat', cfg.headerformat);
+  end
   
   % this option relates to reading over trial boundaries in a pseudo-continuous dataset
   if ~isfield(cfg, 'continuous')

--- a/trialfun/ft_trialfun_general.m
+++ b/trialfun/ft_trialfun_general.m
@@ -74,8 +74,13 @@ if ~isfield(cfg, 'eventformat'),  cfg.eventformat  = []; end
 if ~isfield(cfg, 'headerformat'), cfg.headerformat = []; end
 if ~isfield(cfg, 'dataformat'),   cfg.dataformat   = []; end
 
-% read the header, contains the sampling frequency
-hdr = ft_read_header(cfg.headerfile, 'headerformat', cfg.headerformat);
+% what if we have had header already, lets inherit it
+if isfield(cfg, 'header')
+    hdr = cfg.header;
+else
+    % read the header otherwise, contains the sampling frequency
+    hdr = ft_read_header(cfg.headerfile, 'headerformat', cfg.headerformat);
+end
 
 % read the events
 if isfield(cfg, 'event')


### PR DESCRIPTION
I found a mismatch between timestamps and sample number while reading nlx event file in case of non-continuous (e.g. with pauses) data acquisition. The 8724696 commit is the issue. I think I managed to solve it using mapping from timestamp to sample number acquired from data file.
BR

Mike from KFU