### PR TITLE
FIX - ensure that output args are defined, also if the function gets …

### DIFF
--- a/utilities/ft_warning.m
+++ b/utilities/ft_warning.m
@@ -54,6 +54,8 @@ function [ws, warned] = ft_warning(varargin)
 % $Id$
 
 global ft_default
+warned = false;
+ws = [];
 
 stack = dbstack;
 if any(strcmp({stack.file}, 'ft_warning.m'))
@@ -65,7 +67,6 @@ if nargin < 1
   error('You need to specify at least a warning message');
 end
 
-warned = false;
 if isstruct(varargin{1})
   warning(varargin{1});
   return;


### PR DESCRIPTION
…aborted early on. See http://bugzilla.fieldtriptoolbox.org/show_bug.cgi?id=3076 and thanks to David.