### PR TITLE
Estimate noise properly with rank-deficient cov matrices (Bug 3162)

### DIFF
--- a/inverse/beamformer_pcc.m
+++ b/inverse/beamformer_pcc.m
@@ -157,6 +157,7 @@ Nchan    = size(Cf,1);            % should equal Nmegchan + Nrefchan + Nsupchan
 Cmeg     = Cf(megchan,megchan);   %  the filter uses the csd between all MEG channels
 
 isrankdeficient = (rank(Cmeg)<size(Cmeg,1));
+rankCmeg = rank(Cmeg);
 
 % it is difficult to give a quantitative estimate of lambda, therefore also
 % support relative (percentage) measure that can be specified as string (e.g. '10%')
@@ -167,17 +168,11 @@ if ~isempty(lambda) && ischar(lambda) && lambda(end)=='%'
 end
 
 if projectnoise
-  % estimate the noise power, which is further assumed to be equal and uncorrelated over channels
-  if isrankdeficient
-    % estimated noise floor is equal to or higher than lambda
-    noise = lambda;
-  else
-    % estimate the noise level in the covariance matrix by the smallest singular value
+  % estimate the noise level in the covariance matrix by the smallest singular (non-zero) value
     noise = svd(Cmeg);
-    noise = noise(end);
+    noise = noise(rankCmeg);
     % estimated noise floor is equal to or higher than lambda
     noise = max(noise, lambda);
-  end
 end
 
 if realfilter


### PR DESCRIPTION
...for PCC, analogous to recent changes to beamformer_lcmv and _dics in commit 473c9d1ea14bee63f258479eee34cd122e4518da / pull #275

Runs for me without errors, please double-check anyway.