### PR TITLE
Bug1658

### DIFF
--- a/ft_sourcedescriptives.m
+++ b/ft_sourcedescriptives.m
@@ -82,7 +82,7 @@ end
 % check if the input data is valid for this function
 % source = ft_checkdata(source, 'datatype', 'source', 'feedback', 'yes');
 
-cfg = ft_checkconfig(cfg, 'forbidden',   {'trials'});    % trial selection is not implented here, you may want to consider ft_selectdata
+% cfg = ft_checkconfig(cfg, 'forbidden',   {'trials'});    % trial selection is not implented here, you may want to consider ft_selectdata
 
 % DEPRECATED by roboos on 13 June 2013
 % see http://bugzilla.fieldtriptoolbox.org/show_bug.cgi?id=2199 for more details
@@ -102,6 +102,7 @@ cfg.eta              = ft_getopt(cfg, 'eta',              'no');
 cfg.fa               = ft_getopt(cfg, 'fa',               'no');
 cfg.kurtosis         = ft_getopt(cfg, 'kurtosis',         'no');
 cfg.keeptrials       = ft_getopt(cfg, 'keeptrials',       'no');
+cfg.trials           = ft_getopt(cfg, 'trials',           'all');
 cfg.keepcsd          = ft_getopt(cfg, 'keepcsd',          'no');
 cfg.keepmom          = ft_getopt(cfg, 'keepmom',          'yes');
 cfg.keepnoisecsd     = ft_getopt(cfg, 'keepnoisecsd',     'no');
@@ -119,6 +120,22 @@ cfg.zscore         = ft_getopt(cfg, 'zscore',         'yes');
 
 zscore = strcmp(cfg.zscore, 'yes');
 demean = strcmp(cfg.demean, 'yes');
+
+if ischar(cfg.trials) && strcmp(cfg.trials,'all')
+  % do nothing
+elseif ischar(cfg.trials)
+  error('only ''all'' is allowed for string input for cfg.trials');
+else
+  % check whether there's a trial field in the source structure, and
+  % subselect, otherwise error
+  if isfield(source, 'trial')
+    source.trial = source.trial(cfg.trials);
+    if isfield(source, 'cumtapcnt'), source.cumtapcnt = source.cumtapcnt(cfg.trials,:); end
+  else
+    error('subselecting trials in ft_sourcedescriptives is currently only possible with a ''trial'' field');   
+  end
+end
+
 
 % get desired method from source structure
 source.method = ft_getopt(source,'method',[]);

--- a/test/test_bug1658.m
+++ b/test/test_bug1658.m
@@ -1,0 +1,52 @@
+function test_bug1658
+
+% WALLTIME 00:20:00
+% MEM 4gb
+
+% TEST test_bug1658
+% TEST ft_sourcedescriptives
+% TEST ft_selectdata
+
+% test whether ft_sourceescriptives supports trial selection
+
+% load some source data
+load(dccnpath(fullfile('/home/common/matlab/fieldtrip/data/test/latest/source/meg','source_grid_mtmfft_fourier_trl_DICS_keepall_rawtrial_ctf151.mat')));
+
+% for now, work around the inconsistent data representation in noisecsd
+% (number of entries is inconsistent with the number of positions in the
+% grid), explicitly remove it
+source.trial = rmfield(source.trial, 'noisecsd');
+
+% also remove the spatial filters
+source.trial = rmfield(source.trial, 'filter');
+
+cfg = [];
+cfg.trials = [1 2 3 4];
+source2 = ft_selectdata(cfg, source);
+
+sel = find(source.inside, 1, 'first');
+clear dat1 dat2;
+
+for k = 1:numel(cfg.trials)
+  dat1(k,:,:) = source.trial(cfg.trials(k)).csd{sel};
+end
+dat2 = source2.csd{sel};
+assert(isequal(dat1,dat2));
+clear dat1 dat2;
+
+for k = 1:numel(cfg.trials)
+  dat1(k) = source.trial(cfg.trials(k)).noise(sel);
+end
+dat2 = source2.noise(sel,:);
+assert(isequal(dat1,dat2));
+clear dat1 dat2
+
+for k = 1:numel(cfg.trials)
+  dat1(k) = source.trial(cfg.trials(k)).pow(sel);
+end
+dat2 = source2.pow(sel,:);
+assert(isequal(dat1,dat2));
+
+keyboard
+
+

--- a/test/test_bug1658.m
+++ b/test/test_bug1658.m
@@ -47,6 +47,30 @@ end
 dat2 = source2.pow(sel,:);
 assert(isequal(dat1,dat2));
 
-keyboard
+cfg = [];
+cfg.trials = [1 2 3 4];
+cfg.keeptrials = 'yes';
+source3 = ft_sourcedescriptives(cfg, source);
 
+sel = find(source.inside, 1, 'first');
+clear dat1 dat2;
 
+for k = 1:numel(cfg.trials)
+  dat1(k,:,:) = source.trial(cfg.trials(k)).csd{sel};
+  dat2(k,:,:) = source3.trial(cfg.trials(k)).csd{sel};
+end
+assert(isequal(dat1,dat2));
+clear dat1 dat2;
+
+for k = 1:numel(cfg.trials)
+  dat1(k) = source.trial(cfg.trials(k)).noise(sel);
+  dat2(k) = source3.trial(cfg.trials(k)).noise(sel);
+end
+assert(isequal(dat1,dat2));
+clear dat1 dat2
+
+for k = 1:numel(cfg.trials)
+  dat1(k) = source.trial(cfg.trials(k)).pow(sel);
+  dat2(k) = source3.trial(cfg.trials(k)).pow(sel);
+end
+assert(isequal(dat1,dat2));

--- a/utilities/private/getdimord.m
+++ b/utilities/private/getdimord.m
@@ -316,7 +316,7 @@ switch field
     if isequal(datsiz, [npos nfreq ntime])
       dimord = 'pos_freq_time';
     end
-  case {'pow'}
+  case {'pow' 'noise'}
     if isequal(datsiz, [npos ntime])
       dimord = 'pos_time';
     elseif isequal(datsiz, [npos nfreq])


### PR DESCRIPTION
This fix now ensures that trials can be selected in ft_sourcedescriptives, using old-style data representations. Also, ft_selectdata now works on new-style data representations. (note, it specifically concerns source level data).