### PR TITLE
Enable passing freq data structures to ft_freqgrandaverage in a cell

### DIFF
--- a/ft_freqgrandaverage.m
+++ b/ft_freqgrandaverage.m
@@ -5,6 +5,8 @@ function [grandavg] = ft_freqgrandaverage(cfg, varargin)
 %
 % Use as
 %   [grandavg] = ft_freqgrandaverage(cfg, freq1, freq2, freq3...)
+%   or
+%   [grandavg] = ft_freqgrandaverage(cfg, {freq1, freq2, freq3...})
 %
 % The input data freq1..N are obtained from either FT_FREQANALYSIS with
 % keeptrials=no or from FT_FREQDESCRIPTIVES. The configuration structure
@@ -51,6 +53,11 @@ function [grandavg] = ft_freqgrandaverage(cfg, varargin)
 %    along with FieldTrip. If not, see <http://www.gnu.org/licenses/>.
 %
 % $Id$
+
+% if user provided cell array of freq data, unpack this here
+if numel(varargin)==1 && iscell(varargin{1}) && isfield(varargin{1}{1}, 'label')
+    varargin = varargin{1};
+end
 
 % these are used by the ft_preamble/ft_postamble function and scripts
 ft_revision = '$Id$';


### PR DESCRIPTION
Hi fieldtrippers,

To make it easier to use ft_freqgrandaverage programmatically (without
saving data to file), this change allows users to pass a cell array of
standard freq data to ft_freqgrandaverage. It checks if a cell array was
in argument one, and then "unpacks" it.

Previously it was very hard to pass data to this function in a script if you didn't want to save it to file, since you'd have to manually pass in every single freq data structure.

This could also easily be added to the other grandaverage functions (happy to do so) - as a suggestion!

Also fully backwards compatible.

Cheers,
Jan