### PR TITLE
FIX: use uimagesc so that data with uneven axis is shown correctly.

### DIFF
--- a/plotting/ft_plot_matrix.m
+++ b/plotting/ft_plot_matrix.m
@@ -288,7 +288,7 @@ if ~isempty(highlight)
       % do 4
       rgbcdat = hsv2rgb(hsvcdat);
       % do 5
-      h = imagesc(hdat, vdat, rgbcdat,clim);
+      h = uimagesc(hdat, vdat, rgbcdat,clim);
       set(h,'tag',tag);
       
     case 'outline'


### PR DESCRIPTION
Fixes issue reported at http://bugzilla.fieldtriptoolbox.org/show_bug.cgi?id=3261