### PR TITLE
enh: cfg.keepchannel option

### DIFF
--- a/ft_electroderealign.m
+++ b/ft_electroderealign.m
@@ -1,6 +1,6 @@
 function [elec_realigned] = ft_electroderealign(cfg, elec_original)
 
-% FT_ELECTRODEREALING rotates, translates, scales and warps electrode positions. The
+% FT_ELECTRODEREALIGN rotates, translates, scales and warps electrode positions. The
 % default is to only rotate and translate, i.e. to do a rigid body transformation in
 % which only the coordinate system is changed. With the right settings if can apply
 % additional deformations to the input sensors (e.g. scale them to better fit the
@@ -58,6 +58,7 @@ function [elec_realigned] = ft_electroderealign(cfg, elec_original)
 %                        'fsaverage'       surface-based realignment with the freesurfer fsaverage brain
 %   cfg.channel        = Nx1 cell-array with selection of channels (default = 'all'),
 %                        see  FT_CHANNELSELECTION for details
+%   cfg.keepunused     = string, 'yes' or 'no' (default = 'no')
 %   cfg.fiducial       = cell-array with the name of three fiducials used for
 %                        realigning (default = {'nasion', 'lpa', 'rpa'})
 %   cfg.casesensitive  = 'yes' or 'no', determines whether string comparisons
@@ -172,6 +173,7 @@ cfg = ft_checkconfig(cfg, 'forbidden', 'outline');
 % set the defaults
 cfg.warp          = ft_getopt(cfg, 'warp', 'rigidbody');
 cfg.channel       = ft_getopt(cfg, 'channel',  'all');
+cfg.keepunused    = ft_getopt(cfg, 'keepunused', 'no');
 cfg.feedback      = ft_getopt(cfg, 'feedback', 'no');
 cfg.casesensitive = ft_getopt(cfg, 'casesensitive', 'no');
 cfg.headshape     = ft_getopt(cfg, 'headshape', []);     % for triangulated head surface, without labels
@@ -702,6 +704,14 @@ switch cfg.method
     end
   otherwise
     error('unknown method');
+end
+
+if istrue(cfg.keepunused)
+  % append the channels that are not realigned
+  [~, idx] = setdiff(elec_original.label, elec_realigned.label);
+  idx = sort(idx);
+  elec_realigned.label = [elec_realigned.label; elec_original.label(idx)];
+  elec_realigned.elecpos = [elec_realigned.elecpos; elec_original.elecpos(idx,:)];
 end
 
 % channel positions are identical to the electrode positions (this was checked at the start)

--- a/ft_electroderealign.m
+++ b/ft_electroderealign.m
@@ -58,7 +58,7 @@ function [elec_realigned] = ft_electroderealign(cfg, elec_original)
 %                        'fsaverage'       surface-based realignment with the freesurfer fsaverage brain
 %   cfg.channel        = Nx1 cell-array with selection of channels (default = 'all'),
 %                        see  FT_CHANNELSELECTION for details
-%   cfg.keepunused     = string, 'yes' or 'no' (default = 'no')
+%   cfg.keepchannel    = string, 'yes' or 'no' (default = 'no')
 %   cfg.fiducial       = cell-array with the name of three fiducials used for
 %                        realigning (default = {'nasion', 'lpa', 'rpa'})
 %   cfg.casesensitive  = 'yes' or 'no', determines whether string comparisons
@@ -173,7 +173,7 @@ cfg = ft_checkconfig(cfg, 'forbidden', 'outline');
 % set the defaults
 cfg.warp          = ft_getopt(cfg, 'warp', 'rigidbody');
 cfg.channel       = ft_getopt(cfg, 'channel',  'all');
-cfg.keepunused    = ft_getopt(cfg, 'keepunused', 'no');
+cfg.keepchannel   = ft_getopt(cfg, 'keepchannel', 'no');
 cfg.feedback      = ft_getopt(cfg, 'feedback', 'no');
 cfg.casesensitive = ft_getopt(cfg, 'casesensitive', 'no');
 cfg.headshape     = ft_getopt(cfg, 'headshape', []);     % for triangulated head surface, without labels
@@ -706,7 +706,7 @@ switch cfg.method
     error('unknown method');
 end
 
-if istrue(cfg.keepunused)
+if istrue(cfg.keepchannel)
   % append the channels that are not realigned
   [~, idx] = setdiff(elec_original.label, elec_realigned.label);
   idx = sort(idx);

--- a/test/test_ft_electroderealign_headshape.m
+++ b/test/test_ft_electroderealign_headshape.m
@@ -6,13 +6,13 @@ function test_ft_electroderealign_headshape
 load('SubjectUCI29_elec_tal_f.mat', 'elec_tal_f'); % FIXME: please redirect to correct location at FTP/DCCN cluster
 load('SubjectUCI29_hull_lh.mat', 'mesh'); % FIXME: please redirect to correct location at FTP/DCCN cluster
 
-% keepunused
+% keepchannel
 elec_tal_fr = elec_tal_f;
 grids = {'LPG*', 'LTG*'};
 for g = 1:numel(grids)
   cfg             = [];
   cfg.channel     = grids{g};
-  cfg.keepunused  = 'yes';            % <-
+  cfg.keepchannel = 'yes';            % <-
   cfg.elec        = elec_tal_fr;
   cfg.method      = 'headshape';
   cfg.headshape   = mesh;
@@ -21,12 +21,12 @@ for g = 1:numel(grids)
 end
 assert(isequal(numel(elec_tal_fr.label), 152)); % realigned + unused is 152 elecs
 
-% do not keepunused
+% do not keepchannel
 elec_tal_fr = elec_tal_f;
 grids = {'LPG*'};
 cfg             = [];
 cfg.channel     = grids{1};
-cfg.keepunused  = 'no';             % <-
+cfg.keepchannel = 'no';             % <-
 cfg.elec        = elec_tal_fr;
 cfg.method      = 'headshape';
 cfg.headshape   = mesh;

--- a/test/test_ft_electroderealign_headshape.m
+++ b/test/test_ft_electroderealign_headshape.m
@@ -1,0 +1,35 @@
+function test_ft_electroderealign_headshape
+
+% MEM 2gb
+% WALLTIME 00:20:00
+
+load('SubjectUCI29_elec_tal_f.mat', 'elec_tal_f'); % FIXME: please redirect to correct location at FTP/DCCN cluster
+load('SubjectUCI29_hull_lh.mat', 'mesh'); % FIXME: please redirect to correct location at FTP/DCCN cluster
+
+% keepunused
+elec_tal_fr = elec_tal_f;
+grids = {'LPG*', 'LTG*'};
+for g = 1:numel(grids)
+  cfg             = [];
+  cfg.channel     = grids{g};
+  cfg.keepunused  = 'yes';            % <-
+  cfg.elec        = elec_tal_fr;
+  cfg.method      = 'headshape';
+  cfg.headshape   = mesh;
+  cfg.warp        = 'dykstra2012';
+  elec_tal_fr = ft_electroderealign(cfg);
+end
+assert(isequal(numel(elec_tal_fr.label), 152)); % realigned + unused is 152 elecs
+
+% do not keepunused
+elec_tal_fr = elec_tal_f;
+grids = {'LPG*'};
+cfg             = [];
+cfg.channel     = grids{1};
+cfg.keepunused  = 'no';             % <-
+cfg.elec        = elec_tal_fr;
+cfg.method      = 'headshape';
+cfg.headshape   = mesh;
+cfg.warp        = 'dykstra2012';
+elec_tal_fr = ft_electroderealign(cfg);
+assert(isequal(numel(elec_tal_fr.label), 64)); % realigned LPG has 64 elecs


### PR DESCRIPTION
Adding a cfg.keepchannel option to ft_electroderealign avoids the user having to remerge realigned and unused channels after ft_electroderealign. Example function call (see also test script);

elec_tal_fr = elec_tal_f;
grids = {'LPG*', 'LTG*'};
for g = 1:numel(grids)
  cfg             = [];
  cfg.channel     = grids{g};
  cfg.keepchannel = 'yes';         % <-
  cfg.elec        = elec_tal_fr;
  cfg.method      = 'headshape';
  cfg.headshape   = mesh;
  cfg.warp        = 'dykstra2012';
  elec_tal_fr = ft_electroderealign(cfg);
end


robertoostenveld commented May 9, 2017
unless tra=eye, electrodes are not indicated with a label but channels are indicated with a label.
> ft_electroderealign already checked whether elecpos and chanpos are the same, at line 249.