### PR TITLE
ft_volumenormalizes now properly restores warning settings

### DIFF
--- a/ft_volumenormalise.m
+++ b/ft_volumenormalise.m
@@ -311,6 +311,9 @@ ft_postamble trackconfig
 cfg.spmparams = params;
 cfg.final     = final;
 
+% restore the previous warning state
+warning(ws);
+
 ft_postamble previous   mri
 ft_postamble provenance normalised
 ft_postamble history    normalised


### PR DESCRIPTION
hi,
ft_volumenormalize sets warnings to off but never restores it.