### PR TITLE
ENH - fix the calibration of the status channel for mbraintrain BDF files

### DIFF
--- a/fileio/private/read_biosemi_bdf.m
+++ b/fileio/private/read_biosemi_bdf.m
@@ -27,7 +27,7 @@ function dat = read_biosemi_bdf(filename, hdr, begsample, endsample, chanindx)
 %    chanindx        index of channels to read (optional, default is all)
 % This returns a Nchans X Nsamples data matrix
 
-% Copyright (C) 2006, Robert Oostenveld
+% Copyright (C) 2006-2017, Robert Oostenveld
 %
 % This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
 % for the documentation and details.
@@ -153,10 +153,21 @@ if nargin==1
   tmp = find(EDF.Cal < 0);
   EDF.Cal(tmp) = ones(size(tmp));
   EDF.Off(tmp) = zeros(size(tmp));
+  
+  % the following adresses https://github.com/fieldtrip/fieldtrip/pull/395
+  tmp = find(strcmpi(cellstr(EDF.Label), 'STATUS'));
+  if EDF.Cal(tmp)~=1
+    timeout = 60*15; % do not show it for the next 15 minutes 
+    ft_warning('FieldTrip:BDFCalibration', 'calibration for status channel appears incorrect, setting it to 1', timeout);
+    EDF.Cal(tmp) = 1;
+  end
+  if EDF.Off(tmp)~=0
+    timeout = 60*15; % do not show it for the next 15 minutes 
+    ft_warning('FieldTrip:BDFOffset', 'offset for status channel appears incorrect, setting it to 0', timeout);
+    EDF.Off(tmp) = 0;
+  end
 
   EDF.Calib=[EDF.Off';(diag(EDF.Cal))];
-  %EDF.Calib=sparse(diag([1; EDF.Cal]));
-  %EDF.Calib(1,2:EDF.NS+1)=EDF.Off';
 
   EDF.SampleRate = EDF.SPR / EDF.Dur;
 
@@ -254,14 +265,11 @@ else
   endsample = endsample - (begepoch-1)*epochlength;  % correct for the number of bytes that were skipped
   dat = dat(:, begsample:endsample);
 
-  % Calibrate the data
-  calib = diag(EDF.Cal(chanindx));
-  if length(chanindx)>1
-    % using a sparse matrix speeds up the multiplication
-    dat = sparse(calib) * dat;
-  else
-    % in case of one channel the sparse multiplication would result in a sparse array
-    dat = calib * dat;
+  % convert from digital to physical values and apply the offset
+  calib  = EDF.Cal(chanindx);
+  offset = EDF.Off(chanindx);
+  for i=1:numel(calib)
+    dat(i,:) = calib(i)*dat(i,:) + offset(i);
   end
 end
 

--- a/test/test_pull395.m
+++ b/test/test_pull395.m
@@ -1,0 +1,33 @@
+function test_pull395
+
+% WALLTIME 00:10:00
+% MEM 2gb
+
+cd(dccnpath('/home/common/matlab/fieldtrip/data/test/original/eeg/bdf'));
+
+%%
+
+filename = {
+  '050327BH_overCZnoAlpha.bdf'
+  'Newtest17-2048.bdf'
+  'Newtest17-256.bdf'
+  'mbrain-train-smarting-mobile-eeg.bdf'
+  };
+
+for i=1:numel(filename)
+  hdr = ft_read_header(filename{i});
+  index = find(strcmpi(hdr.label, 'STATUS'));
+  assert(hdr.orig.Cal(index)==1, 'calibration appears incorrect');
+  
+  sdat = ft_read_data(filename{i}, 'chanindx', index);
+  assert(all((sdat-round(sdat))==0), 'non-integer values in STATUS channel');
+  
+  event = ft_read_event(filename{i});
+  sel = strcmpi({event.type}, 'STATUS');
+  smp = [event(sel).sample];
+  val = [event(sel).value];
+  figure; plot(smp, val, '.');
+  assert(all((val-round(val))==0), 'non-integer values in STATUS events');
+  assert(all(val>0), 'non-positive values in STATUS events');
+  
+end


### PR DESCRIPTION
which is incorrect in the file itself, see issue #395