### PR TITLE
Bugfix2203

### DIFF
--- a/ft_databrowser.m
+++ b/ft_databrowser.m
@@ -1549,7 +1549,7 @@ chanindx  = match_str(opt.hdr.label, cfg.channel);
 
 % parse opt.changedchanflg, and reset
 changedchanflg = false;
-if opt.changedchanflg || strcmp(eventdata.EventName,'SizeChanged') % also plot channel labels again if figure height has changed
+if opt.changedchanflg || (exist('eventdata','var') && isa(eventdata,'matlab.ui.eventdata.SizeChangedData')) % also plot channel labels again if figure height has changed
   changedchanflg = true; % trigger for redrawing channel labels and preparing layout again (see bug 2065 and 2878)
   opt.changedchanflg = false;
 end

--- a/ft_databrowser.m
+++ b/ft_databrowser.m
@@ -2102,6 +2102,11 @@ end % function datacursortext
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 function winresize_cb(h,eventdata)
 
+% check whether the current figure is the browser
+if get(0,'currentFigure') ~= h
+  return
+end
+
 % get opt, set flg for redrawing channels, redraw
 h = getparent(h);
 opt = getappdata(h, 'opt');


### PR DESCRIPTION

@robertoostenveld @schoffelen 
Hey both,
These commits have the purpose of setting an acceptable default for the plotting of channel labels in the databrowser with viewmode = 'vertical'. The current default is terrible, with labels quickly becoming unreadable if the number of channels exceed 30ish at full screen.

With the default in these commits labels have readable fonts, are non-overlapping, and dynamically dependent on window-size. This is done by changing the number of labels that are plotted in a rationaled manner. All previous configurable options are left intact, all previously cfg-specified scenarios should be fine. It works fine on my mac in 2012a and 2015a.

If you'd be able to give this branch a shot (not pull directly into master), I'd be much obliged. No default is perfect, but I think this captures the biggest possible audience.

The below should quickly illustrate it. If you resize the window, you'll see the amount of labels changing.
data = [];
data.label = cellstr([repmat('CHAN',[100 1]) num2str((101:200)')]);
data.trial{1} = randn(100,10000);
data.time{1} = (1:10000) ./ 1000;
cfg = [];
cfg.viewmode = 'vertical';
ft_databrowser(cfg,data)



