### PR TITLE
TST: minor fixes in tests

### DIFF
--- a/test/test_bug1811.m
+++ b/test/test_bug1811.m
@@ -19,7 +19,7 @@ end
 clear script;
 
 %check ctf275 meg preoprocessed data
-load(dccnpath('/home/common/matlab/fieldtrip/data/test/latest/raw/meg/preproc_ctf275.mat))'
+load(dccnpath('/home/common/matlab/fieldtrip/data/test/latest/raw/meg/preproc_ctf275.mat'));
 script = ft_analysispipeline(cfg,data);
 
 if isempty(script)

--- a/test/test_bug2463.m
+++ b/test/test_bug2463.m
@@ -1,4 +1,4 @@
-function test_bug24673
+function test_bug2463
 
 % MEM 1gb
 % WALLTIME 00:10:00

--- a/test/test_bug2909.m
+++ b/test/test_bug2909.m
@@ -1,4 +1,4 @@
-function test_bug2865
+function test_bug2909
 
 % WALLTIME 0:10:00
 % MEM 3gb

--- a/test/test_bug840.m
+++ b/test/test_bug840.m
@@ -1,4 +1,4 @@
-function test_bug800
+function test_bug840
 
 % MEM 1500mb
 % WALLTIME 00:10:00

--- a/test/test_ft_prepare_sourcemodel.m
+++ b/test/test_ft_prepare_sourcemodel.m
@@ -18,7 +18,7 @@ success = true;
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % load single sphere volume conduction model
-vol = ft_read_vol(dccnpath('/home/common/matlab/fieldtrip/data/test/latest/vol/Subject01vol_singlesphere.mat')), 'vol');;
+vol = ft_read_vol(dccnpath('/home/common/matlab/fieldtrip/data/test/latest/vol/Subject01vol_singlesphere.mat'), 'vol');
 
 % load gradiometer information of an exemplary subject
 grad_standard = ft_read_sens(dccnpath('/home/common/matlab/fieldtrip/data/test/latest/sens/ctf275.mat'));


### PR DESCRIPTION
For the tests in the 'test' directory:
- renamed some functions so that the filename matches the function name
- fixed some syntax errors when using dccnpath