### PR TITLE
ENH: output labels for a point of interest (cfg.roi)

### DIFF
--- a/ft_volumelookup.m
+++ b/ft_volumelookup.m
@@ -111,14 +111,13 @@ end
 % the checking of the input data is done further down
 
 cfg.maxqueryrange      = ft_getopt(cfg,'maxqueryrange', 1);
+cfg.output             = ft_getopt(cfg,'output', []); % in future, cfg.output could be extended to support both 'label' and 'mask'
 
 roi2mask   = 0;
 mask2label = 0;
 roi2label = 0;
-if isfield(cfg, 'roi') && isfield(cfg, 'output')
-  if strcmp(cfg.output, 'label') % in future, cfg.output should be extended to support both 'label' and 'mask'
+if isfield(cfg, 'roi') && strcmp(cfg.output, 'label')
     roi2label = 1;   
-  end
 elseif isfield(cfg, 'roi');
   roi2mask = 1;
 elseif isfield(cfg, 'maskparameter')

--- a/ft_volumelookup.m
+++ b/ft_volumelookup.m
@@ -10,9 +10,9 @@ function [output] = ft_volumelookup(cfg, volume)
 % be used as:
 %   mask = ft_volumelookup(cfg, volume)
 %
-% Given a binary volume that indicates a region of interest, it looks up
-% the corresponding anatomical or functional labels from a given atlas. In
-% this case the function is to be used as follows:
+% Given a binary volume that indicates a region of interest or a point of 
+% interest, it looks up the corresponding anatomical or functional labels 
+% from a given atlas. In this case the function is to be used as:
 %    labels = ft_volumelookup(cfg, volume)
 %
 % In both cases the input volume can be:
@@ -41,6 +41,16 @@ function [output] = ft_volumelookup(cfg, volume)
 %                        or the WFU atlasses available from http://fmri.wfubmc.edu. see FT_READ_ATLAS
 %   cfg.maskparameter = string, field in volume to be lookedup, data in field should be logical
 %   cfg.maxqueryrange = number, should be 1, 3, 5 (default = 1)
+%
+% The configuration options for labels around a point of interest:
+%   cfg.roi           = Nx3 vector, coordinates of the points of interest
+%   cfg.inputcoord    = 'mni' or 'tal', coordinate system of the mri/source/stat
+%   cfg.atlas         = string, filename of atlas to use, either the AFNI
+%                        brik file that is available from http://afni.nimh.nih.gov/afni/doc/misc/afni_ttatlas/,
+%                        or the WFU atlasses available from http://fmri.wfubmc.edu. see FT_READ_ATLAS
+%   cfg.output        = 'label'
+%   cfg.maxqueryrange = number, should be 1, 3, 5 (default = 1)
+%   cfg.round2nearestvoxel = 'yes' or 'no' (default = 'yes'), voxel closest to point of interest is calculated
 %
 % The label output has a field "names", a field "count" and a field "usedqueryrange"
 % To get a list of areas of the given mask you can do for instance:
@@ -104,7 +114,12 @@ cfg.maxqueryrange      = ft_getopt(cfg,'maxqueryrange', 1);
 
 roi2mask   = 0;
 mask2label = 0;
-if isfield(cfg, 'roi');
+roi2label = 0;
+if isfield(cfg, 'roi') && isfield(cfg, 'output')
+  if strcmp(cfg.output, 'label') % in future, cfg.output should be extended to support both 'label' and 'mask'
+    roi2label = 1;   
+  end
+elseif isfield(cfg, 'roi');
   roi2mask = 1;
 elseif isfield(cfg, 'maskparameter')
   mask2label = 1;
@@ -115,18 +130,18 @@ end
 if roi2mask
   % only for volume data
   volume = ft_checkdata(volume, 'datatype', 'volume');
-
+  
   cfg.round2nearestvoxel = ft_getopt(cfg, 'round2nearestvoxel', 'no');
-
+  
   isatlas = iscell(cfg.roi) || ischar(cfg.roi);
   ispoi   = isnumeric(cfg.roi);
   if isatlas+ispoi ~= 1
     error('do not understand cfg.roi')
   end
-
+  
   if isatlas
     ft_checkconfig(cfg, 'forbidden', {'sphere' 'box'}, ...
-                        'required',  {'atlas' 'inputcoord'});
+      'required',  {'atlas' 'inputcoord'});
   elseif ispoi
     ft_checkconfig(cfg, 'forbidden', {'atlas' 'inputcoord'});
     if isempty(ft_getopt(cfg, 'sphere')) && isempty(ft_getopt(cfg, 'box'))
@@ -134,14 +149,18 @@ if roi2mask
       error('either specify cfg.sphere or cfg.box')
     end
   end
-
-elseif mask2label
+  
+elseif mask2label || roi2label
   % convert to source representation (easier to work with)
   volume = ft_checkdata(volume, 'datatype', 'source');
   ft_checkconfig(cfg, 'required', {'atlas' 'inputcoord'});
-
+  
   if isempty(intersect(cfg.maxqueryrange, [1 3 5]))
     error('incorrect query range, should be one of [1 3 5]');
+  end
+  
+  if roi2label
+    cfg.round2nearestvoxel = ft_getopt(cfg, 'round2nearestvoxel', 'yes');
   end
 end
 
@@ -156,7 +175,7 @@ if roi2mask
   ijk = [I(:) J(:) K(:) ones(prod(dim),1)]';
   % determine location of each anatomical voxel in head coordinates
   xyz = volume.transform * ijk; % note that this is 4xN
-
+  
   if isatlas
     if ischar(cfg.atlas),
       % assume it to represent a filename
@@ -166,7 +185,7 @@ if roi2mask
       % into a config object
       atlas = struct(cfg.atlas);
     end
-
+    
     % determine which field(s) to use to look up the labels,
     % and whether these are boolean or indexed
     fn = fieldnames(atlas);
@@ -188,11 +207,11 @@ if roi2mask
       fn = fn(isboolean);
       isindexed = 0;
     end
-
+    
     if ischar(cfg.roi)
       cfg.roi = {cfg.roi};
     end
-
+    
     if isindexed,
       sel = zeros(0,2);
       for m = 1:length(fn)
@@ -202,13 +221,13 @@ if roi2mask
         end
       end
       fprintf('found %d matching anatomical labels\n', size(sel,1));
-
+      
       % this is to accommodate for multiple parcellations:
       % the brick refers to the parcellationname
       % the value refers to the value within the given parcellation
       brick = sel(:,2);
       value = sel(:,1);
-
+      
       % convert between MNI head coordinates and TAL head coordinates
       % coordinates should be expressed compatible with the atlas
       if     strcmp(cfg.inputcoord, 'mni') && strcmp(atlas.coordsys, 'tal')
@@ -222,26 +241,26 @@ if roi2mask
       elseif ~strcmp(cfg.inputcoord, atlas.coordsys)
         error('there is a mismatch between the coordinate system in the atlas and the coordinate system in the data, which cannot be resolved');
       end
-
+      
       % determine location of each anatomical voxel in atlas voxel coordinates
       ijk = atlas.transform \ xyz;
       ijk = round(ijk(1:3,:))';
-
+      
       inside_vol = ijk(:,1)>=1 & ijk(:,1)<=atlas.dim(1) & ...
         ijk(:,2)>=1 & ijk(:,2)<=atlas.dim(2) & ...
         ijk(:,3)>=1 & ijk(:,3)<=atlas.dim(3);
       inside_vol = find(inside_vol);
-
+      
       % convert the selection inside the atlas volume into linear indices
       ind = sub2ind(atlas.dim, ijk(inside_vol,1), ijk(inside_vol,2), ijk(inside_vol,3));
-
+      
       brick_val = cell(1,numel(brick));
       % search the bricks for the value of each voxel
       for i=1:numel(brick_val)
         brick_val{i} = zeros(prod(dim),1);
         brick_val{i}(inside_vol) = atlas.(fn{brick(i)})(ind);
       end
-
+      
       mask = zeros(prod(dim),1);
       for i=1:numel(brick_val)
         %fprintf('constructing mask for %s\n', atlas.descr.name{sel(i)});
@@ -252,15 +271,15 @@ if roi2mask
       % NOTE: this may be very straightforward indeed: the mask is just the
       % logical or of the specified rois.
     end
-
+    
   elseif ispoi
-
+    
     if istrue(cfg.round2nearestvoxel)
       for i=1:size(cfg.roi,1)
         cfg.roi(i,:) = poi2voi(cfg.roi(i,:), xyz);
       end
     end
-
+    
     % sphere(s)
     if isfield(cfg, 'sphere')
       mask = zeros(1,prod(dim));
@@ -279,12 +298,12 @@ if roi2mask
       end
     end
   end
-
+  
   mask = reshape(mask, dim);
   fprintf('%i voxels in mask, which is %.3f %% of total volume\n', sum(mask(:)), 100*mean(mask(:)));
   output = mask;
-
-elseif mask2label
+  
+elseif mask2label || roi2label
   if ischar(cfg.atlas),
     % assume it to represent a filename
     atlas = ft_read_atlas(cfg.atlas);
@@ -293,7 +312,7 @@ elseif mask2label
     % into a config object
     atlas = struct(cfg.atlas);
   end
-
+  
   % determine which field(s) to use to look up the labels,
   % and whether these are boolean or indexed
   fn = fieldnames(atlas);
@@ -315,7 +334,7 @@ elseif mask2label
     fn = fn(isboolean);
     isindexed = 0;
   end
-  sel = find(volume.(cfg.maskparameter)(:));
+  
   labels.name = cell(0,1);
   for k = 1:numel(fn)
     % ensure that they are concatenated as column
@@ -327,7 +346,19 @@ elseif mask2label
   for iLab = 1:length(labels.name)
     labels.usedqueryrange{iLab} = [];
   end
-
+  
+  if mask2label
+    sel = find(volume.(cfg.maskparameter)(:));
+  elseif roi2label
+    if istrue(cfg.round2nearestvoxel)
+      % determine location of each anatomical voxel in head coordinates
+      xyz = [volume.pos ones(size(volume.pos,1),1)]'; % note that this is 4xN    
+      for i=1:size(cfg.roi,1)
+        cfg.roi(i,:) = poi2voi(cfg.roi(i,:), xyz);
+      end
+    end % round2nearestvoxel
+    sel = find(ismember(volume.pos, cfg.roi, 'rows')==1);
+  end
   for iVox = 1:length(sel)
     usedQR = 1;
     label = atlas_lookup(atlas, [volume.pos(sel(iVox),1) volume.pos(sel(iVox),2) volume.pos(sel(iVox),3)], 'inputcoord', cfg.inputcoord, 'queryrange', 1);
@@ -344,12 +375,12 @@ elseif mask2label
     elseif length(label) == 1
       label = {label};
     end
-
+    
     ind_lab = [];
     for iLab = 1:length(label)
       ind_lab = [ind_lab find(strcmp(label{iLab}, labels.name))];
     end
-
+    
     labels.count(ind_lab) = labels.count(ind_lab) + (1/length(ind_lab));
     for iFoundLab = 1:length(ind_lab)
       if isempty(labels.usedqueryrange{ind_lab(iFoundLab)})
@@ -359,9 +390,9 @@ elseif mask2label
       end
     end
   end %iVox
-
+  
   output = labels;
-
+  
 end
 
 % do the general cleanup and bookkeeping at the end of the function

--- a/private/atlas_lookup.m
+++ b/private/atlas_lookup.m
@@ -82,7 +82,7 @@ elseif strcmp(inputcoord, 'tal') && strcmp(atlas.coordsys, 'tal')
   % nothing to do
 elseif strcmp(inputcoord, 'tal') && strcmp(atlas.coordsys, 'mni')
   pos = tal2mni(pos')'; % this function likes 3xN 
-elseif strcmp(inputcoord, 'spm') && strcmp(atlas.coordsys, 'mni')
+elseif (strcmp(inputcoord, 'spm') && strcmp(atlas.coordsys, 'mni')) || (strcmp(inputcoord, 'mni') && strcmp(atlas.coordsys, 'spm'))
   %fprintf('coordinate system of input data ''spm'' is assume to represent the same coordinate system as the atlas, which is ''mni''\n');
 elseif ~strcmp(inputcoord, atlas.coordsys)
   error('there is a mismatch between the coordinate system in the atlas and the coordinate system in the data, which cannot be resolved');


### PR DESCRIPTION
Note that an extra cfg option needed to be created (cfg.output = 'label') to discriminate between the existing mask2label and the new roi2label functionalities. In future, cfg.output could be extended to support both 'mask' and 'label', and the function re-organized accordingly. 