### PR TITLE
Partially solved bug (bugzilla 3264). basic functionality did not work for raw …

### DIFF
--- a/ft_math.m
+++ b/ft_math.m
@@ -123,6 +123,12 @@ if ~iscell(cfg.parameter)
   cfg.parameter = {cfg.parameter};
 end
 
+if ft_datatype(varargin{1}, 'raw')
+    if length(varargin)>1
+        error('ft_math does not support more than one input argument if the input data is of type "raw"')
+    end
+end
+
 % this function only works for the upcoming (not yet standard) source representation without sub-structures
 if ft_datatype(varargin{1}, 'source')
   % update the old-style beamformer source reconstruction
@@ -164,7 +170,7 @@ end
 dimord = dimordtmp{1}; clear dimordtmp
 dimtok = tokenize(dimord, '_');
 
-% construct the output data structure
+% construct the output data structure; make sure descriptive fields will get copied over
 data = keepfields(varargin{1}, {'label', 'chancmb', 'freq', 'time', 'pos', 'dim', 'transform'});
 
 for p = 1:length(cfg.parameter)

--- a/ft_math.m
+++ b/ft_math.m
@@ -164,13 +164,6 @@ end
 dimord = dimordtmp{1}; clear dimordtmp
 dimtok = tokenize(dimord, '_');
 
-% this determines which descriptive fields will get copied over
-haschan    = any(strcmp(dimtok, 'chan'));
-haschancmb = any(strcmp(dimtok, 'chancmb'));
-hasfreq    = any(strcmp(dimtok, 'freq'));
-hastime    = any(strcmp(dimtok, 'time'));
-haspos     = any(strcmp(dimtok, 'pos'));
-
 % construct the output data structure
 data = keepfields(varargin{1}, {'label', 'chancmb', 'freq', 'time', 'pos', 'dim', 'transform'});
 

--- a/ft_math.m
+++ b/ft_math.m
@@ -444,13 +444,13 @@ for p = 1:length(cfg.parameter)
   % store the result of the operation in the output structure
   data = setsubfield(data, cfg.parameter{p}, y);
 end % p over length(cfg.parameter)
-data.dimord = dimord;
+  data.dimord = dimord;
 
 % certain fields should remain in the output, but only if they are identical in all inputs
 keepfield = {'grad', 'elec', 'inside', 'trialinfo', 'sampleinfo', 'tri'};
 for j=1:numel(keepfield)
   if isfield(varargin{1}, keepfield{j})
-    tmp  = varargin{i}.(keepfield{j});
+    tmp  = varargin{1}.(keepfield{j});
     keep = true;
   else
     keep = false;

--- a/ft_math.m
+++ b/ft_math.m
@@ -172,30 +172,7 @@ hastime    = any(strcmp(dimtok, 'time'));
 haspos     = any(strcmp(dimtok, 'pos'));
 
 % construct the output data structure
-data = [];
-if haschan
-  data.label = varargin{1}.label;
-end
-if haschancmb
-  data.labelcmb = varargin{1}.labelcmb;
-end
-if hasfreq
-  data.freq = varargin{1}.freq;
-end
-if hastime
-  data.time = varargin{1}.time;
-end
-if haspos
-  if isfield(varargin{1}, 'pos')
-    data.pos = varargin{1}.pos;
-  end
-  if isfield(varargin{1}, 'dim')
-    data.dim = varargin{1}.dim;
-  end
-  if isfield(varargin{1}, 'transform')
-    data.transform = varargin{1}.transform;
-  end
-end
+data = keepfields(varargin{1}, {'label', 'chancmb', 'freq', 'time', 'pos', 'dim', 'transform'});
 
 for p = 1:length(cfg.parameter)
   fprintf('selecting %s from the first input argument\n', cfg.parameter{p});

--- a/ft_math.m
+++ b/ft_math.m
@@ -186,7 +186,7 @@ else
     end
     dimordfields = dimordfields(ok);
 end
-data = keepfields(varargin{1}, [dimordfields {'label', 'chancmb', 'freq', 'time', 'pos', 'dim', 'transform'}]);
+data = keepfields(varargin{1}, [dimordfields {'label', 'labelcmb', 'freq', 'time', 'pos', 'dim', 'transform'}]);
 
 for p = 1:length(cfg.parameter)
   fprintf('selecting %s from the first input argument\n', cfg.parameter{p});

--- a/test/test_ft_math.m
+++ b/test/test_ft_math.m
@@ -7,6 +7,15 @@ function test_ft_math
 % TEST ft_math
 
 % create some test data
+raw1 = [];
+raw1.time = {[1:10], [1:10], [1:10]};
+raw1.trial = {ones(2,10), ones(2,10), ones(2,10)};
+raw1.label = {'chan01';'chan02'};
+raw1.trialinfo = rand(3,4);
+
+raw2 = raw1;
+raw2.trial = {2*ones(2,10), 2*ones(2,10), 2*ones(2,10)};
+
 timelock1.label  = {'chan1'; 'chan2'};
 timelock1.time   = 1:5;
 timelock1.dimord = 'chan_time';
@@ -35,6 +44,35 @@ for i=1:10
   source2.mom{i} = ones(3, 20)*2;
 end
 
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% do operation with one raw input
+
+cfg=[];
+cfg.showcallinfo = 'no';
+cfg.trackconfig  = 'no';
+cfg.parameter = 'trial';
+
+cfg.operation = 'log10';
+tmp = ft_math(cfg, raw1);
+assert(isfield(tmp, cfg.parameter), 'the output parameter is missing');
+
+cfg.scalar = pi;
+
+cfg.operation = 'add';
+tmp = ft_math(cfg, raw1);
+assert(isfield(tmp, cfg.parameter), 'the output parameter is missing');
+
+cfg.operation = 'subtract';
+tmp = ft_math(cfg, raw1);
+assert(isfield(tmp, cfg.parameter), 'the output parameter is missing');
+
+cfg.operation = 'multiply';
+tmp = ft_math(cfg, raw1);
+assert(isfield(tmp, cfg.parameter), 'the output parameter is missing');
+
+cfg.operation = 'divide';
+tmp = ft_math(cfg, raw1);
+assert(isfield(tmp, cfg.parameter), 'the output parameter is missing');
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % do operation with one timelock input
@@ -121,6 +159,29 @@ tmp = ft_math(cfg, source1);
 assert(isfield(tmp, cfg.parameter), 'the output parameter is missing');
 assert(isfield(tmp, 'dimord'), 'the output dimord is missing');
 
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% do operation with two raw inputs
+
+cfg=[];
+cfg.showcallinfo = 'no';
+cfg.trackconfig  = 'no';
+cfg.parameter = 'trial';
+
+cfg.operation = 'add';
+tmp = ft_math(cfg, raw1, raw2);
+assert(isfield(tmp, cfg.parameter), 'the output parameter is missing');
+
+cfg.operation = 'subtract';
+tmp = ft_math(cfg, raw1, raw2);
+assert(isfield(tmp, cfg.parameter), 'the output parameter is missing');
+
+cfg.operation = 'multiply';
+tmp = ft_math(cfg, raw1, raw2);
+assert(isfield(tmp, cfg.parameter), 'the output parameter is missing');
+
+cfg.operation = 'divide';
+tmp = ft_math(cfg, raw1, raw2);
+assert(isfield(tmp, cfg.parameter), 'the output parameter is missing');
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % do operation with two timelock inputs
@@ -222,6 +283,36 @@ assert(isfield(tmp, 'dimord'), 'the output dimord is missing');
 % check the numerical output of the operation
 
 cfg = [];
+cfg.parameter = 'trial';
+cfg.operation = 'add';
+tmp = ft_math(cfg, raw1, raw2);
+assert(tmp.trial{1}(1)==3);
+
+cfg.operation = 'subtract';
+tmp = ft_math(cfg, raw1, raw2);
+assert(tmp.trial{1}(1)==-1);
+
+cfg.operation = 'divide';
+tmp = ft_math(cfg, raw1, raw2);
+assert(tmp.trial{1}(1)==1/2);
+
+cfg.operation = 'multiply';
+tmp = ft_math(cfg, raw1, raw2);
+assert(tmp.trial{1}(1)==2);
+
+cfg.operation = 'log10';
+tmp = ft_math(cfg, raw1);
+assert(tmp.trial{1}(1)==0);
+
+cfg.operation = 'multiply';
+cfg.scalar = -1;
+tmp = ft_math(cfg, raw1);
+assert(tmp.trial{1}(1)==-1);
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% idem for a timelock input
+
+cfg = [];
 cfg.parameter = 'avg';
 cfg.operation = 'add';
 tmp = ft_math(cfg, timelock1, timelock2);
@@ -230,10 +321,6 @@ assert(tmp.avg(1)==3);
 cfg.operation = 'subtract';
 tmp = ft_math(cfg, timelock1, timelock2);
 assert(tmp.avg(1)==-1);
-
-cfg.operation = 'add';
-tmp = ft_math(cfg, timelock1, timelock2);
-assert(tmp.avg(1)==3);
 
 cfg.operation = 'divide';
 tmp = ft_math(cfg, timelock1, timelock2);
@@ -274,10 +361,6 @@ cfg.operation = 'subtract';
 tmp = ft_math(cfg, source1, source2);
 assert(tmp.mom{1}(1)==-1);
 
-cfg.operation = 'add';
-tmp = ft_math(cfg, source1, source2);
-assert(tmp.mom{1}(1)==3);
-
 cfg.operation = 'divide';
 tmp = ft_math(cfg, source1, source2);
 assert(tmp.mom{1}(1)==1/2);
@@ -302,4 +385,3 @@ cfg.scalar = 2;
 cfg.operation = '(x1+x2)^s';
 tmp = ft_math(cfg, source1, source2);
 assert(tmp.mom{1}(1)==9);
-

--- a/test/test_ft_math.m
+++ b/test/test_ft_math.m
@@ -132,29 +132,29 @@ cfg.parameter    = 'mom'; % note that this is {pos}_ori_time
 cfg.operation = 'log10';
 tmp = ft_math(cfg, source1);
 assert(isfield(tmp, cfg.parameter), 'the output parameter is missing');
-assert(isfield(tmp, 'dimord'), 'the output dimord is missing');
+assert(isfield(tmp, [cfg.parameter 'dimord']), 'the output dimord is missing');
 
 cfg.scalar = pi;
 
 cfg.operation = 'add';
 tmp = ft_math(cfg, source1);
 assert(isfield(tmp, cfg.parameter), 'the output parameter is missing');
-assert(isfield(tmp, 'dimord'), 'the output dimord is missing');
+assert(isfield(tmp, [cfg.parameter 'dimord']), 'the output dimord is missing');
 
 cfg.operation = 'subtract';
 tmp = ft_math(cfg, source1);
 assert(isfield(tmp, cfg.parameter), 'the output parameter is missing');
-assert(isfield(tmp, 'dimord'), 'the output dimord is missing');
+assert(isfield(tmp, [cfg.parameter 'dimord']), 'the output dimord is missing');
 
 cfg.operation = 'multiply';
 tmp = ft_math(cfg, source1);
 assert(isfield(tmp, cfg.parameter), 'the output parameter is missing');
-assert(isfield(tmp, 'dimord'), 'the output dimord is missing');
+assert(isfield(tmp, [cfg.parameter 'dimord']), 'the output dimord is missing');
 
 cfg.operation = 'divide';
 tmp = ft_math(cfg, source1);
 assert(isfield(tmp, cfg.parameter), 'the output parameter is missing');
-assert(isfield(tmp, 'dimord'), 'the output dimord is missing');
+assert(isfield(tmp, [cfg.parameter 'dimord']), 'the output dimord is missing');
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % do operation with two timelock inputs
@@ -196,22 +196,22 @@ cfg.parameter    = 'mom';
 cfg.operation = 'add';
 tmp = ft_math(cfg, source1, source2);
 assert(isfield(tmp, cfg.parameter), 'the output parameter is missing');
-assert(isfield(tmp, 'dimord'), 'the output dimord is missing');
+assert(isfield(tmp, [cfg.parameter 'dimord']), 'the output dimord is missing');
 
 cfg.operation = 'subtract';
 tmp = ft_math(cfg, source1, source2);
 assert(isfield(tmp, cfg.parameter), 'the output parameter is missing');
-assert(isfield(tmp, 'dimord'), 'the output dimord is missing');
+assert(isfield(tmp, [cfg.parameter 'dimord']), 'the output dimord is missing');
 
 cfg.operation = 'multiply';
 tmp = ft_math(cfg, source1, source2);
 assert(isfield(tmp, cfg.parameter), 'the output parameter is missing');
-assert(isfield(tmp, 'dimord'), 'the output dimord is missing');
+assert(isfield(tmp, [cfg.parameter 'dimord']), 'the output dimord is missing');
 
 cfg.operation = 'divide';
 tmp = ft_math(cfg, source1, source2);
 assert(isfield(tmp, cfg.parameter), 'the output parameter is missing');
-assert(isfield(tmp, 'dimord'), 'the output dimord is missing');
+assert(isfield(tmp, [cfg.parameter 'dimord']), 'the output dimord is missing');
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -244,12 +244,12 @@ cfg.parameter    = 'mom';
 cfg.operation = 'add';
 tmp = ft_math(cfg, source1, source2, source1, source2);
 assert(isfield(tmp, cfg.parameter), 'the output parameter is missing');
-assert(isfield(tmp, 'dimord'), 'the output dimord is missing');
+assert(isfield(tmp, [cfg.parameter 'dimord']), 'the output dimord is missing');
 
 cfg.operation = 'multiply';
 tmp = ft_math(cfg, source1, source2, source1, source2);
 assert(isfield(tmp, cfg.parameter), 'the output parameter is missing');
-assert(isfield(tmp, 'dimord'), 'the output dimord is missing');
+assert(isfield(tmp, [cfg.parameter 'dimord']), 'the output dimord is missing');
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/test/test_ft_math.m
+++ b/test/test_ft_math.m
@@ -13,9 +13,6 @@ raw1.trial = {ones(2,10), ones(2,10), ones(2,10)};
 raw1.label = {'chan01';'chan02'};
 raw1.trialinfo = rand(3,4);
 
-raw2 = raw1;
-raw2.trial = {2*ones(2,10), 2*ones(2,10), 2*ones(2,10)};
-
 timelock1.label  = {'chan1'; 'chan2'};
 timelock1.time   = 1:5;
 timelock1.dimord = 'chan_time';
@@ -160,30 +157,6 @@ assert(isfield(tmp, cfg.parameter), 'the output parameter is missing');
 assert(isfield(tmp, 'dimord'), 'the output dimord is missing');
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% do operation with two raw inputs
-
-cfg=[];
-cfg.showcallinfo = 'no';
-cfg.trackconfig  = 'no';
-cfg.parameter = 'trial';
-
-cfg.operation = 'add';
-tmp = ft_math(cfg, raw1, raw2);
-assert(isfield(tmp, cfg.parameter), 'the output parameter is missing');
-
-cfg.operation = 'subtract';
-tmp = ft_math(cfg, raw1, raw2);
-assert(isfield(tmp, cfg.parameter), 'the output parameter is missing');
-
-cfg.operation = 'multiply';
-tmp = ft_math(cfg, raw1, raw2);
-assert(isfield(tmp, cfg.parameter), 'the output parameter is missing');
-
-cfg.operation = 'divide';
-tmp = ft_math(cfg, raw1, raw2);
-assert(isfield(tmp, cfg.parameter), 'the output parameter is missing');
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % do operation with two timelock inputs
 
 cfg = [];
@@ -284,21 +257,6 @@ assert(isfield(tmp, 'dimord'), 'the output dimord is missing');
 
 cfg = [];
 cfg.parameter = 'trial';
-cfg.operation = 'add';
-tmp = ft_math(cfg, raw1, raw2);
-assert(tmp.trial{1}(1)==3);
-
-cfg.operation = 'subtract';
-tmp = ft_math(cfg, raw1, raw2);
-assert(tmp.trial{1}(1)==-1);
-
-cfg.operation = 'divide';
-tmp = ft_math(cfg, raw1, raw2);
-assert(tmp.trial{1}(1)==1/2);
-
-cfg.operation = 'multiply';
-tmp = ft_math(cfg, raw1, raw2);
-assert(tmp.trial{1}(1)==2);
 
 cfg.operation = 'log10';
 tmp = ft_math(cfg, raw1);


### PR DESCRIPTION
…data structures (with parameter 'trial') because of faulthy indexing. Solved this issue by changing faulthy index (i-->1); also added tests for raw data structures in test_ft_math. 
Furthermore, in test_ft_math, I removed two duplicate checks.

where raw data is input, the output of ft_math still contains a dimord field, which thus remains unresolved.