### PR TITLE
OCTAVE: in "core" functions, do not include matrix.h if mex.h is included

### DIFF
--- a/@config/private/deepcopy.c
+++ b/@config/private/deepcopy.c
@@ -11,7 +11,6 @@
 
 #include <math.h>
 #include "mex.h"
-#include "matrix.h"
 
 void
 mexFunction (int nlhs, mxArray * plhs[], int nrhs, const mxArray * prhs[])

--- a/@config/private/increment.c
+++ b/@config/private/increment.c
@@ -8,7 +8,6 @@
 
 #include <math.h>
 #include "mex.h"
-#include "matrix.h"
 
 void
 mexFunction (int nlhs, mxArray * plhs[], int nrhs, const mxArray * prhs[])

--- a/@config/private/setzero.c
+++ b/@config/private/setzero.c
@@ -8,7 +8,6 @@
 
 #include <math.h>
 #include "mex.h"
-#include "matrix.h"
 
 void
 mexFunction (int nlhs, mxArray * plhs[], int nrhs, const mxArray * prhs[])

--- a/compat/matlablt2010b/@uint64/abs.c
+++ b/compat/matlablt2010b/@uint64/abs.c
@@ -10,7 +10,6 @@
 
 #include <math.h>
 #include "mex.h"
-#include "matrix.h"
 
 void
 mexFunction (int nlhs, mxArray * plhs[], int nrhs, const mxArray * prhs[])

--- a/compat/matlablt2010b/@uint64/max.c
+++ b/compat/matlablt2010b/@uint64/max.c
@@ -10,7 +10,6 @@
 
 #include <math.h>
 #include "mex.h"
-#include "matrix.h"
 
 void
 mexFunction (int nlhs, mxArray * plhs[], int nrhs, const mxArray * prhs[])

--- a/compat/matlablt2010b/@uint64/min.c
+++ b/compat/matlablt2010b/@uint64/min.c
@@ -10,7 +10,6 @@
 
 #include <math.h>
 #include "mex.h"
-#include "matrix.h"
 
 void
 mexFunction (int nlhs, mxArray * plhs[], int nrhs, const mxArray * prhs[])

--- a/compat/matlablt2010b/@uint64/minus.c
+++ b/compat/matlablt2010b/@uint64/minus.c
@@ -21,7 +21,6 @@
 
 #include <math.h>
 #include "mex.h"
-#include "matrix.h"
 
 void
 mexFunction (int nlhs, mxArray * plhs[], int nrhs, const mxArray * prhs[])

--- a/compat/matlablt2010b/@uint64/plus.c
+++ b/compat/matlablt2010b/@uint64/plus.c
@@ -21,7 +21,6 @@
 
 #include <math.h>
 #include "mex.h"
-#include "matrix.h"
 
 void
 mexFunction (int nlhs, mxArray * plhs[], int nrhs, const mxArray * prhs[])

--- a/compat/matlablt2010b/@uint64/rdivide.c
+++ b/compat/matlablt2010b/@uint64/rdivide.c
@@ -10,7 +10,6 @@
  */
 
 #include "mex.h"
-#include "matrix.h"
 #include <math.h>
 
 #if defined(_WIN32) || defined(_WIN64)

--- a/compat/matlablt2010b/@uint64/times.c
+++ b/compat/matlablt2010b/@uint64/times.c
@@ -11,7 +11,6 @@
 
 #include <math.h>
 #include "mex.h"
-#include "matrix.h"
 
 void
 mexFunction (int nlhs, mxArray * plhs[], int nrhs, const mxArray * prhs[])

--- a/private/plgndr.c
+++ b/private/plgndr.c
@@ -25,7 +25,6 @@
 
 #include <math.h>
 #include "mex.h"
-#include "matrix.h"
 
 double legendre_Pmm(double m, double x)
 {

--- a/src/det2x2.c
+++ b/src/det2x2.c
@@ -1,5 +1,4 @@
 #include <math.h>
-#include <matrix.h>
 #include <mex.h>
 
 void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])

--- a/src/ft_spike_sub_crossx.c
+++ b/src/ft_spike_sub_crossx.c
@@ -15,7 +15,6 @@
 
 #include "mex.h"
 #include <math.h>
-#include <matrix.h>
 
 void mexFunction(
   int nOutputs, mxArray *pointerOutputs[],

--- a/src/inv2x2.c
+++ b/src/inv2x2.c
@@ -1,5 +1,4 @@
 #include <math.h>
-#include <matrix.h>
 #include <mex.h>
 
 void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])

--- a/src/lmoutr.c
+++ b/src/lmoutr.c
@@ -1,6 +1,5 @@
 #include <math.h>
 #include "mex.h"
-#include "matrix.h"
 #include "geometry.h"
 
 void

--- a/src/ltrisect.c
+++ b/src/ltrisect.c
@@ -1,6 +1,5 @@
 #include <math.h>
 #include "mex.h"
-#include "matrix.h"
 #include "geometry.h"
 
 void

--- a/src/meg_leadfield1.c
+++ b/src/meg_leadfield1.c
@@ -1,7 +1,6 @@
 #include <string.h>
 #include <math.h>
 #include "mex.h"
-#include "matrix.h"
 
 void
 mexFunction (int nlhs, mxArray * plhs[], int nrhs, const mxArray * prhs[])

--- a/src/mtimes2x2.c
+++ b/src/mtimes2x2.c
@@ -1,5 +1,4 @@
 #include <math.h>
-#include <matrix.h>
 #include <mex.h>
 
 void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])

--- a/src/nanmean.c
+++ b/src/nanmean.c
@@ -1,4 +1,3 @@
-#include <matrix.h>
 #include <mex.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/nanstd.c
+++ b/src/nanstd.c
@@ -1,4 +1,3 @@
-#include <matrix.h>
 #include <mex.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/nansum.c
+++ b/src/nansum.c
@@ -1,4 +1,3 @@
-#include <matrix.h>
 #include <mex.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/nanvar.c
+++ b/src/nanvar.c
@@ -1,4 +1,3 @@
-#include <matrix.h>
 #include <mex.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/plgndr.c
+++ b/src/plgndr.c
@@ -25,7 +25,6 @@
 
 #include <math.h>
 #include "mex.h"
-#include "matrix.h"
 
 double legendre_Pmm(double m, double x)
 {

--- a/src/plinproj.c
+++ b/src/plinproj.c
@@ -1,6 +1,5 @@
 #include <math.h>
 #include "mex.h"
-#include "matrix.h"
 #include "geometry.h"
 
 void

--- a/src/ptriproj.c
+++ b/src/ptriproj.c
@@ -1,6 +1,5 @@
 #include <math.h>
 #include "mex.h"
-#include "matrix.h"
 #include "geometry.h"
 
 void

--- a/src/read_16bit.c
+++ b/src/read_16bit.c
@@ -1,7 +1,6 @@
 #include <math.h>
 #include <string.h>
 #include "mex.h"
-#include "matrix.h"
 
 /*
  * Copyright (C) 2008, Robert Oostenveld, F.C. Donders Ccentre for Cognitive Neuroimaging

--- a/src/read_24bit.c
+++ b/src/read_24bit.c
@@ -31,7 +31,6 @@
 #include <math.h>
 #include <sys/types.h>
 #include "mex.h"
-#include "matrix.h"
 
 #if defined(_WIN32) || defined(_WIN64)
 #define int32_t INT32_T

--- a/src/read_ctf_shm.c
+++ b/src/read_ctf_shm.c
@@ -18,7 +18,6 @@
 #include <sys/ipc.h>
 #include <sys/shm.h>
 #include "mex.h"
-#include "matrix.h"
 
 #define ACQ_MSGQ_SIZE      600
 #define ACQ_MSGQ_SHMKEY    0x39457f73

--- a/src/rename.c
+++ b/src/rename.c
@@ -8,7 +8,6 @@
 #include <stdio.h>
 
 #include "mex.h"
-#include "matrix.h"
 
 void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
 		char *old, *new;

--- a/src/rfbevent.c
+++ b/src/rfbevent.c
@@ -69,7 +69,6 @@
 
 #include "d3des.h"
 #include "mex.h"
-#include "matrix.h"
 
 #define VNC_BASE 5900
 #define CHALLENGESIZE 16

--- a/src/routlm.c
+++ b/src/routlm.c
@@ -1,6 +1,5 @@
 #include <math.h>
 #include "mex.h"
-#include "matrix.h"
 #include "geometry.h"
 
 void

--- a/src/sandwich2x2.c
+++ b/src/sandwich2x2.c
@@ -1,5 +1,4 @@
 #include <math.h>
-#include <matrix.h>
 #include <mex.h>
 
 void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])

--- a/src/solid_angle.c
+++ b/src/solid_angle.c
@@ -1,6 +1,5 @@
 #include <math.h>
 #include "mex.h"
-#include "matrix.h"
 #include "geometry.h"
 
 void

--- a/src/splint_gh.c
+++ b/src/splint_gh.c
@@ -25,7 +25,6 @@
 
 #include <math.h>
 #include "mex.h"
-#include "matrix.h"
 
 double legendre_Pmm(double m, double x)
 {

--- a/src/write_ctf_shm.c
+++ b/src/write_ctf_shm.c
@@ -14,7 +14,6 @@
 #include <sys/ipc.h>
 #include <sys/shm.h>
 #include "mex.h"
-#include "matrix.h"
 
 #define ACQ_MSGQ_SIZE      600
 #define ACQ_MSGQ_SHMKEY    0x39457f73


### PR DESCRIPTION
mex.h includes matrix.h, at least on Octave and recent versions of Matlab. Octave complains if matrix.h is included due to a naming conflict.

Adapted from #318, but this PR does not touch non-core files. I will close #318 shortly.

For reference, the following bash script was used to make the changes:
```
TMP=/tmp/foo

CORE="./@config
./private
./statfun
./template
./trialfun
./utilities
./compat
./bin
./src
./test"


for subdir in $CORE; do 
  for i in `find ${subdir} -name '*.c'`; do
    for matq in \" \<; do
      if [ $matq = "<" ]; then
        matc=">"
      else
        matc=$matq
      fi
      for mexq in  \" \<; do
        if [ $mexq = "<" ]; then
          mexc=">"
        else
          mexc=$mexq
        fi
        mat="#include ${matq}matrix.h${matc}"
        mex="#include ${mexq}mex.h${mexc}" 
        if [ `grep "$mat" $i | wc -l` -gt 0 ]; then 
          if [ `grep "$mex" $i | wc -l` -gt 0 ]; then
            grep --invert-match "${mat}" $i > $TMP
            cat $TMP > $i
            echo "Fixed: $i"
          else
            echo "Skip: $i"
          fi
        fi
      done
    done
  done
done
```