### PR TITLE
Interactive subplots

### DIFF
--- a/ft_multiplotER.m
+++ b/ft_multiplotER.m
@@ -747,7 +747,7 @@ end
 % Make the figure interactive:
 if strcmp(cfg.interactive, 'yes')
   
-  % add the channel information to the figure
+  % add the cfg/data/channel information to the figure under identifier linked to this axis
   ident                 = ['axh' num2str(round(sum(clock.*1e6)))]; % unique identifier for this axis
   set(gca,'tag',ident);
   info                  = guidata(gcf);
@@ -857,6 +857,7 @@ end
 % SUBFUNCTION which is called after selecting channels in case of cfg.interactive='yes'
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 function select_singleplotER(label, varargin)
+% fetch cfg/data based on axis indentifier given as tag
 ident       = get(gca,'tag');
 info        = guidata(gcf);
 cfg         = info.(ident).cfg;

--- a/ft_multiplotER.m
+++ b/ft_multiplotER.m
@@ -181,11 +181,6 @@ cfg.tolerance      = ft_getopt(cfg, 'tolerance', 1e-5);
 cfg.frequency      = ft_getopt(cfg, 'frequency', 'all'); % needed for frequency selection with TFR data
 cfg.latency        = ft_getopt(cfg, 'latency', 'all'); % needed for latency selection with TFR data, FIXME, probably not used
 
-if numel(findobj(gcf, 'type', 'axes', '-not', 'tag', 'ft-colorbar')) > 1 && strcmp(cfg.interactive, 'yes')
-  warning('using cfg.interactive = ''yes'' in subplots is not supported, setting cfg.interactive = ''no''')
-  cfg.interactive = 'no';
-end
-
 Ndata = length(varargin);
 
 for i=1:Ndata
@@ -746,24 +741,27 @@ if isempty(get(gcf, 'Name'))
     set(gcf, 'NumberTitle', 'off');
   end
 else
-  dataname = {};
+  dataname = {''};
 end
 
 % Make the figure interactive:
 if strcmp(cfg.interactive, 'yes')
-
-  % add the dataname and channel information to the figure
-  % this is used in the callbacks
-  info          = guidata(gcf);
-  info.x        = lay.pos(:, 1);
-  info.y        = lay.pos(:, 2);
-  info.label    = lay.label;
-  info.dataname = dataname;
+  
+  % add the channel information to the figure
+  ident                 = ['axh' num2str(round(sum(clock.*1e6)))]; % unique identifier for this axis
+  set(gca,'tag',ident);
+  info                  = guidata(gcf);
+  info.(ident).x        = lay.pos(:, 1);
+  info.(ident).y        = lay.pos(:, 2);
+  info.(ident).label    = lay.label;
+  info.(ident).dataname = dataname;
+  info.(ident).cfg      = cfg;
+  info.(ident).varargin = varargin;
   guidata(gcf, info);
 
-  set(gcf, 'WindowButtonUpFcn',  {@ft_select_channel, 'multiple', true, 'callback', {@select_singleplotER, cfg, varargin{:}}, 'event', 'WindowButtonUpFcn'});
-  set(gcf, 'WindowButtonDownFcn', {@ft_select_channel, 'multiple', true, 'callback', {@select_singleplotER, cfg, varargin{:}}, 'event', 'WindowButtonDownFcn'});
-  set(gcf, 'WindowButtonMotionFcn', {@ft_select_channel, 'multiple', true, 'callback', {@select_singleplotER, cfg, varargin{:}}, 'event', 'WindowButtonMotionFcn'});
+  set(gcf, 'WindowButtonUpFcn',  {@ft_select_channel, 'multiple', true, 'callback', {@select_singleplotER}, 'event', 'WindowButtonUpFcn'});
+  set(gcf, 'WindowButtonDownFcn', {@ft_select_channel, 'multiple', true, 'callback', {@select_singleplotER}, 'event', 'WindowButtonDownFcn'});
+  set(gcf, 'WindowButtonMotionFcn', {@ft_select_channel, 'multiple', true, 'callback', {@select_singleplotER}, 'event', 'WindowButtonMotionFcn'});
 end
 
 axis tight
@@ -858,7 +856,11 @@ end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % SUBFUNCTION which is called after selecting channels in case of cfg.interactive='yes'
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-function select_singleplotER(label, cfg, varargin)
+function select_singleplotER(label, varargin)
+ident       = get(gca,'tag');
+info        = guidata(gcf);
+cfg         = info.(ident).cfg;
+datvarargin = info.(ident).varargin;
 if ~isempty(label)
   if isfield(cfg, 'inputfile')
     % the reading has already been done and varargin contains the data
@@ -866,8 +868,7 @@ if ~isempty(label)
   end
   cfg.channel = label;
   % put data name in here, this cannot be resolved by other means
-  info = guidata(gcf);
-  cfg.dataname = info.dataname;
+  cfg.dataname = info.(ident).dataname;
   fprintf('selected cfg.channel = {');
   for i=1:(length(cfg.channel)-1)
     fprintf('''%s'', ', cfg.channel{i});
@@ -875,5 +876,5 @@ if ~isempty(label)
   fprintf('''%s''}\n', cfg.channel{end});
   p = get(gcf, 'Position');
   f = figure('position', p);
-  ft_singleplotER(cfg, varargin{:});
+  ft_singleplotER(cfg, datvarargin{:});
 end

--- a/ft_multiplotTFR.m
+++ b/ft_multiplotTFR.m
@@ -650,7 +650,8 @@ end
 
 % Make the figure interactive:
 if strcmp(cfg.interactive, 'yes')
-    % add the channel information to the figure
+    
+    % add the cfg/data/channel information to the figure under identifier linked to this axis
     ident                 = ['axh' num2str(round(sum(clock.*1e6)))]; % unique identifier for this axis
     set(gca,'tag',ident);
     info                  = guidata(gcf);
@@ -728,6 +729,7 @@ ft_multiplotTFR(cfg, varargin{:});
 % SUBFUNCTION which is called after selecting channels in case of cfg.interactive='yes'
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 function select_singleplotTFR(label, varargin)
+% fetch cfg/data based on axis indentifier given as tag
 ident = get(gca,'tag');
 info  = guidata(gcf);
 cfg   = info.(ident).cfg;

--- a/ft_multiplotTFR.m
+++ b/ft_multiplotTFR.m
@@ -188,10 +188,6 @@ if ~isfield(cfg, 'box')
     cfg.box = 'no';
   end
 end
-if numel(findobj(gcf, 'type', 'axes', '-not', 'tag', 'ft-colorbar')) > 1 && strcmp(cfg.interactive, 'yes')
-  warning('using cfg.interactive = ''yes'' in subplots is not supported, setting cfg.interactive = ''no''')
-  cfg.interactive = 'no';
-end
 
 dimord = data.dimord;
 dimtok = tokenize(dimord, '_');
@@ -655,16 +651,20 @@ end
 % Make the figure interactive:
 if strcmp(cfg.interactive, 'yes')
     % add the channel information to the figure
-    info       = guidata(gcf);
-    info.x     = lay.pos(:, 1);
-    info.y     = lay.pos(:, 2);
-    info.label = lay.label;
-    info.dataname = dataname;
+    ident                 = ['axh' num2str(round(sum(clock.*1e6)))]; % unique identifier for this axis
+    set(gca,'tag',ident);
+    info                  = guidata(gcf);
+    info.(ident).x        = lay.pos(:, 1);
+    info.(ident).y        = lay.pos(:, 2);
+    info.(ident).label    = lay.label;
+    info.(ident).dataname = dataname;
+    info.(ident).cfg      = cfg;
+    info.(ident).data     = data;
     guidata(gcf, info);
 
-    set(gcf, 'WindowButtonUpFcn', {@ft_select_channel, 'multiple', true, 'callback', {@select_singleplotTFR, cfg, data}, 'event', 'WindowButtonUpFcn'});
-    set(gcf, 'WindowButtonDownFcn', {@ft_select_channel, 'multiple', true, 'callback', {@select_singleplotTFR, cfg, data}, 'event', 'WindowButtonDownFcn'});
-    set(gcf, 'WindowButtonMotionFcn', {@ft_select_channel, 'multiple', true, 'callback', {@select_singleplotTFR, cfg, data}, 'event', 'WindowButtonMotionFcn'});
+    set(gcf, 'WindowButtonUpFcn', {@ft_select_channel, 'multiple', true, 'callback', {@select_singleplotTFR}, 'event', 'WindowButtonUpFcn'});
+    set(gcf, 'WindowButtonDownFcn', {@ft_select_channel, 'multiple', true, 'callback', {@select_singleplotTFR}, 'event', 'WindowButtonDownFcn'});
+    set(gcf, 'WindowButtonMotionFcn', {@ft_select_channel, 'multiple', true, 'callback', {@select_singleplotTFR}, 'event', 'WindowButtonMotionFcn'});
 end
 
 axis tight
@@ -727,7 +727,11 @@ ft_multiplotTFR(cfg, varargin{:});
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % SUBFUNCTION which is called after selecting channels in case of cfg.interactive='yes'
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-function select_singleplotTFR(label, cfg, varargin)
+function select_singleplotTFR(label, varargin)
+ident = get(gca,'tag');
+info  = guidata(gcf);
+cfg   = info.(ident).cfg;
+data  = info.(ident).data;
 if ~isempty(label)
   if isfield(cfg, 'inputfile')
     % the reading has already been done and varargin contains the data
@@ -739,8 +743,7 @@ if ~isempty(label)
   cfg.baseline = 'no';
 
   % put data name in here, this cannot be resolved by other means
-  info = guidata(gcf);
-  cfg.dataname = info.dataname;
+  cfg.dataname = info.(ident).dataname;
 
   fprintf('selected cfg.channel = {');
   for i=1:(length(cfg.channel)-1)
@@ -749,7 +752,7 @@ if ~isempty(label)
   fprintf('''%s''}\n', cfg.channel{end});
   p = get(gcf, 'Position');
   f = figure('position', p);
-  ft_singleplotTFR(cfg, varargin{:});
+  ft_singleplotTFR(cfg, data);
 end
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/ft_singleplotER.m
+++ b/ft_singleplotER.m
@@ -635,17 +635,17 @@ end
 
 % make the figure interactive
 if strcmp(cfg.interactive, 'yes')
-  % add the dataname to the figure
-  % this is used in the callbacks
-  info          = guidata(gcf);
-  info.dataname = dataname;
+  % add the channel information to the figure
+  ident                  = ['axh' num2str(round(sum(clock.*1e6)))]; % unique identifier for this axis
+  set(gca,'tag',ident);
+  info                   = guidata(gcf);
+  info.(ident).cfg       = cfg;
+  info.(ident).varargin  = varargin;
+  info.(ident).dataname  = dataname;
   guidata(gcf, info);
-  % attach data to the figure with the current axis handle as a name
-  dataname = fixname(num2str(double(gca)));
-  setappdata(gcf,dataname,varargin);
-  set(gcf, 'windowbuttonupfcn',     {@ft_select_range, 'multiple', false, 'yrange', false, 'callback', {@select_topoplotER, cfg}, 'event', 'windowbuttonupfcn'});
-  set(gcf, 'windowbuttondownfcn',   {@ft_select_range, 'multiple', false, 'yrange', false, 'callback', {@select_topoplotER, cfg}, 'event', 'windowbuttondownfcn'});
-  set(gcf, 'windowbuttonmotionfcn', {@ft_select_range, 'multiple', false, 'yrange', false, 'callback', {@select_topoplotER, cfg}, 'event', 'windowbuttonmotionfcn'});
+  set(gcf, 'windowbuttonupfcn',     {@ft_select_range, 'multiple', false, 'yrange', false, 'callback', {@select_topoplotER}, 'event', 'windowbuttonupfcn'});
+  set(gcf, 'windowbuttondownfcn',   {@ft_select_range, 'multiple', false, 'yrange', false, 'callback', {@select_topoplotER}, 'event', 'windowbuttondownfcn'});
+  set(gcf, 'windowbuttonmotionfcn', {@ft_select_range, 'multiple', false, 'yrange', false, 'callback', {@select_topoplotER}, 'event', 'windowbuttonmotionfcn'});
 end
 
 % create title text containing channel name(s) and channel number(s):
@@ -699,15 +699,17 @@ end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % SUBFUNCTION which is called after selecting a time range
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-function select_topoplotER(cfg, varargin)
+function select_topoplotER(varargin)
 % first to last callback-input of ft_select_range is range
 % last callback-input of ft_select_range is contextmenu label, if used
 range = varargin{end-1};
 varargin = varargin(1:end-2); % remove range and last
 
-% get appdata belonging to current axis
-dataname = fixname(num2str(double(gca)));
-data = getappdata(gcf, dataname);
+% get cfg/data based on tag
+ident    = get(gca,'tag');
+info     = guidata(gcf);
+cfg      = info.(ident).cfg;
+varargin = info.(ident).varargin;
 
 if isfield(cfg, 'inputfile')
   % the reading has already been done and varargin contains the data
@@ -721,9 +723,8 @@ end
 cfg.channel = 'all';
 cfg.comment = 'auto';
 cfg.xlim = range(1:2);
-% put data name in here, this cannot be resolved by other means
-info = guidata(gcf);
-cfg.dataname = info.dataname;
+%
+cfg.dataname = info.(ident).dataname;
 % if user specified a ylim, copy it over to the zlim of topoplot
 if isfield(cfg, 'ylim')
   cfg.zlim = cfg.ylim;
@@ -732,7 +733,7 @@ end
 fprintf('selected cfg.xlim = [%f %f]\n', cfg.xlim(1), cfg.xlim(2));
 p = get(gcf, 'position');
 f = figure('position', p);
-ft_topoplotER(cfg, data{:});
+ft_topoplotER(cfg, varargin{:});
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % SUBFUNCTION which handles hot keys in the current plot

--- a/ft_singleplotER.m
+++ b/ft_singleplotER.m
@@ -635,7 +635,7 @@ end
 
 % make the figure interactive
 if strcmp(cfg.interactive, 'yes')
-  % add the channel information to the figure
+  % add the cfg/data information to the figure under identifier linked to this axis
   ident                  = ['axh' num2str(round(sum(clock.*1e6)))]; % unique identifier for this axis
   set(gca,'tag',ident);
   info                   = guidata(gcf);
@@ -705,7 +705,7 @@ function select_topoplotER(varargin)
 range = varargin{end-1};
 varargin = varargin(1:end-2); % remove range and last
 
-% get cfg/data based on tag
+% fetch cfg/data based on axis indentifier given as tag
 ident    = get(gca,'tag');
 info     = guidata(gcf);
 cfg      = info.(ident).cfg;

--- a/ft_singleplotTFR.m
+++ b/ft_singleplotTFR.m
@@ -494,7 +494,7 @@ end
 
 % Make the figure interactive:
 if strcmp(cfg.interactive, 'yes')
-  % add the channel information to the figure
+  % add the cfg/data information to the figure under identifier linked to this axis
   ident             = ['axh' num2str(round(sum(clock.*1e6)))]; % unique identifier for this axis
   set(gca,'tag',ident);
   info              = guidata(gcf);
@@ -579,7 +579,7 @@ function select_topoplotTFR(varargin)
 range = varargin{end-1};
 varargin = varargin(1:end-2); % remove range and last
 
-% get cfg/data based on tag
+% fetch cfg/data based on axis indentifier given as tag
 ident  = get(gca,'tag');
 info   = guidata(gcf);
 cfg    = info.(ident).cfg;

--- a/ft_singleplotTFR.m
+++ b/ft_singleplotTFR.m
@@ -494,12 +494,16 @@ end
 
 % Make the figure interactive:
 if strcmp(cfg.interactive, 'yes')
-  % first, attach data to the figure with the current axis handle as a name
-  dataname = fixname(num2str(double(gca)));
-  setappdata(gcf,dataname,data);
-  set(gcf, 'WindowButtonUpFcn',     {@ft_select_range, 'multiple', false, 'callback', {@select_topoplotTFR, cfg}, 'event', 'WindowButtonUpFcn'});
-  set(gcf, 'WindowButtonDownFcn',   {@ft_select_range, 'multiple', false, 'callback', {@select_topoplotTFR, cfg}, 'event', 'WindowButtonDownFcn'});
-  set(gcf, 'WindowButtonMotionFcn', {@ft_select_range, 'multiple', false, 'callback', {@select_topoplotTFR, cfg}, 'event', 'WindowButtonMotionFcn'});
+  % add the channel information to the figure
+  ident             = ['axh' num2str(round(sum(clock.*1e6)))]; % unique identifier for this axis
+  set(gca,'tag',ident);
+  info              = guidata(gcf);
+  info.(ident).cfg  = cfg;
+  info.(ident).data = data;
+  guidata(gcf, info);
+  set(gcf, 'WindowButtonUpFcn',     {@ft_select_range, 'multiple', false, 'callback', {@select_topoplotTFR}, 'event', 'WindowButtonUpFcn'});
+  set(gcf, 'WindowButtonDownFcn',   {@ft_select_range, 'multiple', false, 'callback', {@select_topoplotTFR}, 'event', 'WindowButtonDownFcn'});
+  set(gcf, 'WindowButtonMotionFcn', {@ft_select_range, 'multiple', false, 'callback', {@select_topoplotTFR}, 'event', 'WindowButtonMotionFcn'});
   %   set(gcf, 'WindowButtonUpFcn',     {@ft_select_range, 'multiple', false, 'callback', {@select_topoplotTFR, cfg, data}, 'event', 'WindowButtonUpFcn'});
   %   set(gcf, 'WindowButtonDownFcn',   {@ft_select_range, 'multiple', false, 'callback', {@select_topoplotTFR, cfg, data}, 'event', 'WindowButtonDownFcn'});
   %   set(gcf, 'WindowButtonMotionFcn', {@ft_select_range, 'multiple', false, 'callback', {@select_topoplotTFR, cfg, data}, 'event', 'WindowButtonMotionFcn'});
@@ -569,15 +573,17 @@ end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % SUBFUNCTION which is called after selecting a time range
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-function select_topoplotTFR(cfg, varargin)
+function select_topoplotTFR(varargin)
 % first to last callback-input of ft_select_range is range
 % last callback-input of ft_select_range is contextmenu label, if used
 range = varargin{end-1};
 varargin = varargin(1:end-2); % remove range and last
 
-% get appdata belonging to current axis
-dataname = fixname(num2str(double(gca)));
-data = getappdata(gcf, dataname);
+% get cfg/data based on tag
+ident  = get(gca,'tag');
+info   = guidata(gcf);
+cfg    = info.(ident).cfg;
+data   = info.(ident).data;
 
 if isfield(cfg, 'inputfile')
   % the reading has already been done and varargin contains the data

--- a/plotting/ft_select_channel.m
+++ b/plotting/ft_select_channel.m
@@ -80,6 +80,11 @@ end % if multiple
 % SUBFUNCTION to assist in the selection of a single channel
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 function select_channel_single(pos, callback)
+% If this function is called from a plotting function that supports interactive subplots,
+% then the current axis, which was used for selection, was given a tag that starts with 'axh' followed by a unique ID.
+% If so, then the data (e.g. channel info) that should be used is contained in a subfield of the info (guidata)
+% structure, with field name being the 'tag' in question. 
+% If no such tag is found, then the simple situation is assumed, where the data is contained in the 'root' field
 tag = get(gca,'tag');
 % in case subplots were used
 if strncmp(tag,'axh',3)
@@ -133,6 +138,11 @@ end
 % SUBFUNCTION to assist in the selection of multiple channels
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 function select_channel_multiple(callback,range,cmenulab) % last input is context menu label, see ft_select_range
+% If this function is called from a plotting function that supports interactive subplots,
+% then the current axis, which was used for selection, was given a tag that starts with 'axh' followed by a unique ID.
+% If so, then the data (e.g. channel info) that should be used is contained in a subfield of the info (guidata)
+% structure, with field name being the 'tag' in question. 
+% If no such tag is found, then the simple situation is assumed, where the data is contained in the 'root' field
 tag = get(gca,'tag');
 % in case subplots were used
 if strncmp(tag,'axh',3)

--- a/plotting/ft_select_channel.m
+++ b/plotting/ft_select_channel.m
@@ -80,11 +80,19 @@ end % if multiple
 % SUBFUNCTION to assist in the selection of a single channel
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 function select_channel_single(pos, callback)
-
-info  = guidata(gcf);
-x     = info.x;
-y     = info.y;
-label = info.label;
+tag = get(gca,'tag');
+% in case subplots were used
+if strncmp(tag,'axh',3)
+  info   = guidata(gcf);
+  x      = info.(tag).x(:);
+  y      = info.(tag).y(:);
+  label  = info.(tag).label(:);  
+else % no subplots were used
+  info   = guidata(gcf);
+  x      = info.x(:);
+  y      = info.y(:);
+  label  = info.label(:);
+end
 
 % compute a tolerance measure
 distance = sqrt(abs(sum([x y]'.*[x y]',1)));
@@ -125,11 +133,19 @@ end
 % SUBFUNCTION to assist in the selection of multiple channels
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 function select_channel_multiple(callback,range,cmenulab) % last input is context menu label, see ft_select_range
-
-info   = guidata(gcf);
-x      = info.x(:);
-y      = info.y(:);
-label  = info.label(:);
+tag = get(gca,'tag');
+% in case subplots were used
+if strncmp(tag,'axh',3)
+  info   = guidata(gcf);
+  x      = info.(tag).x(:);
+  y      = info.(tag).y(:);
+  label  = info.(tag).label(:);  
+else % no subplots were used
+  info   = guidata(gcf);
+  x      = info.x(:);
+  y      = info.y(:);
+  label  = info.label(:);
+end
 
 % determine which channels ly in the selected range
 select = false(size(label));

--- a/plotting/ft_select_channel.m
+++ b/plotting/ft_select_channel.m
@@ -15,9 +15,13 @@ function ft_select_channel(handle, eventdata, varargin)
 % You can pass additional arguments to the callback function in a cell-array
 % like {@function_handle,arg1,arg2}
 %
-% Example
+% Example 1
 %   % create a figure
-%   lay = ft_prepare_layout([])
+%   figure
+%   cfg = [];
+%   cfg.channel = {'chan1', 'chan2', 'chan3', 'chan4'};
+%   cfg.layout  = 'ordered';
+%   lay = ft_prepare_layout(cfg);
 %   ft_plot_lay(lay)
 %
 %   % add the required guidata
@@ -34,6 +38,34 @@ function ft_select_channel(handle, eventdata, varargin)
 %   set(gcf, 'WindowButtonDownFcn',   {@ft_select_channel, 'multiple', true, 'callback', @disp, 'event', 'WindowButtonDownFcn'})
 %   set(gcf, 'WindowButtonUpFcn',     {@ft_select_channel, 'multiple', true, 'callback', @disp, 'event', 'WindowButtonDownFcn'})
 %   set(gcf, 'WindowButtonMotionFcn', {@ft_select_channel, 'multiple', true, 'callback', @disp, 'event', 'WindowButtonDownFcn'})
+%
+% Example 2 (executed from within a subplot
+%   % create a figure
+%   figure
+%   subplot(2,2,1)
+%   cfg = [];
+%   cfg.channel = {'chan1', 'chan2', 'chan3', 'chan4'};
+%   cfg.layout  = 'ordered';
+%   lay = ft_prepare_layout(cfg);
+%   ft_plot_lay(lay) 
+%
+%   % add the channel information to guidata under identifier linked to this axis
+%   ident              = ['axh' num2str(round(sum(clock.*1e6)))]; % unique identifier for this axis
+%   set(gca,'tag',ident);
+%   info               = guidata(gcf);
+%   info.(ident).x     = lay.pos(:, 1);
+%   info.(ident).y     = lay.pos(:, 2);
+%   info.(ident).label = lay.label;
+%   guidata(gcf, info)
+%
+%   % add this function as the callback to make a single selection
+%   set(gcf, 'WindowButtonDownFcn', {@ft_select_channel, 'callback', @disp})
+%
+%   % or to make multiple selections
+%   set(gcf, 'WindowButtonDownFcn',   {@ft_select_channel, 'multiple', true, 'callback', @disp, 'event', 'WindowButtonDownFcn'})
+%   set(gcf, 'WindowButtonUpFcn',     {@ft_select_channel, 'multiple', true, 'callback', @disp, 'event', 'WindowButtonDownFcn'})
+%   set(gcf, 'WindowButtonMotionFcn', {@ft_select_channel, 'multiple', true, 'callback', @disp, 'event', 'WindowButtonDownFcn'})
+%      
 %
 % Subsequently you can click in the figure and you'll see that the disp
 % function is executed as callback and that it displays the selected

--- a/private/topoplot_common.m
+++ b/private/topoplot_common.m
@@ -900,24 +900,24 @@ end
 
 % Make the figure interactive
 if strcmp(cfg.interactive, 'yes')
-  % add the channel position information to the figure
-  % this section is required for ft_select_channel to do its work
-  info       = guidata(gcf);
-  info.x     = cfg.layout.pos(:,1);
-  info.y     = cfg.layout.pos(:,2);
-  info.label = cfg.layout.label;
-  guidata(gcf, info);
-  % attach data to the figure with the current axis handle as a name
-  dataname = fixname(num2str(double(gca)));
-  setappdata(gcf,dataname,varargin(1:Ndata));
+    % add the channel information to the figure
+    ident                    = ['axh' num2str(round(sum(clock.*1e6)))]; % unique identifier for this axis
+    set(gca,'tag',ident);
+    info                     = guidata(gcf);
+    info.(ident).x           = cfg.layout.pos(:, 1);
+    info.(ident).y           = cfg.layout.pos(:, 2);
+    info.(ident).label       = cfg.layout.label;
+    info.(ident).cfg         = cfg;
+    info.(ident).datvarargin = varargin(1:Ndata);
+    guidata(gcf, info);
   if any(strcmp(data.dimord, {'chan_time', 'chan_freq', 'subj_chan_time', 'rpt_chan_time', 'chan_chan_freq', 'chancmb_freq', 'rpt_chancmb_freq', 'subj_chancmb_freq'}))
-    set(gcf, 'WindowButtonUpFcn',     {@ft_select_channel, 'multiple', true, 'callback', {@select_singleplotER, cfg}, 'event', 'WindowButtonUpFcn'});
-    set(gcf, 'WindowButtonDownFcn',   {@ft_select_channel, 'multiple', true, 'callback', {@select_singleplotER, cfg}, 'event', 'WindowButtonDownFcn'});
-    set(gcf, 'WindowButtonMotionFcn', {@ft_select_channel, 'multiple', true, 'callback', {@select_singleplotER, cfg}, 'event', 'WindowButtonMotionFcn'});
+    set(gcf, 'WindowButtonUpFcn',     {@ft_select_channel, 'multiple', true, 'callback', {@select_singleplotER}, 'event', 'WindowButtonUpFcn'});
+    set(gcf, 'WindowButtonDownFcn',   {@ft_select_channel, 'multiple', true, 'callback', {@select_singleplotER}, 'event', 'WindowButtonDownFcn'});
+    set(gcf, 'WindowButtonMotionFcn', {@ft_select_channel, 'multiple', true, 'callback', {@select_singleplotER}, 'event', 'WindowButtonMotionFcn'});
   elseif any(strcmp(data.dimord, {'chan_freq_time', 'subj_chan_freq_time', 'rpt_chan_freq_time', 'rpttap_chan_freq_time', 'chan_chan_freq_time', 'chancmb_freq_time', 'rpt_chancmb_freq_time', 'subj_chancmb_freq_time'}))
-    set(gcf, 'WindowButtonUpFcn',     {@ft_select_channel, 'multiple', true, 'callback', {@select_singleplotTFR, cfg}, 'event', 'WindowButtonUpFcn'});
-    set(gcf, 'WindowButtonDownFcn',   {@ft_select_channel, 'multiple', true, 'callback', {@select_singleplotTFR, cfg}, 'event', 'WindowButtonDownFcn'});
-    set(gcf, 'WindowButtonMotionFcn', {@ft_select_channel, 'multiple', true, 'callback', {@select_singleplotTFR, cfg}, 'event', 'WindowButtonMotionFcn'});
+    set(gcf, 'WindowButtonUpFcn',     {@ft_select_channel, 'multiple', true, 'callback', {@select_singleplotTFR}, 'event', 'WindowButtonUpFcn'});
+    set(gcf, 'WindowButtonDownFcn',   {@ft_select_channel, 'multiple', true, 'callback', {@select_singleplotTFR}, 'event', 'WindowButtonDownFcn'});
+    set(gcf, 'WindowButtonMotionFcn', {@ft_select_channel, 'multiple', true, 'callback', {@select_singleplotTFR}, 'event', 'WindowButtonMotionFcn'});
   else
     warning('unsupported dimord "%s" for interactive plotting', data.dimord);
   end
@@ -998,11 +998,12 @@ ft_topoplotER(cfg, data);
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % SUBFUNCTION which is called after selecting channels in case of cfg.interactive='yes'
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-function select_singleplotER(label, cfg)
+function select_singleplotER(label)
+ident       = get(gca,'tag');
+info        = guidata(gcf);
+cfg         = info.(ident).cfg;
+datvarargin = info.(ident).datvarargin;
 if ~isempty(label)
-  % get appdata belonging to current axis
-  dataname = fixname(num2str(double(gca)));
-  data = getappdata(gcf, dataname);
   
   if isfield(cfg, 'inputfile')
     % the reading has already been done and varargin contains the data
@@ -1022,17 +1023,18 @@ if ~isempty(label)
   fprintf('''%s''}\n', cfg.channel{end});
   % ensure that the new figure appears at the same position
   f = figure('Position', get(gcf, 'Position'), 'Visible', get(gcf, 'Visible'));
-  ft_singleplotER(cfg, data{:});
+  ft_singleplotER(cfg, datvarargin{:});
 end
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % SUBFUNCTION which is called after selecting channels in case of cfg.interactive='yes'
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-function select_singleplotTFR(label, cfg)
+function select_singleplotTFR(label)
+ident       = get(gca,'tag');
+info        = guidata(gcf);
+cfg         = info.(ident).cfg;
+datvarargin = info.(ident).datvarargin;
 if ~isempty(label)
-  % get appdata belonging to current axis
-  dataname = fixname(num2str(double(gca)));
-  data = getappdata(gcf, dataname);
   
   if isfield(cfg, 'inputfile')
     % the reading has already been done and varargin contains the data
@@ -1048,7 +1050,7 @@ if ~isempty(label)
   fprintf('''%s''}\n', cfg.channel{end});
   % ensure that the new figure appears at the same position
   f = figure('Position', get(gcf, 'Position'), 'Visible', get(gcf, 'Visible'));
-  ft_singleplotTFR(cfg, data{:});
+  ft_singleplotTFR(cfg, datvarargin{:});
 end
 
 

--- a/private/topoplot_common.m
+++ b/private/topoplot_common.m
@@ -900,7 +900,7 @@ end
 
 % Make the figure interactive
 if strcmp(cfg.interactive, 'yes')
-    % add the channel information to the figure
+    % add the cfg/data/channel information to the figure under identifier linked to this axis
     ident                    = ['axh' num2str(round(sum(clock.*1e6)))]; % unique identifier for this axis
     set(gca,'tag',ident);
     info                     = guidata(gcf);
@@ -999,6 +999,7 @@ ft_topoplotER(cfg, data);
 % SUBFUNCTION which is called after selecting channels in case of cfg.interactive='yes'
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 function select_singleplotER(label)
+% fetch cfg/data based on axis indentifier given as tag
 ident       = get(gca,'tag');
 info        = guidata(gcf);
 cfg         = info.(ident).cfg;


### PR DESCRIPTION
These commits allow for ft_single/topo/multiplotER/TFR in subplots to be interactive. 

It was actually surprisingly simple. All that was needed 'under the hood' was an addition to ft_select_channel. The trick is to save the (subplotted) cfg/data in a subfield of the same guidata, with a unique identifier for the current axes, which is also added as the gca's 'tag'. When ft_select_channel is then called from within this subplot, it searches for a tag, and if successful, used the appropriate data for selection. 

I've tested it in all the applicable functions (which are only the above plotting functions), and tested with test_tutorial_clusterpermutation, which generates several topo's in subplots, which are automatically interactive now! 