### PR TITLE
Avoid potential error when assigning fieldname from filename

### DIFF
--- a/fileio/ft_read_event.m
+++ b/fileio/ft_read_event.m
@@ -838,7 +838,7 @@ switch eventformat
     end;
     for i = 1:numel(xmlfiles)
       if strcmpi(xmlfiles(i).name(1:6), 'Events')
-        fieldname       = xmlfiles(i).name(1:end-4);
+        fieldname       = strrep(xmlfiles(i).name(1:end-4), ' ', '_');
         filename_xml    = fullfile(filename, xmlfiles(i).name);
         xml.(fieldname) = xml2struct(filename_xml);
       end


### PR DESCRIPTION
The filename of the events file is used as fieldname for the structure xml. This will lead to an error if the file name contains blanks (e.g. on EGI EEG systems). 
Replaced blanks in string with underscores before using it as a fieldname.