### PR TITLE
using external reading functions in fileio

### DIFF
--- a/fileio/ft_read_data.m
+++ b/fileio/ft_read_data.m
@@ -31,6 +31,9 @@ function [dat] = ft_read_data(filename, varargin)
 %
 % The list of supported file formats can be found in FT_READ_HEADER.
 %
+% To use an external reading function, use key-value pair: 'dataformat', FUNCTION_NAME.
+% (Function needs to be on the path, and take as input: filename, hdr, begsample, endsample, chanindx.)
+%
 % See also FT_READ_HEADER, FT_READ_EVENT, FT_WRITE_DATA, FT_WRITE_EVENT
 
 % Copyright (C) 2003-2016 Robert Oostenveld
@@ -1352,10 +1355,17 @@ switch dataformat
     end
     
   otherwise
-    if strcmp(fallback, 'biosig') && ft_hastoolbox('BIOSIG', 1)
-      dat = read_biosig_data(filename, hdr, begsample, endsample, chanindx);
-    else
-      error('unsupported data format (%s)', dataformat);
+    % attempt to run dataformat as a function
+    % in case using an external read function was desired, this is where it is executed
+    % if it fails, the regular unsupported error message is thrown
+    try
+      dat = feval(dataformat,filename, hdr, begsample, endsample, chanindx);
+    catch
+      if strcmp(fallback, 'biosig') && ft_hastoolbox('BIOSIG', 1)
+        dat = read_biosig_data(filename, hdr, begsample, endsample, chanindx);
+      else
+        error('unsupported data format (%s)', dataformat);
+      end
     end
 end % switch dataformat
 

--- a/fileio/ft_read_header.m
+++ b/fileio/ft_read_header.m
@@ -33,6 +33,9 @@ function [hdr] = ft_read_header(filename, varargin)
 %
 % For continuously recorded data, nSamplesPre=0 and nTrials=1.
 %
+% To use an external reading function, use key-value pair: 'headerformat', FUNCTION_NAME.
+% (Function needs to be on the path, and take as input: filename)
+%
 % Depending on the file format, additional header information can be
 % returned in the hdr.orig subfield.
 %
@@ -2242,10 +2245,17 @@ switch headerformat
     checkUniqueLabels = false;
     
   otherwise
-    if strcmp(fallback, 'biosig') && ft_hastoolbox('BIOSIG', 1)
-      hdr = read_biosig_header(filename);
-    else
-      error('unsupported header format "%s"', headerformat);
+    % attempt to run headerformat as a function
+    % in case using an external read function was desired, this is where it is executed
+    % if it fails, the regular unsupported error message is thrown
+    try
+      hdr = feval(headerformat,filename);
+    catch
+      if strcmp(fallback, 'biosig') && ft_hastoolbox('BIOSIG', 1)
+        hdr = read_biosig_header(filename);
+      else
+        error('unsupported header format "%s"', headerformat);
+      end
     end
     
 end % switch headerformat


### PR DESCRIPTION
I have a proposition. I'm writing reading functions for some dataset, in its own particular non-recording-equipment related dataformat. I don't think it's a good idea to add such idiosyncratic datasets to ft_read_data/event/header. So, how about the possibility of using external unsupported reading functions? 

In this pull request is an easy and safe way to allow for this. In side the 'otherwise' of the main case-switch, dataformat/headerformat/eventformat is attempted to be executed as a function in a try-catch. If it fails, the regular failure message is given. Reasonably safe I would say. (Initially I thought of feeding xxxformat as a function handle, to prevent rare unintended executions, but the switch-case cannot handle that type). 

What do you think?

If you agree, I'd also happily remove the 'nmc_archive_k''s (idiosyncratic data like the above), which I added years ago for my work with some datasets. They are no longer used at the Donders, and the external people that depend on them will send me an email if they still use them.