### PR TITLE
ENH: added and tested the ability to use ft_convert_coordsys under SP…

### DIFF
--- a/test/test_spm12.m
+++ b/test/test_spm12.m
@@ -30,6 +30,14 @@ mri2.coordsys = 'mni';
 
 %----------------------------- SPM12 -----------------------------------
 
+%ft_convert_coordsys: currently uses OldNorm sub-toolbox (i.e. SPM8)
+ft_hastoolbox('spm12',1)
+mri.coordsys = 'ctf';
+c2a = ft_convert_coordsys(mri, 'tal', 1);
+c2b = ft_convert_coordsys(mri, 'tal', 2);
+
+rmpath(spm('dir'));
+
 %ft_volumerealign: coregistration (used in human ecog tutorial)
 cfg             = [];
 cfg.method      = 'spm';

--- a/test/test_spm12.m
+++ b/test/test_spm12.m
@@ -39,6 +39,7 @@ c2b = ft_convert_coordsys(mri, 'tal', 2);
 rmpath(spm('dir'));
 
 %ft_volumerealign: coregistration (used in human ecog tutorial)
+mri.coordsys = 'tal';
 cfg             = [];
 cfg.method      = 'spm';
 cfg.spmversion  = 'spm12';

--- a/utilities/private/align_ctf2spm.m
+++ b/utilities/private/align_ctf2spm.m
@@ -97,7 +97,7 @@ if opt==1
       else
         template = fullfile(spm('Dir'),'toolbox','OldNorm','T1.nii');
       end
-      warning('using ''OldNorm'' affine registration'); % FIXME there's yet no spm_affreg equivalent in external/spm12
+      fprintf('using ''OldNorm'' affine registration\n'); % FIXME there's yet no spm_affreg equivalent in external/spm12
 
     otherwise
       error('unsupported spm-version');
@@ -161,7 +161,7 @@ elseif opt==2
           addpath(fullfile(spm('Dir'),'toolbox','OldNorm'));
         end
       end
-      warning('using ''OldNorm'' normalisation'); % FIXME there's yet no spm_normalise equivalent in external/spm12
+      fprintf('using ''OldNorm'' normalisation\n'); % FIXME there's yet no spm_normalise equivalent in external/spm12
       
     otherwise
       error('unsupported spm-version');

--- a/utilities/private/align_ctf2spm.m
+++ b/utilities/private/align_ctf2spm.m
@@ -97,7 +97,7 @@ if opt==1
       else
         template = fullfile(spm('Dir'),'toolbox','OldNorm','T1.nii');
       end
-      error('spm12 is not yet supported'); % FIXME: there's yet no spm_affreg equivalent in external/spm12
+      warning('using ''OldNorm'' affine registration'); % FIXME there's yet no spm_affreg equivalent in external/spm12
 
     otherwise
       error('unsupported spm-version');
@@ -161,7 +161,7 @@ elseif opt==2
           addpath(fullfile(spm('Dir'),'toolbox','OldNorm'));
         end
       end
-      %error('spm12 is not yet supported'); % FIXME: there's yet no spm_normalise equivalent in external/spm12
+      warning('using ''OldNorm'' normalisation'); % FIXME there's yet no spm_normalise equivalent in external/spm12
       
     otherwise
       error('unsupported spm-version');


### PR DESCRIPTION
…M12, which resorts to using the OldNorm sub toolbox. as a result, explicitly switching to SPM8 is no longer needed. 

Testing was done with both opt = 1 and opt = 2, and it was able to run through under both conditions.