### PR TITLE
improvement of ft_appendsens

### DIFF
--- a/ft_appendsens.m
+++ b/ft_appendsens.m
@@ -99,7 +99,6 @@ haschanori = 0;
 hasoptopos = 0;
 haslabelold = 0;
 haschanposold = 0;
-tramatch = 0;
 for i=1:length(varargin)
   % the following fields should be present in any sens structure
   if isfield(varargin{i}, 'label')

--- a/test/test_pull393.m
+++ b/test/test_pull393.m
@@ -194,7 +194,7 @@ append3 = ft_appendtimelock(cfg, timelock_ieeg, timelock_ieegb);
 assert(isequal(numel(append3.label),5)) % 5 ieeg labels
 assert(isequal(numel(append3.elec.label),5)) % 5 ieeg labels
 assert(isequal(size(append3.elec.elecpos,1),3)) % 3 original elecpos
-assert(isequal(size(append3.elec.tra),[5 3])) % FIXME this produces a 5x3 matrix, but the bottom half is zeros
+assert(isequal(size(append3.elec.tra),[5 3]))
 
 % do not append (discard inconsistent sens information)
 append4 = ft_appendtimelock([], timelock_eeg, timelock_meg);

--- a/test/test_pull393.m
+++ b/test/test_pull393.m
@@ -194,7 +194,7 @@ append3 = ft_appendtimelock(cfg, timelock_ieeg, timelock_ieegb);
 assert(isequal(numel(append3.label),5)) % 5 ieeg labels
 assert(isequal(numel(append3.elec.label),5)) % 5 ieeg labels
 assert(isequal(size(append3.elec.elecpos,1),3)) % 3 original elecpos
-assert(isequal(size(append3.elec.tra,1),5)) % 5 tra rows
+assert(isequal(size(append3.elec.tra),[5 3])) % FIXME this produces a 5x3 matrix, but the bottom half is zeros
 
 % do not append (discard inconsistent sens information)
 append4 = ft_appendtimelock([], timelock_eeg, timelock_meg);

--- a/test/test_pull434.m
+++ b/test/test_pull434.m
@@ -11,17 +11,17 @@ function test_pull434
 
 %% construct some electrode structures
 
-elec1.label = {'1', '2', '3'};
+elec1.label = {'1'; '2'; '3'};
 elec1.elecpos = [1 1 1; 2 2 2; 3 3 3];
 elec1.chanpos = [1 1 1; 2 2 2; 3 3 3];
 elec1.tra = eye(3);
 
-elec2.label = {'3', '4'};
+elec2.label = {'3'; '4'};
 elec2.elecpos = [3 3 3; 4 4 4];
 elec2.chanpos = [3 3 3; 4 4 4];
-elec2.tra = eye(3);
+elec2.tra = eye(2);
 
-elec3.label = {'4', '5', '6'};
+elec3.label = {'4'; '5'; '6'};
 elec3.elecpos = [4 4 4; 5 5 5; 6 6 6];
 elec3.chanpos = [4 4 4; 5 5 5; 6 6 6];
 elec3.tra = eye(3);
@@ -30,13 +30,19 @@ elec3.tra = eye(3);
 
 cfg = [];
 
-append1   = ft_appendsens(cfg, elec);
+append1   = ft_appendsens(cfg, elec1);
 append11  = ft_appendsens(cfg, elec1, elec1);
-append111 = ft_appendsens(cfg, elec1, elec1, elec13);
+append111 = ft_appendsens(cfg, elec1, elec1, elec1);
 
-assert(isequal(append1,   elec1));
-assert(isequal(append11,  elec1));
-assert(isequal(append111, elec1));
+assert(isequal(append1.label,   elec1.label));
+assert(isequal(append1.chanpos,   elec1.chanpos));
+assert(isequal(append1.tra,   elec1.tra));
+assert(isequal(append11.label,   elec1.label));
+assert(isequal(append11.chanpos,   elec1.chanpos));
+assert(isequal(append11.tra,   elec1.tra));
+assert(isequal(append111.label,   elec1.label));
+assert(isequal(append111.chanpos,   elec1.chanpos));
+assert(isequal(append111.tra,   elec1.tra));
 
 %%
 
@@ -83,17 +89,17 @@ elec1c.tra = eye(3);
 
 %%
 
-append11b = ft_appendsens(cfg, elec1, elec1b);
+append11b = ft_appendsens(cfg, elec1, elec1b); % same elec, diff chan
 
 assert(numel(append11b.label)==6);
 assert(size(append11b.chanpos,1)==6);
 assert(size(append11b.elecpos,1)==3);
-assert(isequal(size(append11b.tra), [6 3]));
+assert(isequal(size(append11b.tra), [6 3])); % FIXME this produces a 6x3 matrix, but the bottom half is zeros
 
 %%
 
 if false
-append11c = ft_appendsens(cfg, elec1, elec1c);
-% here I don't know yet what to expect
+append11c = ft_appendsens(cfg, elec1, elec1c); % same chan, diff elec
+% this should crash because there are 6 labels and only 3 chanpos
 end
 

--- a/test/test_pull434.m
+++ b/test/test_pull434.m
@@ -94,7 +94,7 @@ append11b = ft_appendsens(cfg, elec1, elec1b); % same elec, diff chan
 assert(numel(append11b.label)==6);
 assert(size(append11b.chanpos,1)==6);
 assert(size(append11b.elecpos,1)==3);
-assert(isequal(size(append11b.tra), [6 3])); % FIXME this produces a 6x3 matrix, but the bottom half is zeros
+assert(isequal(size(append11b.tra), [6 3]));
 
 %%
 


### PR DESCRIPTION
a couple of small fixes:

- removed old code that was somehow still present
- ensured label and labelold have a column orientation
- made computation of the tra matrix work for many more situations (as in test_pull393 and test_pull434)

open tra-related issue:

- ft_appendsens still cannot deal well with the situation in which two datasets have identical or overlapping elecpos but different chanpos, e.g.

elec1.label = {'1'; '2'; '3'};
elec1.elecpos = [1 1 1; 2 2 2; 3 3 3];
elec1.chanpos = [1 1 1; 2 2 2; 3 3 3];
elec1.tra = eye(3);

elec1b = elec1;
elec1b.label = {'1b', '2b', '3b'};
elec1b.chanpos = elec1.chanpos+10;

append11b = ft_appendsens([], elec1, elec1b);
append11b.tra

     1     0     0
     0     1     0
     0     0     1
     0     0     0
     0     0     0
     0     0     0

whereas this should produce two identity matrices on top of each other. Any suggestions per the implementation of the tra matrix computation/pruning are welcome (see FIXME in the code).
