### PR TITLE
ENH: adapted qsub memory reservation for SGE systems

### DIFF
--- a/qsub/qsubfeval.m
+++ b/qsub/qsubfeval.m
@@ -297,7 +297,7 @@ switch backend
     end
     
     if ~isempty(memreq) && ~isnan(memreq) && ~isinf(memreq)
-      submitoptions = [submitoptions sprintf('-l h_vmem=%.0f ', memreq+memoverhead)];
+      submitoptions = [submitoptions sprintf('-l mem_free=%.0fG ', round((memreq+memoverhead)/1024^3))];
     end
     
     if compiled


### PR DESCRIPTION
Since SGE wants memory to reserved according to -l memfree=XXG, where XX is amount of Gb, the code has been adjusted from

submitoptions = [submitoptions sprintf('-l mem_free=%.0f ', memreq+memoverhead)];

into

submitoptions = [submitoptions sprintf('-l mem_free=%.0fG ', round((memreq+memoverhead)/1024^3))];

at line 300 of qsubfeval.m.