### PR TITLE
bugfix - use more robust nanmean for calculation of mean when using…

### DIFF
--- a/ft_resampledata.m
+++ b/ft_resampledata.m
@@ -245,7 +245,7 @@ elseif usetime
     
     % always remove the mean to avoid edge effects when there's a strong
     % offset, the cfg.demean option is dealt with below
-    bsl             = mean(data.trial{itr},2);
+    bsl             = nanmean(data.trial{itr},2);
     data.trial{itr} = data.trial{itr} - bsl(:,ones(1,size(data.trial{itr},2)));
     
     % perform the resampling


### PR DESCRIPTION
…cfg.time

I came across this when doing a time-axis based downsampling with data containing nans. The mean subtraction caused all nans. Use nanmean instead (was already the case when using resamplefs)  