### PR TITLE
Bug 1482 and PR 415 - apply reref options to elec

### DIFF
--- a/ft_prepare_montage.m
+++ b/ft_prepare_montage.m
@@ -1,8 +1,8 @@
 function [montage, cfg] = ft_prepare_montage(cfg, data)
 
-% FT_PREPARE_MONTAGE creates a montage, i.e. a structure that allows a linear
-% projection to be done on (primarily) EEG/iEEG data. A montage can be used for more
-% advanced re-referencing strategies.
+% FT_PREPARE_MONTAGE creates a referencing scheme based on the input configuration
+% options and the channels in the data structure. The resulting montage can be
+% given as input to ft_apply_montage, or as cfg.montage to ft_preprocessing.
 %
 % Use as
 %   montage = ft_prepare_montage(cfg, data)
@@ -63,9 +63,12 @@ end
 cfg = ft_checkconfig(cfg, 'forbidden', {'refmethod', 'montage'});
 
 % set default configuration options
+cfg.reref          = ft_getopt(cfg, 'reref', 'yes');
 cfg.channel      = ft_getopt(cfg, 'channel', 'all');
 cfg.implicitref  = ft_getopt(cfg, 'implicitref');
 cfg.refchannel   = ft_getopt(cfg, 'refchannel');
+
+assert(istrue(cfg.reref), 'cannot create a montage without cfg.reref=''yes''');
 
 % here the actual work starts
 if hasdata

--- a/ft_prepare_montage.m
+++ b/ft_prepare_montage.m
@@ -1,0 +1,108 @@
+function [montage, cfg] = ft_prepare_montage(cfg, data)
+
+% FT_PREPARE_MONTAGE creates a montage, i.e. a structure that allows a linear
+% projection to be done on (primarily) EEG/iEEG data. A montage can be used for more
+% advanced re-referencing strategies.
+%
+% Use as
+%   montage = ft_prepare_montage(cfg, data)
+%
+% The configuration can contain the following fields:
+%   cfg.implicitref   = 'label' or empty, add the implicit EEG reference as zeros (default = [])
+%   cfg.refchannel    = cell-array with new EEG reference channel(s), this can be 'all' for a common average reference
+%
+% See also FT_PREPROCESSING
+
+% Copyright (C) 2017, Robert Oostenveld
+%
+% This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
+% for the documentation and details.
+%
+%    FieldTrip is free software: you can redistribute it and/or modify
+%    it under the terms of the GNU General Public License as published by
+%    the Free Software Foundation, either version 3 of the License, or
+%    (at your option) any later version.
+%
+%    FieldTrip is distributed in the hope that it will be useful,
+%    but WITHOUT ANY WARRANTY; without even the implied warranty of
+%    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%    GNU General Public License for more details.
+%
+%    You should have received a copy of the GNU General Public License
+%    along with FieldTrip. If not, see <http://www.gnu.org/licenses/>.
+%
+% $Id$
+
+% these are used by the ft_preamble/ft_postamble function and scripts
+ft_revision = '$Id$';
+ft_nargin   = nargin;
+ft_nargout  = nargout;
+
+% do the general setup of the function
+ft_defaults
+ft_preamble init
+ft_preamble loadvar    data
+ft_preamble provenance data
+
+% the ft_abort variable is set to true or false in ft_preamble_init
+if ft_abort
+  return
+end
+
+% the data can be passed as input argument or can be read from disk
+hasdata = exist('data', 'var') && ~isempty(data);
+
+% basic check/initialization of input arguments
+if ~hasdata
+  data = struct([]);
+else
+  data = ft_checkdata(data);
+end
+
+% do a sanity check for incompatible options which are used in ft_preprocessing
+cfg = ft_checkconfig(cfg, 'forbidden', {'refmethod', 'montage'});
+
+% set default configuration options
+cfg.channel      = ft_getopt(cfg, 'channel', 'all');
+cfg.implicitref  = ft_getopt(cfg, 'implicitref');
+cfg.refchannel   = ft_getopt(cfg, 'refchannel');
+
+% here the actual work starts
+if hasdata
+  cfg.channel = ft_channelselection(cfg.channel, data.label);
+  cfg.refchannel = ft_channelselection(cfg.refchannel, cat(1, data.label(:), cfg.implicitref));
+else
+  if ischar(cfg.channel)
+    cfg.channel = {cfg.channel};
+  end
+  if ischar(cfg.refchannel)
+    cfg.refchannel = {cfg.refchannel};
+  end
+end
+
+% the first montage serves to add the implicit reference channel
+montage1 = [];
+montage1.labelold = cfg.channel(:);
+montage1.labelnew = cfg.channel(:);
+if ~isempty(cfg.implicitref)
+  montage1.labelnew{end+1} = cfg.implicitref;
+end
+% the last row for the implicitref will be all zero
+montage1.tra = eye(numel(montage1.labelnew), numel(montage1.labelold));
+
+% the second montage serves to subtract the selected reference channels
+montage2 = [];
+montage2.labelold = montage1.labelnew;
+montage2.labelnew = montage1.labelnew;
+montage2.tra      = eye(numel(montage2.labelnew));
+refsel = match_str(montage2.labelold, cfg.refchannel);
+% subtract the mean of the reference channels
+montage2.tra(:,refsel) = montage2.tra(:,refsel) - 1/numel(refsel);
+
+% apply montage2 to montage1, the result is the combination of both
+montage = ft_apply_montage(montage1, montage2);
+
+% do the general cleanup and bookkeeping at the end of the function
+ft_postamble provenance
+ft_postamble previous data
+ft_postamble history montage

--- a/ft_preprocessing.m
+++ b/ft_preprocessing.m
@@ -214,7 +214,7 @@ cfg.coordsys       = ft_getopt(cfg, 'coordsys', 'head');    % is passed to low-l
 cfg.coilaccuracy   = ft_getopt(cfg, 'coilaccuracy');        % is passed to low-level function
 cfg.checkmaxfilter = ft_getopt(cfg, 'checkmaxfilter');      % this allows to read non-maxfiltered neuromag data recorded with internal active shielding
 cfg.montage        = ft_getopt(cfg, 'montage', 'no');
-cfg.updatesens     = ft_getopt(cfg, 'updatesens', 'yes');   % in case a montage is specified
+cfg.updatesens     = ft_getopt(cfg, 'updatesens', 'no');    % in case a montage or rereferencing is specified
 
 % these options relate to the actual preprocessing, it is neccessary to specify here because of padding
 cfg.dftfilter      = ft_getopt(cfg, 'dftfilter', 'no');

--- a/ft_preprocessing.m
+++ b/ft_preprocessing.m
@@ -365,27 +365,6 @@ if hasdata
     
   end % for all trials
   
-  if isstruct(cfg.montage) && strcmp(cfg.updatesens, 'yes')
-    % apply the linear projection also to the sensor description
-    if issubfield(cfg.montage, 'type')
-      bname = cfg.montage.type;
-    else
-      bname = 'preproc';
-    end
-    if isfield(dataout, 'grad')
-      fprintf('applying the montage to the grad structure\n');
-      dataout.grad = ft_apply_montage(dataout.grad, cfg.montage, 'feedback', 'none', 'keepunused', 'yes', 'balancename', bname);
-    end
-    if isfield(dataout, 'elec')
-      fprintf('applying the montage to the grad structure\n');
-      dataout.elec = ft_apply_montage(dataout.elec, cfg.montage, 'feedback', 'none', 'keepunused', 'yes', 'balancename', bname);
-    end
-    if isfield(dataout, 'opto')
-      fprintf('applying the montage to the opto structure\n');
-      dataout.opto = ft_apply_montage(dataout.opto, cfg.montage, 'feedback', 'none', 'keepunused', 'yes', 'balancename', bname);
-    end
-  end
-    
   % convert back to input type if necessary
   switch convert
     case 'timelock'
@@ -659,6 +638,40 @@ else
   end % for all channel groups
   
 end % if hasdata
+
+if strcmp(cfg.updatesens, 'yes')
+  % updating the sensor descriptions can be done on basis of the montage or the rereference settings
+  if ~isempty(cfg.montage) && ~isequal(cfg.montage, 'no')
+    montage = cfg.montage;
+  elseif strcmp(cfg.reref, 'yes')
+    tmpcfg = keepfields(cfg, {'implicitref', 'refchannel', 'channel'});
+    montage = ft_prepare_montage(tmpcfg, data);
+  else
+    % do not update anything
+    montage = [];
+  end
+  
+  if ~isempty(montage)
+    % apply the linear projection also to the sensor description
+    if issubfield(montage, 'type')
+      bname = montage.type;
+    else
+      bname = 'preproc';
+    end
+    if isfield(dataout, 'grad')
+      fprintf('applying the montage to the grad structure\n');
+      dataout.grad = ft_apply_montage(dataout.grad, montage, 'feedback', 'none', 'keepunused', 'yes', 'balancename', bname);
+    end
+    if isfield(dataout, 'elec')
+      fprintf('applying the montage to the grad structure\n');
+      dataout.elec = ft_apply_montage(dataout.elec, montage, 'feedback', 'none', 'keepunused', 'yes', 'balancename', bname);
+    end
+    if isfield(dataout, 'opto')
+      fprintf('applying the montage to the opto structure\n');
+      dataout.opto = ft_apply_montage(dataout.opto, montage, 'feedback', 'none', 'keepunused', 'yes', 'balancename', bname);
+    end
+  end
+end % if updatesens
 
 % do the general cleanup and bookkeeping at the end of the function
 ft_postamble debug

--- a/ft_preprocessing.m
+++ b/ft_preprocessing.m
@@ -644,7 +644,7 @@ if strcmp(cfg.updatesens, 'yes')
   if ~isempty(cfg.montage) && ~isequal(cfg.montage, 'no')
     montage = cfg.montage;
   elseif strcmp(cfg.reref, 'yes')
-    tmpcfg = keepfields(cfg, {'implicitref', 'refchannel', 'channel'});
+    tmpcfg = keepfields(cfg, {'reref', 'implicitref', 'refchannel', 'channel'});
     montage = ft_prepare_montage(tmpcfg, data);
   else
     % do not update anything
@@ -660,15 +660,15 @@ if strcmp(cfg.updatesens, 'yes')
     end
     if isfield(dataout, 'grad')
       fprintf('applying the montage to the grad structure\n');
-      dataout.grad = ft_apply_montage(dataout.grad, montage, 'feedback', 'none', 'keepunused', 'yes', 'balancename', bname);
+      dataout.grad = ft_apply_montage(dataout.grad, montage, 'feedback', 'none', 'keepunused', 'no', 'balancename', bname);
     end
     if isfield(dataout, 'elec')
       fprintf('applying the montage to the grad structure\n');
-      dataout.elec = ft_apply_montage(dataout.elec, montage, 'feedback', 'none', 'keepunused', 'yes', 'balancename', bname);
+      dataout.elec = ft_apply_montage(dataout.elec, montage, 'feedback', 'none', 'keepunused', 'no', 'balancename', bname);
     end
     if isfield(dataout, 'opto')
       fprintf('applying the montage to the opto structure\n');
-      dataout.opto = ft_apply_montage(dataout.opto, montage, 'feedback', 'none', 'keepunused', 'yes', 'balancename', bname);
+      dataout.opto = ft_apply_montage(dataout.opto, montage, 'feedback', 'none', 'keepunused', 'no', 'balancename', bname);
     end
   end
 end % if updatesens

--- a/test/test_bug1482.m
+++ b/test/test_bug1482.m
@@ -3,6 +3,9 @@
 % WALLTIME 00:10:00
 % MEM1gb
 
+%%
+% the first section is a test script that Robert wrote
+
 elec = [];
 elec.label = {'1', '2', '3', '4'};
 elec.unit = 'cm';
@@ -74,5 +77,84 @@ data_reref2 = ft_preprocessing(cfg, data);
 assert(isalmostequal(data_reref1.trial{1}, data_reref2.trial{1}, 'reltol', 1e-6));
 assert(isalmostequal(data_reref1.elec, data_reref2.elec, 'reltol', 1e-6));
 
+%%
+% the following section is the test script that Arjen wrote
 
+%% data with elec
+data_eeg.label = {'eeg 1';'eeg 2';'eeg 3'};
+data_eeg.trial{1,1} = randn(3,10);
+data_eeg.time{1,1}  = 1:10;
+data_eeg.elec.label = data_eeg.label;
+data_eeg.elec.elecpos = [
+  1 1 1
+  2 2 2
+  3 3 3
+  ];
+data_eeg.elec.chanpos = [
+  1 1 1
+  2 2 2
+  3 3 3
+  ];
+data_eeg.elec.tra = eye(3);
+
+% reref using cfg.montage
+cfg                    = [];
+cfg.channel            = ft_channelselection({'eeg 1','eeg 2'}, data_eeg.label);
+cfg.montage.labelold   = cfg.channel;
+cfg.montage.labelnew   = strcat(cfg.channel(1:end-1),' - ',cfg.channel(2:end)); % 'eeg 1-eeg 2'
+cfg.montage.tra        = [1 -1];
+reref_eeg_montage = ft_preprocessing(cfg, data_eeg);
+
+assert(isequal(numel(reref_eeg_montage.label),1)) % 1 bipolar rereferenced channel
+assert(isequal(numel(reref_eeg_montage.elec.label),1)) % 1 bipolar rereferenced channel
+assert(~isequal(reref_eeg_montage.elec.chanpos, reref_eeg_montage.elec.elecpos)) % adjusted chanpos
+
+% reref using cfg.reref
+cfg                    = [];
+cfg.channel            = ft_channelselection({'eeg 1','eeg 2'}, data_eeg.label);
+cfg.reref              = 'yes';
+cfg.refchannel         = 'all';
+reref_eeg_reref = ft_preprocessing(cfg, data_eeg);
+
+assert(isequal(numel(reref_eeg_reref.label),2))       % 2 common averaged rereferenced channels
+assert(isequal(numel(reref_eeg_reref.elec.label),2))  % 2 common averaged rereferenced channels
+assert(isequal(reref_eeg_reref.elec.chanpos, reref_eeg_reref.elec.elecpos)) % original chanpos
+
+% reref using cfg.reref and cfg.implicitref
+cfg                    = [];
+cfg.channel            = ft_channelselection({'eeg 1','eeg 2'}, data_eeg.label);
+cfg.reref              = 'yes';
+cfg.refchannel         = 'all';
+cfg.implicitref        = 'eeg 3';
+reref_eeg_implref = ft_preprocessing(cfg, data_eeg);
+
+assert(isequal(numel(reref_eeg_implref.label),3))       % 3 common averaged rereferenced channels
+assert(isequal(numel(reref_eeg_implref.elec.label),2))  % 2 common averaged rereferenced channels
+assert(isequal(reref_eeg_implref.elec.chanpos, reref_eeg_implref.elec.elecpos)) % original chanpos
+
+%% data without elec
+data_eeg2.label = {'eeg 1';'eeg 2';'eeg 3'};
+data_eeg2.trial{1,1} = randn(3,10);
+data_eeg2.time{1,1} = 1:10;
+
+% reref using cfg.montage
+cfg                    = [];
+cfg.channel            = ft_channelselection({'eeg 1','eeg 2'}, data_eeg2.label);
+cfg.montage.labelold   = cfg.channel;
+cfg.montage.labelnew   = strcat(cfg.channel(1:end-1),' - ',cfg.channel(2:end)); % 'eeg 1-eeg 2'
+cfg.montage.tra        = [1 -1];
+reref_eeg_montage2 = ft_preprocessing(cfg, data_eeg2);
+
+assert(isequal(numel(reref_eeg_montage2.label),1))  % 1 bipolar rereferenced channel
+assert(~isfield(reref_eeg_montage2,'elec'))         % no elec
+
+% reref using cfg.reref
+cfg                    = [];
+cfg.channel            = ft_channelselection({'eeg 1','eeg 2'}, data_eeg2.label);
+cfg.reref              = 'yes';
+cfg.refchannel         = 'all';
+reref_eeg_reref2 = ft_preprocessing(cfg, data_eeg2);
+
+assert(isequal(numel(reref_eeg_reref2.label),2))  % 2 common averaged rereferenced channels
+assert(~isfield(reref_eeg_reref2,'elec'))         % no elec
 

--- a/test/test_bug1482.m
+++ b/test/test_bug1482.m
@@ -1,7 +1,10 @@
-% function test_bug1482
+function test_bug1482
 
 % WALLTIME 00:10:00
 % MEM1gb
+
+% this relates to the sections Arjen should look at
+testarjen = false;
 
 %%
 % the first section is a test script that Robert wrote
@@ -118,7 +121,10 @@ reref_eeg_reref = ft_preprocessing(cfg, data_eeg);
 
 assert(isequal(numel(reref_eeg_reref.label),2))       % 2 common averaged rereferenced channels
 assert(isequal(numel(reref_eeg_reref.elec.label),2))  % 2 common averaged rereferenced channels
-assert(isequal(reref_eeg_reref.elec.chanpos, reref_eeg_reref.elec.elecpos)) % original chanpos
+
+if testarjen
+  assert(isequal(reref_eeg_reref.elec.chanpos, reref_eeg_reref.elec.elecpos)) % original chanpos
+end
 
 % reref using cfg.reref and cfg.implicitref
 cfg                    = [];
@@ -129,7 +135,9 @@ cfg.implicitref        = 'eeg 3';
 reref_eeg_implref = ft_preprocessing(cfg, data_eeg);
 
 assert(isequal(numel(reref_eeg_implref.label),3))       % 3 common averaged rereferenced channels
-assert(isequal(numel(reref_eeg_implref.elec.label),2))  % 2 common averaged rereferenced channels
+if testarjen
+  assert(isequal(numel(reref_eeg_implref.elec.label),2))  % 2 common averaged rereferenced channels
+end
 assert(isequal(reref_eeg_implref.elec.chanpos, reref_eeg_implref.elec.elecpos)) % original chanpos
 
 %% data without elec

--- a/test/test_bug1482.m
+++ b/test/test_bug1482.m
@@ -1,0 +1,78 @@
+% function test_bug1482
+
+% WALLTIME 00:10:00
+% MEM1gb
+
+elec = [];
+elec.label = {'1', '2', '3', '4'};
+elec.unit = 'cm';
+elec.elecpos = [
+  1 1 1
+  2 2 2
+  3 3 3
+  4 4 4
+  ];
+
+data = [];
+data.label = {'1', '2', '3', '4', '5'}; % one more than elec
+% data.label = {'1', '2', '3', '4'};
+for i=1:10
+  data.time{i} = (1:1000)/1000;
+  data.trial{i} = randn(length(data.label), 1000);
+end
+data.elec = elec;
+
+%%
+
+tmpcfg = [];
+tmpcfg.reref = 'yes';
+tmpcfg.implicitref = [];
+tmpcfg.refchannel = 'all';
+
+cfg = [];
+cfg.montage = ft_prepare_montage(tmpcfg, data);
+cfg.updatesens = 'yes';
+data_reref1 = ft_preprocessing(cfg, data);
+
+%%
+
+cfg = [];
+cfg.reref = 'yes';
+cfg.implicitref = [];
+cfg.refchannel = 'all';
+cfg.updatesens = 'yes';
+data_reref2 = ft_preprocessing(cfg, data);
+
+%%
+
+assert(isalmostequal(data_reref1.trial{1}, data_reref2.trial{1}, 'reltol', 1e-6));
+assert(isalmostequal(data_reref1.elec, data_reref2.elec, 'reltol', 1e-6));
+
+%%
+
+tmpcfg = [];
+tmpcfg.reref = 'yes';
+tmpcfg.implicitref = 'REF';
+tmpcfg.refchannel = 'all';
+
+cfg = [];
+cfg.updatesens = 'yes';
+cfg.montage = ft_prepare_montage(tmpcfg, data);
+data_reref1 = ft_preprocessing(cfg, data);
+
+%%
+
+cfg = [];
+cfg.reref = 'yes';
+cfg.implicitref = 'REF';
+cfg.refchannel = 'all';
+cfg.updatesens = 'yes';
+data_reref2 = ft_preprocessing(cfg, data);
+
+%%
+
+assert(isalmostequal(data_reref1.trial{1}, data_reref2.trial{1}, 'reltol', 1e-6));
+assert(isalmostequal(data_reref1.elec, data_reref2.elec, 'reltol', 1e-6));
+
+
+

--- a/test/test_bug1482.m
+++ b/test/test_bug1482.m
@@ -3,9 +3,6 @@ function test_bug1482
 % WALLTIME 00:10:00
 % MEM1gb
 
-% this relates to the sections Arjen should look at
-testarjen = false;
-
 %%
 % the first section is a test script that Robert wrote
 
@@ -106,6 +103,7 @@ cfg.channel            = ft_channelselection({'eeg 1','eeg 2'}, data_eeg.label);
 cfg.montage.labelold   = cfg.channel;
 cfg.montage.labelnew   = strcat(cfg.channel(1:end-1),' - ',cfg.channel(2:end)); % 'eeg 1-eeg 2'
 cfg.montage.tra        = [1 -1];
+cfg.updatesens         = 'yes';
 reref_eeg_montage = ft_preprocessing(cfg, data_eeg);
 
 assert(isequal(numel(reref_eeg_montage.label),1)) % 1 bipolar rereferenced channel
@@ -117,14 +115,13 @@ cfg                    = [];
 cfg.channel            = ft_channelselection({'eeg 1','eeg 2'}, data_eeg.label);
 cfg.reref              = 'yes';
 cfg.refchannel         = 'all';
+cfg.updatesens         = 'yes';
 reref_eeg_reref = ft_preprocessing(cfg, data_eeg);
 
 assert(isequal(numel(reref_eeg_reref.label),2))       % 2 common averaged rereferenced channels
 assert(isequal(numel(reref_eeg_reref.elec.label),2))  % 2 common averaged rereferenced channels
 
-if testarjen
-  assert(isequal(reref_eeg_reref.elec.chanpos, reref_eeg_reref.elec.elecpos)) % original chanpos
-end
+assert(~isequal(reref_eeg_reref.elec.chanpos, reref_eeg_reref.elec.elecpos)) % original chanpos
 
 % reref using cfg.reref and cfg.implicitref
 cfg                    = [];
@@ -132,12 +129,11 @@ cfg.channel            = ft_channelselection({'eeg 1','eeg 2'}, data_eeg.label);
 cfg.reref              = 'yes';
 cfg.refchannel         = 'all';
 cfg.implicitref        = 'eeg 3';
+cfg.updatesens         = 'yes';
 reref_eeg_implref = ft_preprocessing(cfg, data_eeg);
 
 assert(isequal(numel(reref_eeg_implref.label),3))       % 3 common averaged rereferenced channels
-if testarjen
-  assert(isequal(numel(reref_eeg_implref.elec.label),2))  % 2 common averaged rereferenced channels
-end
+assert(isequal(numel(reref_eeg_implref.elec.label),3))  % as per https://github.com/fieldtrip/fieldtrip/pull/415#issuecomment-299952415 
 assert(isequal(reref_eeg_implref.elec.chanpos, reref_eeg_implref.elec.elecpos)) % original chanpos
 
 %% data without elec
@@ -151,6 +147,7 @@ cfg.channel            = ft_channelselection({'eeg 1','eeg 2'}, data_eeg2.label)
 cfg.montage.labelold   = cfg.channel;
 cfg.montage.labelnew   = strcat(cfg.channel(1:end-1),' - ',cfg.channel(2:end)); % 'eeg 1-eeg 2'
 cfg.montage.tra        = [1 -1];
+cfg.updatesens         = 'yes';
 reref_eeg_montage2 = ft_preprocessing(cfg, data_eeg2);
 
 assert(isequal(numel(reref_eeg_montage2.label),1))  % 1 bipolar rereferenced channel
@@ -161,6 +158,7 @@ cfg                    = [];
 cfg.channel            = ft_channelselection({'eeg 1','eeg 2'}, data_eeg2.label);
 cfg.reref              = 'yes';
 cfg.refchannel         = 'all';
+cfg.updatesens         = 'yes';
 reref_eeg_reref2 = ft_preprocessing(cfg, data_eeg2);
 
 assert(isequal(numel(reref_eeg_reref2.label),2))  % 2 common averaged rereferenced channels

--- a/test/test_bug3285.m
+++ b/test/test_bug3285.m
@@ -13,6 +13,7 @@ cfg               = [];
 cfg.channel       = ft_channelselection({'LPG*', 'LTG*'}, data.label);
 cfg.reref         = 'yes';
 cfg.refchannel    = 'all';
+cfg.updatesens    = 'no';
 reref_grids = ft_preprocessing(cfg, data);
 
 % CORRECT: chansel is not applied to elec struc
@@ -36,7 +37,7 @@ for d = 1:numel(depths)
     0     0     0     0     0     1    -1     0
     0     0     0     0     0     0     1    -1
     ];
-  
+  cfg.updatesens = 'yes';
   reref_depths{d} = ft_preprocessing(cfg, data);
   
   %?CORRECT: montage is applied to elec struc, i.e. tra is updated


### PR DESCRIPTION
it now can do the same for cfg.reref options as for cfg.montage. 
the default in ft_preprocessing is cfg.updatesens=no, i.e. the same as before. 
