### PR TITLE
fix bug in header payload indexing

### DIFF
--- a/realtime/src/buffer/python/FieldTrip.py
+++ b/realtime/src/buffer/python/FieldTrip.py
@@ -311,7 +311,7 @@ class Client:
                 (chunk_type, chunk_len) = struct.unpack(
                     'II', payload[offset:offset + 8])
                 offset += 8
-                if offset + chunk_len < bufsize:
+                if offset + chunk_len >= bufsize:
                     break
                 H.chunks[chunk_type] = payload[offset:offset + chunk_len]
                 offset += chunk_len


### PR DESCRIPTION
Hi,
I was not able to read channel info properly when trying out `FieldTrip.py` from mne-python. Here is a minimal example (alpha is a TRIUX acquisition workstation):

```
from mne.externals.FieldTrip import Client as FtClient

ftc = FtClient()
ftc.connect('alpha', 1972)
hdr = ftc.getHeader()
ftc.disconnect()
print hdr.labels
```

I traced it down to `getHeader()`. I think the comparison of offset + chunk_len vs bufsize is the wrong way around; it should break if offset + chunk_len is larger than bufsize (or equal to bufsize, because of zero-based indexing). With this change, it starts to work.

