### PR TITLE
Make code compile for mac

### DIFF
--- a/realtime/src/acquisition/emotiv/emotiv2ft.cc
+++ b/realtime/src/acquisition/emotiv/emotiv2ft.cc
@@ -1,9 +1,19 @@
 #include <iostream>
 #include <fstream>
-#include <conio.h>
 #include <sstream>
-#include <windows.h>
 #include <map>
+
+#ifdef PLATFORM_WIN32
+    #include <windows.h>
+    void dosleep(unsigned milliseconds) {
+        Sleep(milliseconds);
+    }
+#else
+    #include <unistd.h>
+    void dosleep(unsigned milliseconds) {
+        usleep(milliseconds * 1000); // takes microseconds
+    }
+#endif
 
 #include <OnlineDataManager.h>
 #include <ConsoleInput.h>
@@ -112,7 +122,7 @@ void acquisition(const char *configFile, unsigned int fSample) {
 			sampleCounter += nSamplesTaken;
 			printf("Wrote %2i samples (%i total)\n", nSamplesTaken, sampleCounter);
 		}
-		Sleep(10);
+		dosleep(10);
 	}
 	EE_DataFree(hData);
 }


### PR DESCRIPTION
When trying recompiling emotiv2ft for the mac (to benefit from the event timing enhancement in dmarequest.cc), it appeared code was not mac compatible anymore. The suggested code in this pull request makes code for emotiv2ft.cc compile for mac again. In an older mac-compailable version, it showed a warning for sleep(0.01) being executed as sleep(0), this is also fixed.