### PR TITLE
vlim and hlim in multiplot are translated to ylim and xlim.

### DIFF
--- a/ft_multiplotER.m
+++ b/ft_multiplotER.m
@@ -866,6 +866,8 @@ if ~isempty(label)
     cfg = rmfield(cfg, 'inputfile');
   end
   cfg.channel = label;
+  cfg.xlim = cfg.hlim;
+  cfg.ylim = cfg.vlim;
   % put data name in here, this cannot be resolved by other means
   info = guidata(gcf);
   cfg.dataname = info.dataname;


### PR DESCRIPTION
vlim and hlim in multiplot are translated to ylim and xlim in singleplot when the interactive option is used. This could be advantageous when the multiplotER is used interactively.
In the previous version even if zlim, vlim, and hlim are set in the call of multiplotER, they are not forwarded correctly to the interactively called singleplotER and the subsequent topoplotER. For example, this is problematic especially when you want to have a 'maxabs' limited topoplot. Even if the vlim and zlim are set to 'maxabs' before calling multiplot, in the subsequent topoplot which is interactively plotted,  the zlim is still 'minmax'. The simple change proposed by this pull request solves the problem.
