### PR TITLE
enh: preparing subcortical meshes

### DIFF
--- a/fileio/ft_read_atlas.m
+++ b/fileio/ft_read_atlas.m
@@ -87,7 +87,7 @@ elseif strcmp(x, '.nii') && exist(fullfile(p, [f '.txt']), 'file')
     defaultformat = 'aal';
   end
   fclose(fid);
-elseif strcmp(x, '.mgz') && ~isempty(strfind(f, 'aparc')) && ~isempty(strfind(f, 'aseg'))
+elseif strcmp(x, '.mgz') && ~isempty(strfind(f, 'aparc')) || ~isempty(strfind(f, 'aseg'))
   % individual volume based segmentation from freesurfer
   defaultformat = 'freesurfer_volume';
 elseif ft_filetype(filename, 'caret_label')

--- a/private/prepare_mesh_segmentation.m
+++ b/private/prepare_mesh_segmentation.m
@@ -2,8 +2,15 @@ function bnd = prepare_mesh_segmentation(cfg, mri)
 
 % PREPARE_MESH_SEGMENTATION
 %
+% The following configuration options can be specified if cfg.method = iso2mesh:
+%   cfg.maxsurf     = 1 = only use the largest disjointed surface
+%                     0 = use all surfaces for that levelset
+%   cfg.radbound    = a scalar indicating the radius of the target surface 
+%                     mesh element bounding sphere
+%
 % See also PREPARE_MESH_MANUAL, PREPARE_MESH_HEADSHAPE,
 % PREPARE_MESH_HEXAHEDRAL, PREPARE_MESH_TETRAHEDRAL
+
 
 % Copyrights (C) 2009, Robert Oostenveld
 %
@@ -31,6 +38,8 @@ mri = ft_checkdata(mri, 'datatype', {'volume', 'segmentation'}, 'hasunit', 'yes'
 % get the default options
 cfg.spmversion    = ft_getopt(cfg, 'spmversion', 'spm8');
 cfg.method        = ft_getopt(cfg, 'method', 'projectmesh');
+cfg.maxsurf       = ft_getopt(cfg, 'maxsurf', 1);
+cfg.radbound      = ft_getopt(cfg, 'radbound', 3);
 if all(isfield(mri, {'gray', 'white', 'csf'}))
   cfg.tissue      = ft_getopt(cfg, 'tissue', 'brain');    % set the default
   cfg.numvertices = ft_getopt(cfg, 'numvertices', 3000);  % set the default
@@ -150,10 +159,10 @@ for i =1:numel(cfg.tissue)
       % this requires the external iso2mesh toolbox
       ft_hastoolbox('iso2mesh', 1);
       
-      opt = [];
-      opt.radbound = 3; % set the target surface mesh element bounding sphere be <3 pixels in radius
-      opt.maxnode = cfg.numvertices(i);
-      opt.maxsurf = 1;
+       opt = [];
+       opt.radbound = cfg.radbound; % set the target surface mesh element bounding sphere be <3 pixels in radius
+       opt.maxnode = cfg.numvertices(i);
+       opt.maxsurf = cfg.maxsurf;
       
       method = 'cgalsurf';
       isovalues = 0.5;


### PR DESCRIPTION
Added hidden option to prepare_mesh_segmentation that facilitates preparing meshes of oddly shaped volumes (e.g., hippocampus) using vol2surf.

setting cfg.maxsurf = 0 is necessary in case the volume is not continuous
setting cfg.radbound = 2 is necessary to create a surface with more vertices, which facilitates smoothing

See pictures for reference

![maxsurf 0 radbound 2 smoothed](https://cloud.githubusercontent.com/assets/25670186/23977101/4cc1ff88-09a9-11e7-88b1-4c93f593c338.png)
maxsurf=0 radbound=2 smoothed
![maxsurf 0 radbound 3 smoothed](https://cloud.githubusercontent.com/assets/25670186/23977102/4cd4d81a-09a9-11e7-89ea-b213068a3b24.png)
maxsurf=0 radbound=3 smoothed
![maxsurf 0 radbound 2](https://cloud.githubusercontent.com/assets/25670186/23977104/4cde6a2e-09a9-11e7-8fed-31ccd8530a09.png)
maxsurf=0 radbound=2
![maxsurf 0 radbound 3](https://cloud.githubusercontent.com/assets/25670186/23977106/4ce1bd50-09a9-11e7-9066-d3e8199a01d9.png)
maxsurf=0 radbound=3
![maxsurf 1](https://cloud.githubusercontent.com/assets/25670186/23977105/4ce0398a-09a9-11e7-99f0-b18529eccd21.png)
maxsurf=1