### PR TITLE
FIX - fixed issue with GUI as per bug 3230

### DIFF
--- a/ft_anonimizedata.m
+++ b/ft_anonimizedata.m
@@ -277,13 +277,22 @@ set(info.table, 'data', data);
 end % function
 
 function keyboard_cb(h, eventdata)
-if isempty(eventdata)
+
+% if isempty(eventdata)
+%   % determine the key that corresponds to the uicontrol element that was activated
+%   key = get(h, 'userdata');
+% else
+%   % determine the key that was pressed on the keyboard
+%   key = parseKeyboardEvent(eventdata);
+% end
+if (isempty(eventdata) && ft_platform_supports('matlabversion',-Inf, '2014a')) || isa(eventdata, 'matlab.ui.eventdata.ActionData')
   % determine the key that corresponds to the uicontrol element that was activated
   key = get(h, 'userdata');
 else
   % determine the key that was pressed on the keyboard
   key = parseKeyboardEvent(eventdata);
 end
+
 h = getparent(h);
 info = getappdata(h, 'info');
 
@@ -319,6 +328,33 @@ end
 setappdata(h, 'info', info);
 redraw_cb(h)
 end % function
+
+function key = parseKeyboardEvent(eventdata)
+
+key = eventdata.Key;
+
+% handle possible numpad events (different for Windows and UNIX systems)
+% NOTE: shift+numpad number does not work on UNIX, since the shift
+% modifier is always sent for numpad events
+if isunix()
+  shiftInd = match_str(eventdata.Modifier, 'shift');
+  if ~isnan(str2double(eventdata.Character)) && ~isempty(shiftInd)
+    % now we now it was a numpad keystroke (numeric character sent AND
+    % shift modifier present)
+    key = eventdata.Character;
+    eventdata.Modifier(shiftInd) = []; % strip the shift modifier
+  end
+elseif ispc()
+  if strfind(eventdata.Key, 'numpad')
+    key = eventdata.Character;
+  end
+end
+
+if ~isempty(eventdata.Modifier)
+  key = [eventdata.Modifier{1} '+' key];
+end
+
+end % function parseKeyboardEvent
 
 function sort_cb(h, eventdata)
 h = getparent(h);


### PR DESCRIPTION
It seems that some subfunction was missing, and that some matlab version specific behavior needed to be accounted for. I copied some relevant code over from ft_databrowser, under the assumption that this code's GUI is best-supported across platforms/matlab versions