### PR TITLE
ft_channelrepair outputs all of the fields that were given in data struct

### DIFF
--- a/ft_channelrepair.m
+++ b/ft_channelrepair.m
@@ -359,13 +359,7 @@ exfields = setdiff(datafields,interpfields);
 for f = 1:length(exfields)
     interp.(exfields{f}) = data.(exfields{f});
 end
-% 
-% if isfield(data, 'sampleinfo')
-%   interp.sampleinfo = data.sampleinfo;
-% end
-% if isfield(data, 'trialinfo')
-%   interp.trialinfo = data.trialinfo;
-% end
+
 if iseeg
   interp.elec  = sens;
 elseif ismeg

--- a/ft_channelrepair.m
+++ b/ft_channelrepair.m
@@ -351,12 +351,21 @@ else
 end
 
 % copy the additional fields over to the newly interpolated data
-if isfield(data, 'sampleinfo')
-  interp.sampleinfo = data.sampleinfo;
+datafields = fieldnames(data);
+interpfields = fieldnames(interp);
+
+exfields = setdiff(datafields,interpfields);
+
+for f = 1:length(exfields)
+    interp.(exfields{f}) = data.(exfields{f});
 end
-if isfield(data, 'trialinfo')
-  interp.trialinfo = data.trialinfo;
-end
+% 
+% if isfield(data, 'sampleinfo')
+%   interp.sampleinfo = data.sampleinfo;
+% end
+% if isfield(data, 'trialinfo')
+%   interp.trialinfo = data.trialinfo;
+% end
 if iseeg
   interp.elec  = sens;
 elseif ismeg


### PR DESCRIPTION
Previously, ft_channelrepair only returns sampleinfo and trialinfo as additional fields to the output struct. The more modern versions of fieldtrip have added fields in the data struct. This code fix adds in all additional fields so that the output and input will have the same fields even if more are added (or removed) in future versions. 