### PR TITLE
bugfix in eeg_leadfield4.m for dipoles with negative z-coordinate

### DIFF
--- a/forward/private/eeg_leadfield4.m
+++ b/forward/private/eeg_leadfield4.m
@@ -66,7 +66,7 @@ elc = r4 * elc ./ [dist dist dist];
 
 % rotate everything so that the dipole is along the pos. z-axis
 % only if the dipole is not in the origin or along the positive z-axis
-if R(1)~=0 | R(2)~=0
+if R(1)~=0 || R(2)~=0
   % compute the rotation matrix
   % the inverse rotation matrix is the transposed of this one
   val1 = norm(R);
@@ -81,9 +81,8 @@ if R(1)~=0 | R(2)~=0
   % rotate the electrodes
   elc = elc*rot';
 elseif R(1)==0 && R(2)==0 && R(3)<0
-  % dipole on negative z-axis, rotation is very simple: around x-axis
-  elc(2,:) = -elc(2,:);
-  elc(3,:) = -elc(3,:);
+  % dipole on negative z-axis, this case is very simple: reflect on xy-plane
+  elc(:,3) = -elc(:,3);
 else
   % dipole is on positive z-axis, nothing has to be done
 end
@@ -136,7 +135,6 @@ end
 if R(1)~=0 || R(2)~=0
   lf = lf*rot;
 elseif R(1)==0 && R(2)==0 && R(3)<0
-  lf(2,:) = -lf(2,:);
-  lf(3,:) = -lf(3,:);
+  lf(:,3) = -lf(:,3);
 end
 


### PR DESCRIPTION
Leadfield computation in eeg_leadfield4.m treats dipoles on the negative z-axis as a special case, which makes totally sense but there was a bug in the indexing of the z-coordinate of electrode positions.
The electrode matrix elc has size Nx3 and hence the z-coordinates are elc(:,3).