### PR TITLE
FIX: Check for SOS structures in filtfilt drop-in

### DIFF
--- a/external/signal/filtfilt.m
+++ b/external/signal/filtfilt.m
@@ -50,11 +50,11 @@
 function y = filtfilt(b, a, x)
 
 if (nargin ~= 3)
-    usage('y=filtfilt(b,a,x)');
+    error('Usage: y=filtfilt(b,a,x)');
 end
 
 if (min(size(b)) > 1)
-    warning('SOS structures not supported for fieldtrip drop-in filtfilt');
+    warning('SOS structures not supported for FieldTrip drop-in filtfilt');
     error('Usage: y=filtfilt(b,a,x)');
 end
 

--- a/external/signal/filtfilt.m
+++ b/external/signal/filtfilt.m
@@ -48,8 +48,14 @@
 
 
 function y = filtfilt(b, a, x)
+
 if (nargin ~= 3)
     usage('y=filtfilt(b,a,x)');
+end
+
+if (min(size(b)) > 1)
+    warning('SOS structures not supported for fieldtrip drop-in filtfilt');
+    error('Usage: y=filtfilt(b,a,x)');
 end
 
 rotate = (size(x, 1)==1);


### PR DESCRIPTION
Without the fix the param b can be a matrix and will be converted to a vector by this line of code: 
`b = b(:).';`
Since the MATLAB version of filtfilt provides an override to use Second Order Section (SOS) matrices, together with a Gain (G) vector, the drop-in version has to handle this accordingly.

With the fix, the filtfilt will behave accordingly:

MATLAB filtfilt:
`y=filtfilt(b,a,x);` works
`y=filtfilt(SOS,G,x);` works
`y=filtfilt(dFilterObject,x);` works

Fieldtrip filtfilt
`y=filtfilt(b,a,x);` works
`y=filtfilt(SOS,G,x);` will give a warning + error about correct usage
`y=filtfilt(dFilterObject,x);` will give a warning + error about correct usage

```
Warning: SOS structures not supported for fieldtrip drop-in filtfilt 
> In filtfilt (line 57)
  In digitalFilter>filtfiltIIR (line 1155)
  In digitalFilter/filtfilt (line 948) 
Usage: y=filtfilt(b,a,x)
```
@robertoostenveld There is another sanity check above my fix, which uses a command called `usage`. It seems that this command is not available. Therefore I used `error` for my code fix. Shall I update the other sanity check from `usage('...')` to `error('Usage: ...')`
