### PR TITLE
bugfix - allow for correct handling of mouse click/button press

### DIFF
--- a/ft_artifact_zvalue.m
+++ b/ft_artifact_zvalue.m
@@ -695,20 +695,16 @@ uiresume;
 function keyboard_cb(h, eventdata)
 
 clear tmpKey
-if isa(eventdata,'matlab.ui.eventdata.ActionData') % only the case when clicked with mouse
-  % determine the key that corresponds to the uicontrol element that was activated
-  tmpKey = get(h, 'userdata');
+
+tmpKey = get(h, 'userdata');
+if ~isempty(tmpKey)
   h = getparent(h); % otherwise h is empty if isa [...].ActionData
+  curKey = tmpKey;
+else
+  curKey = eventdata.Key;
 end
 
 opt = getappdata(h, 'opt');
-
-% If a mouseclick was made, use that value. If not use the pressed key
-if exist('tmpKey', 'var')
-    curKey=tmpKey;
-else
-    curKey=eventdata.Key;
-end
 
 disp(strcat('Pressed Key (or the key corresponding to the pressed button) is: ', curKey))
 switch curKey


### PR DESCRIPTION
@robertoostenveld could you review this suggested fix please? It's basically reverting some low-level gui related data handling, that currently causes mous clicks not to work in ft_artifact_zvalue (as per bug 3118).
With this change in place, it at least works again in matlab2013b.

Thanks.