### PR TITLE
ENH: rereferencing with and without montage using ft_preprocessing

### DIFF
--- a/forward/ft_apply_montage.m
+++ b/forward/ft_apply_montage.m
@@ -95,11 +95,11 @@ end
 haschantype = (isfield(input, 'chantype') || isfield(input, 'chantypenew')) && all(isfield(montage, {'chantypeold', 'chantypenew'}));
 haschanunit = (isfield(input, 'chanunit') || isfield(input, 'chanunitnew')) && all(isfield(montage, {'chanunitold', 'chanunitnew'}));
 
-if ~istrue(keepunused)
+if ~istrue(keepunused) && strcmp(ft_datatype(input), 'elec')
   % remove the channels that are not rereferenced from the input
   cfg = [];
   cfg.channel = montage.labelold;
-  input = ft_selectdata(cfg, input);
+  input = ft_selectdata(cfg, input); % FIXME a low-level function (like ft_apply_montage) should never be calling a high-level function
 end
 
 % make sure they always exist to facilitate the remainder of the code

--- a/forward/ft_apply_montage.m
+++ b/forward/ft_apply_montage.m
@@ -99,7 +99,7 @@ if ~istrue(keepunused) && strcmp(ft_datatype(input), 'elec')
   % remove the channels that are not rereferenced from the input
   cfg = [];
   cfg.channel = montage.labelold;
-  input = ft_selectdata(cfg, input); % FIXME a low-level function (like ft_apply_montage) should never be calling a high-level function
+  input = ft_selectdata(cfg, input); % FIXME a low-level function should not be calling a high-level function like ft_selectdata
 end
 
 % make sure they always exist to facilitate the remainder of the code

--- a/forward/ft_apply_montage.m
+++ b/forward/ft_apply_montage.m
@@ -95,6 +95,13 @@ end
 haschantype = (isfield(input, 'chantype') || isfield(input, 'chantypenew')) && all(isfield(montage, {'chantypeold', 'chantypenew'}));
 haschanunit = (isfield(input, 'chanunit') || isfield(input, 'chanunitnew')) && all(isfield(montage, {'chanunitold', 'chanunitnew'}));
 
+if ~istrue(keepunused)
+  % remove the channels that are not rereferenced from the input
+  cfg = [];
+  cfg.channel = montage.labelold;
+  input = ft_selectdata(cfg, input);
+end
+
 % make sure they always exist to facilitate the remainder of the code
 if ~isfield(montage, 'chantypeold')
   montage.chantypeold = repmat({'unknown'}, size(montage.labelold));
@@ -275,7 +282,7 @@ if istrue(keepunused)
   montage.chanunitold = cat(1, montage.chanunitold(:), addchanunit(:));
   montage.chanunitnew = cat(1, montage.chanunitnew(:), addchanunit(:));
 else
-  % add the channels that are not rereferenced to the input of the montage only
+  % add the channels that are not rereferenced to the input of the montage
   montage.tra(:,(n+(1:k))) = zeros(m,k);
   montage.labelold    = cat(1, montage.labelold(:), addlabel(:));
   montage.chantypeold = cat(1, montage.chantypeold(:), addchantype(:));

--- a/ft_prepare_montage.m
+++ b/ft_prepare_montage.m
@@ -54,26 +54,27 @@ end
 
 % set the defaults
 cfg.reref          = ft_getopt(cfg, 'reref', 'yes');
-cfg.refchannel     = ft_getopt(cfg, 'refchannel', 'all');
-cfg.implicitref    = ft_getopt(cfg, 'implicitref', []);
+cfg.refchannel     = ft_getopt(cfg, 'refchannel', {});
+cfg.implicitref    = ft_getopt(cfg, 'implicitref');
 
 % check of input arguments
 if strcmp(cfg.reref, 'no')
   error('cfg.reref should be set to ''yes'' in order to create a montage')
 end
 
+cfg.refchannel = ft_channelselection(cfg.refchannel, data);
+
 % create the refchannel-dependent montage
 montage.labelold = data.label;
 montage.labelnew = data.label;
-montage.tra      = eye(numel(data.label)); % a simple identity matrix
-if ~strmp(cfgrefchannel, 'all')
-  montage.tra(match_str(data.label, cfg.refchannel),:) = []; % fill the refchannel column(s) with -1
-end
+montage.labelnew(match_str(data.label, cfg.refchannel)) = []; % remove the refchannel label
+montage.tra      = eye(numel(data.label)); % an identity matrix
+montage.tra(match_str(data.label, cfg.refchannel),:) = []; % empty the refchannel row(s)
 
 % append implicitref if specified
 if ~isempty(cfg.implicitref)  
   match_str(data.label, cfg.implicitref)
-  montage.tra(match_str(data.label, cfg.implicitref),:) = 0; % fill the implicitref row with 0
+  montage.tra(match_str(data.label, cfg.implicitref),:) = 0; % fill the implicitref row with zeros
 end
 
 % do the general cleanup and bookkeeping at the end of the function

--- a/ft_prepare_montage.m
+++ b/ft_prepare_montage.m
@@ -1,0 +1,82 @@
+function [montage] = ft_prepare_montage(cfg, data)
+
+% FT_PREPARE_MONTAGE creates a referencing scheme based on the input
+% configuration options and the channels in the data structure. The
+% resulting montage can be given as input to ft_apply_montage, or as
+% cfg.montage to ft_preprocessing.
+%
+% Use as
+%   [montage] = ft_prepare_montage(cfg, data)
+%
+% Referencing options:
+%   cfg.reref         = 'no' or 'yes' (default = 'yes')
+%   cfg.refchannel    = cell-array with new EEG reference channel(s), this can be 'all' for a common average reference
+%   cfg.implicitref   = 'label' or empty, add the implicit EEG reference as zeros (default = [])
+%
+% See also FT_APPLY_MONTAGE and FT_PREPROCESSING
+
+% Copyright (C) 2017, Arjen Stolk & Robert Oostenveld
+%
+% This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
+% for the documentation and details.
+%
+%    FieldTrip is free software: you can redistribute it and/or modify
+%    it under the terms of the GNU General Public License as published by
+%    the Free Software Foundation, either version 3 of the License, or
+%    (at your option) any later version.
+%
+%    FieldTrip is distributed in the hope that it will be useful,
+%    but WITHOUT ANY WARRANTY; without even the implied warranty of
+%    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%    GNU General Public License for more details.
+%
+%    You should have received a copy of the GNU General Public License
+%    along with FieldTrip. If not, see <http://www.gnu.org/licenses/>.
+%
+% $Id$
+
+
+% these are used by the ft_preamble/ft_postamble function and scripts
+ft_revision = '$Id$';
+ft_nargin   = nargin;
+ft_nargout  = nargout;
+
+% do the general setup of the function
+ft_defaults
+ft_preamble init
+ft_preamble loadvar    data
+ft_preamble provenance data
+
+% the ft_abort variable is set to true or false in ft_preamble_init
+if ft_abort
+  return
+end
+
+% set the defaults
+cfg.reref          = ft_getopt(cfg, 'reref', 'yes');
+cfg.refchannel     = ft_getopt(cfg, 'refchannel', 'all');
+cfg.implicitref    = ft_getopt(cfg, 'implicitref', []);
+
+% check of input arguments
+if strcmp(cfg.reref, 'no')
+  error('cfg.reref should be set to ''yes'' in order to create a montage')
+end
+
+% create the refchannel-dependent montage
+montage.labelold = data.label;
+montage.labelnew = data.label;
+montage.tra      = eye(numel(data.label)); % a simple identity matrix
+if ~strmp(cfgrefchannel, 'all')
+  montage.tra(match_str(data.label, cfg.refchannel),:) = []; % fill the refchannel column(s) with -1
+end
+
+% append implicitref if specified
+if ~isempty(cfg.implicitref)  
+  match_str(data.label, cfg.implicitref)
+  montage.tra(match_str(data.label, cfg.implicitref),:) = 0; % fill the implicitref row with 0
+end
+
+% do the general cleanup and bookkeeping at the end of the function
+ft_postamble provenance
+ft_postamble previous data
+ft_postamble history montage

--- a/ft_preprocessing.m
+++ b/ft_preprocessing.m
@@ -367,7 +367,7 @@ if hasdata
     
   if strcmp(cfg.updatesens, 'yes')
     if isfield(dataout, 'elec') && strcmp(cfg.reref, 'yes') && ~isstruct(cfg.montage) % create EEG montage on-the-fly in case cfg.reref
-      cfg.montage = ft_prepare_montage(keepfields(cfg, 'reref', 'refchannel', 'implicitref'), data);
+      cfg.montage = ft_prepare_montage(keepfields(cfg, {'reref', 'refchannel', 'implicitref'}), dataout);
     end  
     if isstruct(cfg.montage)
       % apply the linear projection also to the sensor description

--- a/ft_preprocessing.m
+++ b/ft_preprocessing.m
@@ -365,13 +365,9 @@ if hasdata
     
   end % for all trials
     
-  if strcmp(cfg.updatesens, 'yes') && (isfield(dataout, 'grad') || isfield(dataout, 'elec') || isfield(dataout, 'opto'))
-    if strcmp(cfg.reref, 'yes') && ~isstruct(cfg.montage)
-      fprintf('creating an identity matrix montage');
-      cfg.montage          = [];
-      cfg.montage.labelold = data.label;
-      cfg.montage.labelnew = data.label;
-      cfg.montage.tra      = eye(numel(data.label)); % do not adjust chanpos
+  if strcmp(cfg.updatesens, 'yes')
+    if isfield(dataout, 'elec') && strcmp(cfg.reref, 'yes') && ~isstruct(cfg.montage) % create EEG montage on-the-fly in case cfg.reref
+      cfg.montage = ft_prepare_montage(keepfields(cfg, 'reref', 'refchannel', 'implicitref'), data);
     end  
     if isstruct(cfg.montage)
       % apply the linear projection also to the sensor description

--- a/ft_preprocessing.m
+++ b/ft_preprocessing.m
@@ -364,25 +364,34 @@ if hasdata
     [dataout.trial{i}, dataout.label, dataout.time{i}, cfg] = preproc(data.trial{i}, data.label,  data.time{i}, cfg, begpadding, endpadding);
     
   end % for all trials
-  
-  if isstruct(cfg.montage) && strcmp(cfg.updatesens, 'yes')
-    % apply the linear projection also to the sensor description
-    if issubfield(cfg.montage, 'type')
-      bname = cfg.montage.type;
-    else
-      bname = 'preproc';
-    end
-    if isfield(dataout, 'grad')
-      fprintf('applying the montage to the grad structure\n');
-      dataout.grad = ft_apply_montage(dataout.grad, cfg.montage, 'feedback', 'none', 'keepunused', 'yes', 'balancename', bname);
-    end
-    if isfield(dataout, 'elec')
-      fprintf('applying the montage to the grad structure\n');
-      dataout.elec = ft_apply_montage(dataout.elec, cfg.montage, 'feedback', 'none', 'keepunused', 'yes', 'balancename', bname);
-    end
-    if isfield(dataout, 'opto')
-      fprintf('applying the montage to the opto structure\n');
-      dataout.opto = ft_apply_montage(dataout.opto, cfg.montage, 'feedback', 'none', 'keepunused', 'yes', 'balancename', bname);
+    
+  if strcmp(cfg.updatesens, 'yes') && (isfield(dataout, 'grad') || isfield(dataout, 'elec') || isfield(dataout, 'opto'))
+    if strcmp(cfg.reref, 'yes') && ~isstruct(cfg.montage)
+      fprintf('creating an identity matrix montage');
+      cfg.montage          = [];
+      cfg.montage.labelold = data.label;
+      cfg.montage.labelnew = data.label;
+      cfg.montage.tra      = eye(numel(data.label)); % do not adjust chanpos
+    end  
+    if isstruct(cfg.montage)
+      % apply the linear projection also to the sensor description
+      if issubfield(cfg.montage, 'type')
+        bname = cfg.montage.type;
+      else
+        bname = 'preproc';
+      end
+      if isfield(dataout, 'grad')
+        fprintf('applying the montage to the grad structure\n');
+        dataout.grad = ft_apply_montage(dataout.grad, cfg.montage, 'feedback', 'none', 'keepunused', 'no', 'balancename', bname);
+      end
+      if isfield(dataout, 'elec')
+        fprintf('applying the montage to the elec structure\n');
+        dataout.elec = ft_apply_montage(dataout.elec, cfg.montage, 'feedback', 'none', 'keepunused', 'no', 'balancename', bname);
+      end
+      if isfield(dataout, 'opto')
+        fprintf('applying the montage to the opto structure\n');
+        dataout.opto = ft_apply_montage(dataout.opto, cfg.montage, 'feedback', 'none', 'keepunused', 'no', 'balancename', bname);
+      end
     end
   end
     

--- a/test/test_preprocmontage.m
+++ b/test/test_preprocmontage.m
@@ -28,6 +28,17 @@ assert(isequal(numel(reref_eeg_reref.label),2)) % 2 common averaged rereferenced
 assert(isequal(numel(reref_eeg_reref.elec.label),2)) % 2 common averaged rereferenced channels
 assert(isequal(reref_eeg_reref.elec.chanpos, reref_eeg_reref.elec.elecpos)) % original chanpos
 
+% reref using cfg.reref and cfg.implicitref
+cfg                    = [];
+cfg.channel            = ft_channelselection({'eeg 1','eeg 2'}, data_eeg.label);
+cfg.reref              = 'yes';
+cfg.refchannel         = 'all';
+cfg.implicitref        = 'eeg 3';
+reref_eeg_implref = ft_preprocessing(cfg, data_eeg);
+assert(isequal(numel(reref_eeg_implref.label),3)) % 3 common averaged rereferenced channels
+assert(isequal(numel(reref_eeg_implref.elec.label),2)) % 2 common averaged rereferenced channels
+assert(isequal(reref_eeg_implref.elec.chanpos, reref_eeg_implref.elec.elecpos)) % original chanpos
+
 %% data without elec
 data_eeg2.label = {'eeg 1';'eeg 2';'eeg 3'};
 data_eeg2.trial{1,1} = randn(3,10);

--- a/test/test_preprocmontage.m
+++ b/test/test_preprocmontage.m
@@ -1,0 +1,53 @@
+%% data with elec
+data_eeg.label = {'eeg 1';'eeg 2';'eeg 3'};
+data_eeg.trial{1,1} = randn(3,10);
+data_eeg.time{1,1} = 1:10;
+data_eeg.elec.label = data_eeg.label;
+data_eeg.elec.elecpos = [1 1 1; 2 2 2; 3 3 3];
+data_eeg.elec.chanpos = [1 1 1; 2 2 2; 3 3 3];
+data_eeg.elec.tra = eye(3); 
+
+% reref using cfg.montage
+cfg                    = [];
+cfg.channel            = ft_channelselection({'eeg 1','eeg 2'}, data_eeg.label);
+cfg.montage.labelold   = cfg.channel;
+cfg.montage.labelnew   = strcat(cfg.channel(1:end-1),'-',cfg.channel(2:end)); % 'eeg 1-eeg 2'
+cfg.montage.tra        = [1 -1];
+reref_eeg_montage = ft_preprocessing(cfg, data_eeg);
+assert(isequal(numel(reref_eeg_montage.label),1)) % 1 bipolar rereferenced channel
+assert(isequal(numel(reref_eeg_montage.elec.label),1)) % 1 bipolar rereferenced channel
+assert(~isequal(reref_eeg_montage.elec.chanpos, reref_eeg_montage.elec.elecpos)) % adjusted chanpos
+
+% reref using cfg.reref
+cfg                    = [];
+cfg.channel            = ft_channelselection({'eeg 1','eeg 2'}, data_eeg.label);
+cfg.reref              = 'yes';
+cfg.refchannel         = 'all';
+reref_eeg_reref = ft_preprocessing(cfg, data_eeg);
+assert(isequal(numel(reref_eeg_reref.label),2)) % 2 common averaged rereferenced channels
+assert(isequal(numel(reref_eeg_reref.elec.label),2)) % 2 common averaged rereferenced channels
+assert(isequal(reref_eeg_reref.elec.chanpos, reref_eeg_reref.elec.elecpos)) % original chanpos
+
+%% data without elec
+data_eeg2.label = {'eeg 1';'eeg 2';'eeg 3'};
+data_eeg2.trial{1,1} = randn(3,10);
+data_eeg2.time{1,1} = 1:10;
+
+% reref using cfg.montage
+cfg                    = [];
+cfg.channel            = ft_channelselection({'eeg 1','eeg 2'}, data_eeg2.label);
+cfg.montage.labelold   = cfg.channel;
+cfg.montage.labelnew   = strcat(cfg.channel(1:end-1),'-',cfg.channel(2:end)); % 'eeg 1-eeg 2'
+cfg.montage.tra        = [1 -1];
+reref_eeg_montage2 = ft_preprocessing(cfg, data_eeg2);
+assert(isequal(numel(reref_eeg_montage2.label),1)) % 1 bipolar rereferenced channel
+assert(~isfield(reref_eeg_montage2,'elec')) % no elec
+
+% reref using cfg.reref
+cfg                    = [];
+cfg.channel            = ft_channelselection({'eeg 1','eeg 2'}, data_eeg2.label);
+cfg.reref              = 'yes';
+cfg.refchannel         = 'all';
+reref_eeg_reref2 = ft_preprocessing(cfg, data_eeg2);
+assert(isequal(numel(reref_eeg_reref2.label),2)) % 2 common averaged rereferenced channels
+assert(~isfield(reref_eeg_reref2,'elec')) % no elec


### PR DESCRIPTION
- ft_preprocessing creates a unit matrix on the fly in case cfg.reref = 'yes' (and in case there's a sens)
- ft_apply_montage keepunused = 'no' still had too many elecpos. the function is pretty oldskool and the most reliable way to ensure that keepunused = 'no' didn't still attach unused stuff was by using a call to ft_selectdata on the input right in the beginning (rather than sifting out fields at the end)
- test_preprocmontage test the different rereferencing options on data with and without a sens

unclear: should ft_preprocessing, when it creates the unit matrix (in case cfg.reref) , also take into account cfg.implicitref if existent? physically, there's no elecpos to assign to it, but there may be a chanpos hypothetically (although no idea where to put it)