### PR TITLE
fieldtrip2fiff fails if filename is only a file (no path)

### DIFF
--- a/fieldtrip2fiff.m
+++ b/fieldtrip2fiff.m
@@ -48,8 +48,8 @@ ft_defaults
 if ~strcmp(ext, '.fif')
   error('if the filename is specified with extension, this should read .fif');
 end
-fifffile = [pathstr filesep name '.fif'];
-eventfile = [pathstr filesep name '-eve.fif'];
+fifffile = fullfile(pathstr ,[name '.fif']);
+eventfile = fullfile(pathstr ,[name '-eve.fif']);
 
 % ensure the mne-toolbox to be on the path
 ft_hastoolbox('mne', 1);


### PR DESCRIPTION
if filename is only a file name, prepending filesep creates a conflict. fieldtrip2fiff tries to write in / and fails if no permission.
Fixed by using fullfile.
