### PR TITLE
enable plotting of the lateralized output with dimord from input

### DIFF
--- a/ft_lateralizedpotential.m
+++ b/ft_lateralizedpotential.m
@@ -111,6 +111,17 @@ lrp.plotlabel = {};
 lrp.avg       = [];
 lrp.time      = avgL.time;
 
+% add timelock signature
+if isfield(avgL, 'dimord') && isfield(avgR, 'dimord')
+    if ~strcmp(avgL.dimord, avgR.dimord)
+        error('The input data are of different dimord types');
+    else
+        lrp.dimord = avgL.dimord;
+    end
+else
+    error('''dimord'' not found. The function expects timelock data');
+end
+
 % compute the lateralized potentials
 Nchan = size(cfg.channelcmb);
 for i=1:Nchan


### PR DESCRIPTION
I found that calling `ft_singleplotER` on the output from `ft_lateralizedpotential` results in:

`Error using fixdimord (line 85)
the data does not contain a dimord, but it also does not resemble raw or component data`

The new code checks if a dimord was provided in the input data, if it is of the same type for the two data inputs, and returns error if the validation fails. If the validation passes, the dimord from one of the inputs is assigned to the lrp. This enables immediate plotting of lateralized potentials such as the lateralized readiness potential (LRP) and the contralateral delay activity (CDA) ([Vogel & Machizawa, 2004. Nature](http://www.ncbi.nlm.nih.gov/pubmed/15085132)).

Signed-off-by: Daniel Labbé <daniel.labbe@rub.de>