### PR TITLE
FIX - Calculation of endsample

### DIFF
--- a/trialfun/ft_trialfun_brainvision_segmented.m
+++ b/trialfun/ft_trialfun_brainvision_segmented.m
@@ -95,7 +95,7 @@ for i=1:ntrial
 end
 
 % the endsample of each trial aligns with the beginsample of the next one
-endsample(1:end-1) = begsample(2:end);
+endsample(1:end-1) = begsample(2:end) - 1;
 % the last endsample corresponds to the end of the file
 endsample(end)     = hdr.nSamples*hdr.nTrials;
 


### PR DESCRIPTION
The endsample of one trial is definitely not equal to the next begsample, since the data in the eeg file is segmented and the two data points (endsample and begsample) are with highest probability in many cases not consecutive data points in the raw data.
