### PR TITLE
FIX - improved robustness of datatype detection source/mesh

### DIFF
--- a/ft_sourceinterpolate.m
+++ b/ft_sourceinterpolate.m
@@ -159,7 +159,7 @@ else
 end
 
 if isUnstructuredAna
-  anatomical = ft_checkdata(anatomical, 'datatype', {'source', 'source+label'}, 'inside', 'logical', 'feedback', 'yes', 'hasunit', 'yes');
+  anatomical = ft_checkdata(anatomical, 'datatype', {'source', 'source+label', 'mesh'}, 'inside', 'logical', 'feedback', 'yes', 'hasunit', 'yes');
 else
   anatomical = ft_checkdata(anatomical, 'datatype', {'volume', 'volume+label'}, 'inside', 'logical', 'feedback', 'yes', 'hasunit', 'yes');
 end

--- a/utilities/ft_datatype.m
+++ b/utilities/ft_datatype.m
@@ -142,10 +142,10 @@ if nargin>1
     case 'volume'
       type = any(strcmp(type, {'volume', 'volume+label'}));
     case 'source'
-      type = any(strcmp(type, {'source', 'source+label', 'mesh', 'mesh+label'})); % a single mesh does qualify as source structure
+      type = any(strcmp(type, {'source', 'source+label', 'mesh', 'mesh+label', 'source+mesh'})); % a single mesh does qualify as source structure
       type = type && isstruct(data) && numel(data)==1;                            % an array of meshes does not qualify
     case 'mesh'
-      type = any(strcmp(type, {'mesh', 'mesh+label'}));
+      type = any(strcmp(type, {'mesh', 'mesh+label', 'source+mesh'}));
     case 'segmentation'
       type = any(strcmp(type, {'segmentation', 'volume+label'}));
     case 'parcellation'


### PR DESCRIPTION
This fix ensures consistent behavior of ft_datatype when the input is source+mesh (analogous to raw+comp). It now returns true for:

ft_datatype(data, 'source')
ft_datatype(data, 'mesh')
ft_datatype(data, 'source+mesh')

I ran a batch of test scripts, and all functions that started failing yesterday run through again (without new failures :o))