### PR TITLE
bugfix: in ft_convert_units, fix issue when .orig.pos present

### DIFF
--- a/fileio/private/ft_convert_units.m
+++ b/fileio/private/ft_convert_units.m
@@ -247,8 +247,13 @@ end
 
 % sourcemodel obtained through mne also has a orig-field with the high
 % number of vertices
-if isfield(obj, 'orig') && (isfield(obj.orig, 'pnt') || isfield(obj.orig, 'pos'))
-  obj.orig.pnt = scale * obj.orig.pnt; 
+if isfield(obj, 'orig')
+  if isfield(obj.orig, 'pnt')
+    obj.orig.pnt = scale * obj.orig.pnt;
+  end
+  if isfield(obj.orig, 'pos')
+    obj.orig.pos = scale * obj.orig.pos;
+  end
 end
 
 % remember the unit

--- a/forward/ft_convert_units.m
+++ b/forward/ft_convert_units.m
@@ -247,8 +247,13 @@ end
 
 % sourcemodel obtained through mne also has a orig-field with the high
 % number of vertices
-if isfield(obj, 'orig') && (isfield(obj.orig, 'pnt') || isfield(obj.orig, 'pos'))
-  obj.orig.pnt = scale * obj.orig.pnt; 
+if isfield(obj, 'orig')
+  if isfield(obj.orig, 'pnt')
+    obj.orig.pnt = scale * obj.orig.pnt;
+  end
+  if isfield(obj.orig, 'pos')
+    obj.orig.pos = scale * obj.orig.pos;
+  end
 end
 
 % remember the unit

--- a/plotting/private/ft_convert_units.m
+++ b/plotting/private/ft_convert_units.m
@@ -247,8 +247,13 @@ end
 
 % sourcemodel obtained through mne also has a orig-field with the high
 % number of vertices
-if isfield(obj, 'orig') && (isfield(obj.orig, 'pnt') || isfield(obj.orig, 'pos'))
-  obj.orig.pnt = scale * obj.orig.pnt; 
+if isfield(obj, 'orig')
+  if isfield(obj.orig, 'pnt')
+    obj.orig.pnt = scale * obj.orig.pnt;
+  end
+  if isfield(obj.orig, 'pos')
+    obj.orig.pos = scale * obj.orig.pos;
+  end
 end
 
 % remember the unit


### PR DESCRIPTION
The original code threw and error when obj.orig field has field ".pos" but not a field ".pnt". 