### PR TITLE
added freesurfer aseg.mgz atlas as freesurfer_volume fileformat in ft_read_atlas

### DIFF
--- a/fileio/ft_read_atlas.m
+++ b/fileio/ft_read_atlas.m
@@ -87,7 +87,7 @@ elseif strcmp(x, '.nii') && exist(fullfile(p, [f '.txt']), 'file')
     defaultformat = 'aal';
   end
   fclose(fid);
-elseif strcmp(x, '.mgz') && ~isempty(strfind(f, 'aparc')) && ~isempty(strfind(f, 'aseg'))
+elseif strcmp(x, '.mgz') && ~isempty(strfind(f, 'aparc')) || ~isempty(strfind(f, 'aseg'))
   % individual volume based segmentation from freesurfer
   defaultformat = 'freesurfer_volume';
 elseif ft_filetype(filename, 'caret_label')


### PR DESCRIPTION
ft_read_atlas would only categorize aseg+aparc.mgz as a freesurfer_volume fileformat, and not the more basic aseg.mgz segmentation from freesurfer.  Changed fileformat section to detect the aseg.mgz as a freesurfer volume so that aseg.mgz atlas can be used as well with ft_read_atlas.