### PR TITLE
enhancement - made detection of neuromag306 more robust

### DIFF
--- a/forward/ft_senstype.m
+++ b/forward/ft_senstype.m
@@ -354,9 +354,9 @@ else
       type = 'yokogawa9';
       
       % there are two possibilities for the neuromag channel labels: with and without a space, hence the 0.4
-    elseif any(mean(ismember(ft_senslabel('neuromag306_combined'), sens.label)) > 0.4)
+    elseif sum(sum(ismember(ft_senslabel('neuromag306_combined'), sens.label)))/204 > 0.8
       type = 'neuromag306_combined';
-    elseif any(mean(ismember(ft_senslabel('neuromag306'),          sens.label)) > 0.4)
+    elseif sum(sum(ismember(ft_senslabel('neuromag306'),          sens.label)))/306 > 0.8
       type = 'neuromag306';
     elseif all(mean(ismember(ft_senslabel('neuromag122_combined'), sens.label)) > 0.4)
       type = 'neuromag122_combined';


### PR DESCRIPTION
This pertains to the fact that an uncombined dataset (i.e. a 'native' 306-channel data structure) was recognized by ft_senstype to be 'neuromag306_combined'. This caused a problem in ft_combineplanar, where ft_senslabel is called as output = ft_senslabel(ft_senstype(data),'output','planarcombined');

