### PR TITLE
[FIX] ft_version now also works if fieldtrip is used as a git submodule

### DIFF
--- a/utilities/ft_version.m
+++ b/utilities/ft_version.m
@@ -57,7 +57,7 @@ end
 
 if isempty(isgit)
   % are we dealing with an GIT working copy of fieldtrip?
-  isgit = isdir(fullfile(ftpath, '.git'));
+  isgit = exist(fullfile(ftpath, '.git'), 'file');
 end
 
 if ispc


### PR DESCRIPTION
ft_version does not use git if it is used as a git submodule because in that case .git is not a folder but a file. this patch allows ft_version to use git also in these cases.