### PR TITLE
Compatibility with Bandpass Butterworth filter

### DIFF
--- a/external/signal/butter.m
+++ b/external/signal/butter.m
@@ -49,7 +49,7 @@
 function [a, b, c, d] = butter (n, W, varargin)
 
 if (nargin>4 || nargin<2) || (nargout>4 || nargout<2)
-  usage ('[b, a] or [z, p, g] or [a,b,c,d] = butter (n, W [, "ftype"][,"s"])');
+  error ('usage: [b, a] or [z, p, g] or [a,b,c,d] = butter (n, W [, "ftype"][,"s"])');
 end
 
 % interpret the input parameters
@@ -64,7 +64,7 @@ for i=1:length(varargin)
     case 's', digital = 0;
     case 'z', digital = 1;
     case { 'high', 'stop' }, stop = 1;
-    case { 'low',  'pass' }, stop = 0;
+    case { 'low',  'pass', 'bandpass' }, stop = 0;
     otherwise,  error ('butter: expected [high|stop] or [s|z]');
   end
 end


### PR DESCRIPTION
Add 'bandpass' as filter type for compatibility with MATLAB:
http://www.mathworks.com/help/signal/ref/butter.html?refresh=true#inputarg_ftype

Would it also be possible to _only_ add alternative implementation functions to the MATLAB path when MathWorks' toolboxes are missing:
https://github.com/fieldtrip/fieldtrip/blob/master/ft_defaults.m#L134