### PR TITLE
add support for intervals and other events in NEX files

### DIFF
--- a/fileio/private/read_nex_event.m
+++ b/fileio/private/read_nex_event.m
@@ -1,15 +1,23 @@
 function [event] = read_nex_event(filename)
 
-% READ_NEX_EVENT for Plexon *.nex file
+% READ_NEX_EVENT for Plexon *.nex file, supports NEX variable types:
+%   marker, interval, and event
 %
 % Use as
 %   [event] = read_nex_event(filename)
+%
+% The event.type used to select events in ft_trialfun_general is the
+% variable name from the NEX file (hdr.varheader.name - not to be confused
+% with hdr.varheader.type).
 %
 % The sample numbers returned in event.sample correspond with the
 % timestamps, correcting for the difference in sampling frequency in the
 % continuous LFP channels and the system sampling frequency. Assuming 40kHz
 % sampling frequency for the system and 1kHz for the LFP channels, it is
 %   event.sample = timestamp / (40000/1000);
+% If there are no continuous variables in the file, the system sampling
+% frequency is used throughout, so
+%   event.sample = timestamp;
 %
 % See also READ_NEX_HEADER, READ_NEX_DATA
 
@@ -35,33 +43,107 @@ function [event] = read_nex_event(filename)
 
 hdr = read_nex_header(filename);
 adindx = find(cell2mat({hdr.varheader.typ})==5);
-smpfrq = hdr.varheader(adindx(1)).wfrequency;
-
-% find the channel with the strobed trigger
-mrkvarnum = find([hdr.varheader.typ] == 6);
-
-fid=fopen(filename,'r','ieee-le');
-status = fseek(fid,hdr.varheader(mrkvarnum).offset,'bof');
-
-% read the time of the triggers
-dum = fread(fid,hdr.varheader(mrkvarnum).cnt,'int32');
-timestamp = dum;
-dum = dum ./(hdr.filheader.frequency./smpfrq);
-mrk.tim = round(dum);
-
-% read the value of the triggers
-status = fseek(fid,64,'cof');
-dum = fread(fid,[hdr.varheader(mrkvarnum).mrklen,hdr.varheader(mrkvarnum).cnt],'uchar');
-mrk.val = str2num(char(dum(1:5,:)'));
-
-status = fclose(fid);
-
-% translate into an FCDC event structure
-Nevent = length(mrk.tim);
-event = struct('sample', num2cell(mrk.tim), 'value', num2cell(mrk.val), 'timestamp', num2cell(timestamp));
-for i=1:Nevent
-  event(i).type     = hdr.varheader(mrkvarnum).nam;
-  event(i).duration = 1;
-  event(i).offset   = 0;
+if isempty(adindx)  % this would otherwise produce an error
+  warning('No continuous variables found - using hdr.filheader.frequency');
+  smpfrq = hdr.filheader.frequency;
+else
+  smpfrq = hdr.varheader(adindx(1)).wfrequency;
 end
 
+fid=fopen(filename,'r','ieee-le');
+event = struct('sample',{},'value',{},'timestamp',{},'type',{}, ...
+  'duration',{},'offset',{});
+
+% find the channel with the strobed trigger ("marker")
+mrkvarnum = find([hdr.varheader.typ] == 6);
+
+if ~isempty(mrkvarnum)  % both of these cases would have produced errors
+  if numel(mrkvarnum) > 1
+    warning('file contains >1 "marker" variable, reading only the first');
+    mrkvarnum = mrkvarnum(1);
+  end
+  status = fseek(fid,hdr.varheader(mrkvarnum).offset,'bof');
+  if status < 0;  error('error with fseek');  end
+  
+  % read the time of the triggers
+  dum = fread(fid,hdr.varheader(mrkvarnum).cnt,'int32');
+  timestamp = dum;
+  dum = dum ./(hdr.filheader.frequency./smpfrq);
+  mrk.tim = round(dum);
+  
+  % read the value of the triggers
+  status = fseek(fid,64,'cof');
+  if status < 0;  error('error with fseek');  end
+  dum = fread(fid, [hdr.varheader(mrkvarnum).mrklen, ...
+    hdr.varheader(mrkvarnum).cnt], 'uchar');
+  mrk.val = str2num(char(dum(1:5,:)')); %#ok<ST2NM> non-scalar
+  
+  % translate into an FCDC event structure
+  Nevent = length(mrk.tim);
+  for i=1:Nevent
+    event(i).sample         = mrk.tim(i);
+    event(i).value          = mrk.val(i);
+    event(i).timestamp      = timestamp(i);
+    event(i).type           = hdr.varheader(mrkvarnum).nam;
+    event(i).duration       = 1;
+    event(i).offset         = 0;
+  end
+end
+
+% find interval channels
+intvarnum = find([hdr.varheader.typ] == 2);
+
+for int = 1:numel(intvarnum)
+  status = fseek(fid,hdr.varheader(intvarnum(int)).offset,'bof');
+  if status < 0;  error('error with fseek');  end
+
+  % read the time of the triggers
+  dum1 = fread(fid,hdr.varheader(intvarnum(int)).cnt,'int32');
+  dum2 = fread(fid,hdr.varheader(intvarnum(int)).cnt,'int32');
+  timestamp = dum1;
+  dum1 = dum1 ./(hdr.filheader.frequency./smpfrq);
+  dum2 = dum2 ./(hdr.filheader.frequency./smpfrq);
+  evt.tim = round(dum1);
+  evt.dur = round(dum2-dum1);
+  
+  % translate into an FCDC event structure
+  Nold = length(event);
+  Nevent = length(evt.tim);
+  for i=1:Nevent
+    event(Nold+i).sample        = evt.tim(i);
+    event(Nold+i).value         = [];
+    event(Nold+i).timestamp     = timestamp(i);
+    event(Nold+i).type          = hdr.varheader(intvarnum(int)).nam;
+    event(Nold+i).duration      = evt.dur(i);
+    event(Nold+i).offset        = 0;
+  end
+end
+
+% find event channels
+evtvarnum = find([hdr.varheader.typ] == 1);
+
+for ev = 1:numel(evtvarnum)
+  status = fseek(fid,hdr.varheader(evtvarnum(ev)).offset,'bof');
+  if status < 0;  error('error with fseek');  end
+
+  % read the time of the triggers
+  dum = fread(fid,hdr.varheader(evtvarnum(ev)).cnt,'int32');
+  timestamp = dum;
+  dum = dum ./(hdr.filheader.frequency./smpfrq);
+  evt.tim = round(dum);
+  
+  % translate into an FCDC event structure
+  Nold = length(event);
+  Nevent = length(evt.tim);
+  for i=1:Nevent
+    event(Nold+i).sample        = evt.tim(i);
+    event(Nold+i).value         = [];
+    event(Nold+i).timestamp     = timestamp(i);
+    event(Nold+i).type          = hdr.varheader(evtvarnum(ev)).nam;
+    event(Nold+i).duration      = 1;
+    event(Nold+i).offset        = 0;
+  end
+end
+
+status = fclose(fid);
+if status < 0;  error('error with fclose');  end

--- a/test/test_bug2093.m
+++ b/test/test_bug2093.m
@@ -6,6 +6,7 @@ function test_bug2093
 testnexfile = 'S:\Teresa\Analyses\FieldTrip\test files\p213parall.nex';
 testmatfile = 'S:\Teresa\Analyses\FieldTrip\test files\bug2093.mat';
 
+%% first get output of old code
 if ~exist(testmatfile, 'file')
   % run only once, using old fieldtrip code
   git checkout master
@@ -21,10 +22,12 @@ else
   load(testmatfile)
 end
 
+%% then get output of new code
 % new.hdr = ft_read_header(testnexfile);
 % new.dat = ft_read_data(testnexfile);
 new.evt = ft_read_event(testnexfile);
 
+%% then compare the 2
 % make sure the old header and data are identical, since I haven't changed
 % them yet
 % assert(isequal(old.hdr,new.hdr))
@@ -68,7 +71,7 @@ oldevttable = struct2table(old.evt);
 % when verifying that all old event rows are contained in the new event
 % data.
 newrows = ~any(mtnew,2);
-newevttable = table;
+newevttable = table; %#ok<*AGROW>
 for fieldn = 1:numel(fnames)
   if isequal(size(newcell{fieldn},1), numel(newrows))
     newevttable = [newevttable table(newcell{fieldn}(newrows,:), ...

--- a/test/test_bug2093.m
+++ b/test/test_bug2093.m
@@ -4,8 +4,9 @@ function test_bug2093
 % (nexhandling branch) versions of the FieldTrip code
 
 testnexfile = 'S:\Teresa\Analyses\FieldTrip\test files\p213parall.nex';
+testmatfile = 'S:\Teresa\Analyses\FieldTrip\test files\bug2093.mat';
 
-if ~exist(['data_bug2093' filesep 'bug2093.mat'], 'file')
+if ~exist(testmatfile, 'file')
   % run only once, using old fieldtrip code
   git checkout master
   
@@ -14,10 +15,10 @@ if ~exist(['data_bug2093' filesep 'bug2093.mat'], 'file')
   old.evt = ft_read_event(testnexfile);
   
   git checkout nexhandling
-  save(['data_bug2093' filesep 'bug2093.mat'], 'old')
+  save(testmatfile, 'old')
 else
   % all future test executions with newer FT code
-  load(['data_bug2093' filesep 'bug2093.mat'])
+  load(testmatfile)
 end
 
 % new.hdr = ft_read_header(testnexfile);

--- a/test/test_bug2093.m
+++ b/test/test_bug2093.m
@@ -1,0 +1,84 @@
+function test_bug2093
+%TEST_BUG2093 Compares output of same test NEX file from ft_read_header,
+% ft_read_data, and ft_read_event using old (master branch) and new
+% (nexhandling branch) versions of the FieldTrip code
+
+testnexfile = 'S:\Teresa\Analyses\FieldTrip\test files\p213parall.nex';
+
+if ~exist(['data_bug2093' filesep 'bug2093.mat'], 'file')
+  % run only once, using old fieldtrip code
+  git checkout master
+  
+  old.hdr = ft_read_header(testnexfile);
+  old.dat = ft_read_data(testnexfile);
+  old.evt = ft_read_event(testnexfile);
+  
+  git checkout nexhandling
+  save(['data_bug2093' filesep 'bug2093.mat'], 'old')
+else
+  % all future test executions with newer FT code
+  load(['data_bug2093' filesep 'bug2093.mat'])
+end
+
+% new.hdr = ft_read_header(testnexfile);
+% new.dat = ft_read_data(testnexfile);
+new.evt = ft_read_event(testnexfile);
+
+% make sure the old header and data are identical, since I haven't changed
+% them yet
+% assert(isequal(old.hdr,new.hdr))
+% assert(isequaln(old.dat,new.dat)) % data padded with NaNs should still be =
+
+%% make sure all old events are still present, despite adding more
+assert(isequal(fieldnames(old.evt), fieldnames(new.evt)))
+fnames = fieldnames(old.evt);
+oldcell = cell(1,numel(fnames));
+newcell = cell(1,numel(fnames));
+mtnew = false(numel(new.evt),numel(fnames));
+for fieldn = 1:numel(fnames)
+  if ischar(old.evt(1).(fnames{fieldn})) && ...
+      ischar(new.evt(1).(fnames{fieldn}))
+    oldcell{fieldn} = {old.evt.(fnames{fieldn})}';
+    newcell{fieldn} = {new.evt.(fnames{fieldn})}';
+  else
+    oldcell{fieldn} = vertcat(old.evt.(fnames{fieldn}));
+    newcell{fieldn} = vertcat(new.evt.(fnames{fieldn}));
+  end
+  assert(isequal(class(oldcell{fieldn}), class(newcell{fieldn})))
+  
+  if ~isequal(size(oldcell{fieldn},1), numel(old.evt))
+    error('This strategy won''t work.')
+  end
+  if ~isequal(size(newcell{fieldn},1), numel(new.evt))
+    for evn = 1:numel(new.evt)
+      mtnew(evn,fieldn) = isempty(new.evt(evn).(fnames{fieldn}));
+    end
+    if ~isequal(size(newcell{fieldn},1), sum(~mtnew(:,fieldn)))
+      error('Empty fields don''t account for difference in event #s.')
+    end
+  end
+end
+
+oldevttable = struct2table(old.evt);
+% Empty values in numeric variables cause the column to be represented as a
+% cell array when the structure is converted to a table, which is not
+% supported by ismember.  The empty values should only be in the new event
+% types I added support for, so they can be safely excluded from the table
+% when verifying that all old event rows are contained in the new event
+% data.
+newrows = ~any(mtnew,2);
+newevttable = table;
+for fieldn = 1:numel(fnames)
+  if isequal(size(newcell{fieldn},1), numel(newrows))
+    newevttable = [newevttable table(newcell{fieldn}(newrows,:), ...
+      'VariableNames',fnames(fieldn))];
+  elseif isequal(size(newcell{fieldn},1), sum(newrows))
+    newevttable = [newevttable table(newcell{fieldn}, ...
+      'VariableNames',fnames(fieldn))];
+  else
+    error('There may be different empty cells in different event fields.')
+  end
+end
+
+assert(all(ismember(oldevttable,newevttable)))
+disp('All old events found in new event output.')


### PR DESCRIPTION
read_nex_event should now support NEX variable types "event" and "interval," in addition to the present "marker."  I also added some workarounds for rare errors and related documentation, but none of my changes should affect the output for anyone who is already using the function successfully.

Relates to http://bugzilla.fieldtriptoolbox.org/show_bug.cgi?id=2093