### PR TITLE
critical bugfix for beamformer_lcmv nai/unitnoisegain orientation selection

### DIFF
--- a/inverse/beamformer_lcmv.m
+++ b/inverse/beamformer_lcmv.m
@@ -254,7 +254,7 @@ for i=1:size(dip.pos,1)
           case {'unitnoisegain','nai'};
               % optimal orientation calculation for unit-noise gain beamformer,
               % (also applies to similar NAI), based on equation 4.47 from Sekihara & Nagarajan (2008)
-              [vv, dd] = eig(pinv(lf' * invCy *lf)*(lf' * invCy^2 *lf));
+              [vv, dd] = eig(pinv(lf' * invCy^2 *lf)*(lf' * invCy *lf));
               [~,maxeig]=max(diag(dd));
               eta = vv(:,maxeig);
               lf  = lf * eta;


### PR DESCRIPTION
 critical bugfix!  the new nai/unitnoisegain orientation selection formula was incorrectly flipped (denominator vs numerator), now fixed and tested as providing correct orientation using a simulation.