### PR TITLE
enh: changed default axes label (e.g. +X) color from yellow to orange…

### DIFF
--- a/plotting/ft_plot_axes.m
+++ b/plotting/ft_plot_axes.m
@@ -13,7 +13,7 @@ function ft_plot_axes(object, varargin)
 % and can include
 %   'axisscale'    = scaling factor for the reference axes and sphere (default = 1)
 %   'unit'         = string, convert the data to the specified geometrical units (default = [])
-%   'fontcolor'    = string, color specification (default = 'y')
+%   'fontcolor'    = string, color specification (default = [1 .5 0], i.e. orange)
 %   'fontsize'     = number, sets the size of the text (default = 10)
 %   'fontunits'    =
 %   'fontname'     =
@@ -45,7 +45,7 @@ axisscale = ft_getopt(varargin, 'axisscale', 1);   % this is used to scale the a
 unit      = ft_getopt(varargin, 'unit');
 coordsys  = ft_getopt(varargin, 'coordsys');
 % these have to do with the font
-fontcolor   = ft_getopt(varargin, 'fontcolor', 'y'); % default is yellow
+fontcolor   = ft_getopt(varargin, 'fontcolor', [1 .5 0]); % default is orange
 fontsize    = ft_getopt(varargin, 'fontsize',   get(0, 'defaulttextfontsize'));
 fontname    = ft_getopt(varargin, 'fontname',   get(0, 'defaulttextfontname'));
 fontweight  = ft_getopt(varargin, 'fontweight', get(0, 'defaulttextfontweight'));


### PR DESCRIPTION
…, which stands out better from the black and grey background in ft_determine_coordsys