### PR TITLE
Fixed bug leading to error if 'compile' = 'auto'

### DIFF
--- a/qsub/qsubcellfun.m
+++ b/qsub/qsubcellfun.m
@@ -236,7 +236,7 @@ end
 
 % running a compiled version in parallel takes no MATLAB licenses
 % auto compilation will be attempted if the total batch takes more than 30 minutes
-if istrue(compile) || (strcmp(compile, 'auto') && (numjob*timreq/3600)>0.5)
+if (strcmp(compile, 'auto') && (numjob*timreq/3600)>0.5) || istrue(compile)
   try
     % try to compile into a stand-allone application
     fcomp = qsubcompile(fname, 'batch', batch, 'batchid', batchid);


### PR DESCRIPTION
If variable 'compile' is set to 'auto', istrue(compile) will lead to an error. 
Checking for strcmp(compile, 'auto') first circumvents that issue.