### PR TITLE
FIX: bug3221, error reporting in ft_definetrial and warning reporting in ft_getuserfun

### DIFF
--- a/ft_definetrial.m
+++ b/ft_definetrial.m
@@ -152,10 +152,11 @@ if isfield(cfg, 'trl')
 
 elseif isfield(cfg, 'trialfun')
 
+  trialfunSpecified = cfg.trialfun;
   cfg.trialfun = ft_getuserfun(cfg.trialfun, 'trialfun');
 
   if isempty(cfg.trialfun)
-    error('the specified trialfun ''%s'' was not found', func2str(cfg.trialfun));
+    error('the specified trialfun ''%s'' was not found', trialfunSpecified);
   else
     fprintf('evaluating trialfunction ''%s''\n', func2str(cfg.trialfun));
   end

--- a/private/ft_getuserfun.m
+++ b/private/ft_getuserfun.m
@@ -45,6 +45,6 @@ elseif isfunction(['ft_' prefix '_' func])
   func = str2func(['ft_' prefix '_' func]);
 else
   warning(['no function by the name ''' func ''', ''' prefix '_' func...
-    ''', or ''ft_' prefix '_' func ''' could not be found']);
+    ''', or ''ft_' prefix '_' func ''' could be found']);
   func = [];
 end


### PR DESCRIPTION
See bug 3221, concerning ft_definetrial.

When a function specified by cfg.trialfun does not exist ft_getuserfun
replaces cfg.trialfun by an empty double (and gives a false double
negative warning while doing so), yet the subsequent error message
assumes cfg.trialfun is still a char.