### PR TITLE
enhancement: support integer coordinates for channel positions

### DIFF
--- a/ft_prepare_layout.m
+++ b/ft_prepare_layout.m
@@ -923,10 +923,21 @@ fid=fopen(filename);
 lay_string=fread(fid,inf,'char=>char')';
 fclose(fid);
 
-% pattern to match is 5 numeric values followed by a string that can
-% contain whitespaces and plus characters, followed by newline
-pat=['(\d+)\s+([\d\.-]+)\s+([\d\.-]+)\s+([\d\.-]+)\s+([\d\.-]+)\s+'...
-        '([\w\s\+]+\w)\s*' sprintf('\n')];
+% pattern to match is integer, than 4 numeric values followed by a
+% string that can contain whitespaces and plus characters, followed by
+% newline
+integer='(\d+)';
+float='([\d\.-]+)';
+space='\s+';
+channel_label='([\w \t\r\f\v\+]+)';
+single_newline='\n';
+
+pat=[integer, space, ...
+     float, space, ...
+     float, space, ...
+     float, space, ...
+     float, space, ...
+     channel_label, single_newline];
 
 matches=regexp(sprintf('%s\n',lay_string),pat,'tokens');
 
@@ -942,7 +953,12 @@ num_values=str2num(str_values);
 layout.pos    = num_values(:,2:3);
 layout.width  = num_values(:,4);
 layout.height = num_values(:,5);
-layout.label  = layout_matrix(:,6);
+
+% trim whitespace around channel names
+label=layout_matrix(:,6);
+label=regexprep(label,'^\s*','');
+label=regexprep(label,'\s*$','');
+layout.label  = label;
 return % function readlay
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
As pointed out by @jschmiedt [1], layouts with integer coordinates are not supported. I don't know if such layouts exists, but in case, the current PR allows also for integer coordinates.

[1] https://github.com/fieldtrip/fieldtrip/commit/a297d505daa7e817a77f3fb6625c16acd84aed68#commitcomment-18351186