### PR TITLE
bugfix: verify label is a column vector

### DIFF
--- a/utilities/ft_selectdata.m
+++ b/utilities/ft_selectdata.m
@@ -671,6 +671,7 @@ for k = 1:ndata
   end
   label      = union(label, selchannel);
 end
+label = label(:);   % ensure column array
 
 % this call to match_str ensures that that labels are always in the
 % order of the first input argument see bug_2917, but also temporarily keep


### PR DESCRIPTION
In case of one unique channel name per file, label became a row vector instead and threw an error when concatenation was attempted at line 681 (now 682).

This was such a small bug with such an easy fix, I didn't bother to make a bug report, but let me know if you'd prefer I do.  Also, let me know if it would be easier in the future for me to just suggest tiny changes like this, rather than creating a pull request.