### PR TITLE
deal with overlapping channels and electrodes in ft_appendsens

### DIFF
--- a/ft_appendsens.m
+++ b/ft_appendsens.m
@@ -7,6 +7,12 @@ function [sens] = ft_appendsens(cfg, varargin)
 % Use as
 %   combined = ft_appendsens(cfg, sens1, sens2, ...)
 %
+% A call to FT_APPENDSENS results in the label, chanpos, and when applicable, 
+% the chanori fields to be concatenated. Any duplicates will be removed. 
+% Moreover, the elecpos, labelold, and chanposold fields are copied over
+% from the first input under the condition that these fields are identical 
+% across the inputs. If applicable, the tra matrices are also merged.
+%
 % See also FT_ELECTRODEPLACEMENT, FT_ELECTRODEREALIGN, FT_DATAYPE_SENS,
 % FT_APPENDDATA, FT_APPENDTIMELOCK, FT_APPENDFREQ, FT_APPENDSOURCE
 
@@ -62,26 +68,22 @@ for i=1:length(varargin)
 end
 typematch = all(strcmp(senstype{1}, senstype));
 
+unitmatch = 1;
 if isfield(varargin{1}, 'unit')
   unit = cell(1,length(varargin));
   for i=1:length(varargin)
     unit{i} = varargin{i}.unit;
   end
   unitmatch = all(strcmp(unit{1}, unit));
-else
-  unitmatch = 1;
-  warning('no unit information present, assuming that the units match');
 end
 
+coordsysmatch = 1;
 if isfield(varargin{1}, 'coordsys')
   coordsys = cell(1,length(varargin));
   for i=1:length(varargin)
     coordsys{i} = varargin{i}.coordsys;
   end
   coordsysmatch = all(strcmp(coordsys{1}, coordsys));
-else
-  coordsysmatch = 1;
-  warning('no coordinate system information present, assuming that the coordinate systems match');
 end
 
 if ~typematch || ~unitmatch || ~coordsysmatch
@@ -91,7 +93,7 @@ end
 % keep these fields (when present) in the output
 sens = keepfields(varargin{1}, {'type', 'unit', 'coordsys'});
 
-% concatenate - see test_pull393.m for a test script
+% make inventory
 haslabelold = 0;
 haschanposold = 0;
 haselecpos = 0;
@@ -112,14 +114,10 @@ for i=1:length(varargin)
   if isfield(varargin{i}, 'labelold')
     labelold{i} = varargin{i}.labelold;
     haslabelold = 1;
-  else % use current labels in case there are no old labels
-    labelold{i} = varargin{i}.label;
   end
   if isfield(varargin{i}, 'chanposold')
     chanposold{i} = varargin{i}.chanposold;
     haschanposold = 1;
-  else % use current chanpos in case there are no old chanpos
-    chanposold{i} = varargin{i}.chanpos;
   end
   
   % the following fields might be present in a sens structure
@@ -143,36 +141,58 @@ for i=1:length(varargin)
     optopos{i} = varargin{i}.optopos;
     hasoptopos = 1;
   end
+  if isfield(varargin{i}, 'tra') % tra
+    tra{i} = varargin{i}.tra;
+    hastra = 1;
+  end
 end
 
+% concatenate channels - see test_pull393.m for a test script
 sens.label = cat(1,label{:});
 sens.chanpos = cat(1,chanpos{:});
-
-if haslabelold % append in case one of the elec structures has old labels
-  sens.labelold = cat(1,labelold{:});
-end
-if haschanposold % append in case one of the elec structures has old chanpos
-  sens.chanposold = cat(1,chanposold{:});
-end
-
-if haselecpos
-  sens.elecpos = cat(1,elecpos{:});
-end
-if hascoilpos
-  sens.coilpos = cat(1,coilpos{:});
-end
-if hascoilori
-  sens.coilori = cat(1,coilori{:});
-end
 if haschanori
   sens.chanori = cat(1,chanori{:});
 end
-if hasoptopos
-  sens.optopos = cat(1,optopos{:});
+
+% remove duplicate channels
+[~, idx] = unique(sens.label);
+if ~isequal(numel(idx), numel(sens.label))
+  warning('duplicate channel labels found and removed, assuming that the chanpos fields match')
+  idx = sort(idx);
+  sens.label = sens.label(idx);
 end
 
-% ensure a that the output sensor description  is according to the latest standards
-% FIXME: tra is not appended
+
+% copy sensor information when identical across inputs (thus likely to have the same origin)
+if haselecpos && all(isequal(elecpos{1}, elecpos{:})) % elecposmatch
+  sens.elecpos = elecpos{1};
+  if hastra && ~any(cellfun(@isempty, tra))
+    sens.tra = cat(1,tra{:});
+  end
+end
+if hasoptopos && all(isequal(optopos{1}, optopos{:})) % optoposmatch
+  sens.optopos = optopos{1};
+  if hastra && ~any(cellfun(@isempty, tra))
+    sens.tra = cat(1,tra{:});
+  end
+end
+if hascoilpos && all(isequal(coilpos{1}, coilpos{:})) % coilposmatch
+  sens.coilpos = coilpos{1};
+  if hastra && ~any(cellfun(@isempty, tra))
+    sens.tra = cat(1,tra{:});
+  end
+end
+if hascoilori && all(isequal(coilori{1}, coilori{:})) % coilorimatch
+  sens.coilori = coilori{1};
+end
+if haslabelold && all(strcmp(labelold{1}, labelold)) % labeloldmatch
+  sens.labelold = labelold{1};
+end
+if haschanposold && all(isequal(chanposold{1}, chanposold{:})) % chanposoldmatch
+  sens.chanposold = chanposold{1};
+end
+
+% ensure up-to-date output sensor description
 sens = ft_datatype_sens(sens);
 
 % do the general cleanup and bookkeeping at the end of the function

--- a/test/test_pull393.m
+++ b/test/test_pull393.m
@@ -13,6 +13,11 @@ data_eeg.elec.elecpos = [1 1 1; 2 2 2; 3 3 3];
 data_eeg.elec.chanpos = [1 1 1; 2 2 2; 3 3 3];
 data_eeg.elec.tra = eye(3);
 
+% data_eeg2 (a different EEG recording: same labels but different elecpos: this should break)
+data_eeg2 = data_eeg;
+data_eeg2.elec.elecpos = data_eeg.elec.elecpos+randn(1); % note the random offset
+data_eeg2.elec.chanpos = data_eeg2.elec.elecpos;
+
 % data_meg
 data_meg.label = {'meg 1';'meg 2';'meg 3'};
 data_meg.trial{1,1} = randn(3,10);
@@ -99,6 +104,13 @@ freq_ieegb = ft_freqanalysis(cfg, data_ieegb);
 %% append raw data
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+% % eeg and eeg2: this should break because of inconsistent label and chanpos
+% cfg = [];
+% cfg.appendsens = 'yes';
+% append0 = ft_appenddata(cfg, data_eeg, data_eeg2);
+% assert(isequal(numel(append0.label),3)) % 3 labels (concat across rpt dim)
+% assert(isequal(numel(append0.elec.label),3)) % 3 elec labels
+
 % eeg and meg
 cfg = [];
 cfg.appendsens = 'yes';
@@ -106,6 +118,8 @@ append1 = ft_appenddata(cfg, data_eeg, data_meg);
 assert(isequal(numel(append1.label),6)) % 6 labels
 assert(isequal(numel(append1.elec.label),3)) % 3 elec labels
 assert(isequal(numel(append1.grad.label),3)) % 3 grad labels
+assert(isequal(size(append1.elec.tra,1),3)) % 3 tra rows
+assert(isequal(size(append1.grad.tra,1),3)) % 3 tra rows
 
 % eeg and nirs
 cfg = [];
@@ -114,6 +128,8 @@ append2 = ft_appenddata(cfg, data_eeg, data_nirs);
 assert(isequal(numel(append2.label),6)) % 6 labels
 assert(isequal(numel(append2.elec.label),3)) % 3 elec labels
 assert(isequal(numel(append2.opto.label),3)) % 3 opto labels
+assert(isequal(size(append2.elec.tra,1),3)) % 3 tra rows
+assert(isequal(size(append2.opto.tra,1),3)) % 3 tra rows
 
 % monopolar and bipolar
 cfg = [];
@@ -121,7 +137,8 @@ cfg.appendsens = 'yes';
 append3 = ft_appenddata(cfg, data_ieeg, data_ieegb);
 assert(isequal(numel(append3.label),5)) % 5 ieeg labels
 assert(isequal(numel(append3.elec.label),5)) % 5 ieeg labels
-assert(isequal(numel(append3.elec.labelold),6)) % 6 ieeg labelolds
+assert(isequal(size(append3.elec.elecpos,1),3)) % 3 original elecpos
+assert(isequal(size(append3.elec.tra,1),5)) % 5 tra rows
 
 % do not append (discard inconsistent sens information)
 append4 = ft_appenddata([], data_eeg, data_meg);
@@ -157,6 +174,8 @@ append1 = ft_appendtimelock(cfg, timelock_eeg, timelock_meg);
 assert(isequal(numel(append1.label),6)) % 6 labels
 assert(isequal(numel(append1.elec.label),3)) % 3 elec labels
 assert(isequal(numel(append1.grad.label),3)) % 3 grad labels
+assert(isequal(size(append1.elec.tra,1),3)) % 3 tra rows
+assert(isequal(size(append1.grad.tra,1),3)) % 3 tra rows
 
 % eeg and nirs
 cfg = [];
@@ -165,6 +184,8 @@ append2 = ft_appendtimelock(cfg, timelock_eeg, timelock_nirs);
 assert(isequal(numel(append2.label),6)) % 6 labels
 assert(isequal(numel(append2.elec.label),3)) % 3 elec labels
 assert(isequal(numel(append2.opto.label),3)) % 3 opto labels
+assert(isequal(size(append2.elec.tra,1),3)) % 3 tra rows
+assert(isequal(size(append2.opto.tra,1),3)) % 3 tra rows
 
 % monopolar and bipolar
 cfg = [];
@@ -172,7 +193,8 @@ cfg.appendsens = 'yes';
 append3 = ft_appendtimelock(cfg, timelock_ieeg, timelock_ieegb);
 assert(isequal(numel(append3.label),5)) % 5 ieeg labels
 assert(isequal(numel(append3.elec.label),5)) % 5 ieeg labels
-assert(isequal(numel(append3.elec.labelold),6)) % 6 ieeg labelolds
+assert(isequal(size(append3.elec.elecpos,1),3)) % 3 original elecpos
+assert(isequal(size(append3.elec.tra,1),5)) % 5 tra rows
 
 % do not append (discard inconsistent sens information)
 append4 = ft_appendtimelock([], timelock_eeg, timelock_meg);
@@ -208,6 +230,8 @@ append1 = ft_appendfreq(cfg, freq_eeg, freq_meg);
 assert(isequal(numel(append1.label),6)) % 6 labels
 assert(isequal(numel(append1.elec.label),3)) % 3 elec labels
 assert(isequal(numel(append1.grad.label),3)) % 3 grad labels
+assert(isequal(size(append1.elec.tra,1),3)) % 3 tra rows
+assert(isequal(size(append1.grad.tra,1),3)) % 3 tra rows
 
 % eeg and nirs
 cfg = [];
@@ -216,6 +240,8 @@ append2 = ft_appendfreq(cfg, freq_eeg, freq_nirs);
 assert(isequal(numel(append2.label),6)) % 6 labels
 assert(isequal(numel(append2.elec.label),3)) % 3 elec labels
 assert(isequal(numel(append2.opto.label),3)) % 3 opto labels
+assert(isequal(size(append2.elec.tra,1),3)) % 3 tra rows
+assert(isequal(size(append2.opto.tra,1),3)) % 3 tra rows
 
 % monopolar and bipolar
 cfg = [];
@@ -223,7 +249,8 @@ cfg.appendsens = 'yes';
 append3 = ft_appendfreq(cfg, freq_ieeg, freq_ieegb);
 assert(isequal(numel(append3.label),5)) % 5 ieeg labels
 assert(isequal(numel(append3.elec.label),5)) % 5 ieeg labels
-assert(isequal(numel(append3.elec.labelold),6)) % 6 ieeg labelolds
+assert(isequal(size(append3.elec.elecpos,1),3)) % 3 original elecpos
+assert(isequal(size(append3.elec.tra,1),5)) % 5 tra rows
 
 % do not append (discard inconsistent sens information)
 append4 = ft_appendfreq([], freq_eeg, freq_meg);


### PR DESCRIPTION
Trumped down the functionality of appendsens. It's now simply concatenating and removing duplicates, while still checking the consistency between the relevant fields.

Are channels appended and are overlapping channels in multiple input dealt with?
a) yes
b) no
c) I prefer to give fuzzy answers
> A but also C of course

Are electrodes appended and are overlapping electrodes in multiple input dealt with?
a) yes
b) no
c) I prefer to give fuzzy answers
> idem as above

