### PR TITLE
ft_sloreta critical bugfix (see Bug 2979)

### DIFF
--- a/inverse/ft_sloreta.m
+++ b/inverse/ft_sloreta.m
@@ -208,6 +208,10 @@ elseif ~isempty(subspace)
   end
 end
 
+L = cell2mat(dip.leadfield);
+G = L*L'; % Gram matrix
+invG = inv(G + lambda * eye(size(G))); % regularized G^-1
+
 % start the scanning with the proper metric
 ft_progress('init', feedback, 'scanning grid');
 
@@ -229,31 +233,11 @@ for i=1:size(dip.pos,1)
     lf = ft_compute_leadfield(dip.pos(i,:), grad, headmodel, 'reducerank', reducerank, 'normalize', normalize, 'normalizeparam', normalizeparam);
   end
   
-  if isfield(dip, 'subspace')
-    % do subspace projection of the forward model
-    lf    = dip.subspace{i} * lf;
-    % the data and the covariance become voxel dependent due to the projection
-    dat   =      dip.subspace{i} * dat_pre_subspace;
-    Cy    =      dip.subspace{i} * (Cy_pre_subspace + lambda * eye(size(Cy_pre_subspace))) * dip.subspace{i}';
-    invCy = pinv(dip.subspace{i} * (Cy_pre_subspace + lambda * eye(size(Cy_pre_subspace))) * dip.subspace{i}');
-  elseif ~isempty(subspace)
-    % do subspace projection of the forward model only
-    lforig = lf;
-    lf     = subspace * lf;
-    
-    % according to Kensuke's paper, the eigenspace bf boils down to projecting
-    % the 'traditional' filter onto the subspace
-    % spanned by the first k eigenvectors [u,s,v] = svd(Cy); filt = ESES*filt; 
-    % ESES = u(:,1:k)*u(:,1:k)';
-    % however, even though it seems that the shape of the filter is identical to
-    % the shape it is obtained with the following code, the w*lf=I does not hold.
-  end
   
-  G = lf * lf'; % Gram matrix
-  invG = inv(G + lambda * eye(size(G))); % regularized G^-1
-  
+
   if fixedori
-      [vv, dd] = eig(pinv(lf' * invG * lf) * lf' * invG * Cy * invG * lf); % eqn 13.22 from Sekihara & Nagarajan 2008 for sLORETA
+  %    [vv, dd] = eig(pinv(lf' * invG * lf) * lf' * invG * Cy * invG * lf); % eqn 13.22 from Sekihara & Nagarajan 2008 for sLORETA
+      [vv, dd] = eig(pinv(lf' * invG * Cy * invG * lf) * lf' * invG * lf); % eqn 13.22 from Sekihara & Nagarajan 2008 for sLORETA
       [~,maxeig]=max(diag(dd));
       eta = vv(:,maxeig);
       lf  = lf * eta;

--- a/inverse/ft_sloreta.m
+++ b/inverse/ft_sloreta.m
@@ -236,8 +236,7 @@ for i=1:size(dip.pos,1)
   
 
   if fixedori
-  %    [vv, dd] = eig(pinv(lf' * invG * lf) * lf' * invG * Cy * invG * lf); % eqn 13.22 from Sekihara & Nagarajan 2008 for sLORETA
-      [vv, dd] = eig(pinv(lf' * invG * Cy * invG * lf) * lf' * invG * lf); % eqn 13.22 from Sekihara & Nagarajan 2008 for sLORETA
+      [vv, dd] = eig(pinv(lf' * invG * lf) * lf' * invG * Cy * invG * lf); % eqn 13.22 from Sekihara & Nagarajan 2008 for sLORETA
       [~,maxeig]=max(diag(dd));
       eta = vv(:,maxeig);
       lf  = lf * eta;


### PR DESCRIPTION
ft_sloreta critical bugfix: the Gram matrix was improperly computed voxel-by-voxel, now fixed by computing it before the for-loop. (See Bug 2979)

Furthermore, orientation optimization was validated by confirming that the selected orientation indeed maximizes equation 13.23 from Sekihara & Nagarajan (2008) for a real dataset.