### PR TITLE
bugfix - ensures COMNT field in layout is used when topoplotting 

### DIFF
--- a/private/topoplot_common.m
+++ b/private/topoplot_common.m
@@ -127,7 +127,7 @@ cfg.contournum        = ft_getopt(cfg, 'contournum',    6);
 cfg.colorbar          = ft_getopt(cfg, 'colorbar',      'no');
 cfg.shading           = ft_getopt(cfg, 'shading',       'flat');
 cfg.comment           = ft_getopt(cfg, 'comment',       'auto');
-cfg.commentpos        = ft_getopt(cfg, 'commentpos',    'leftbottom');
+cfg.commentpos        = ft_getopt(cfg, 'commentpos',    []);
 cfg.fontsize          = ft_getopt(cfg, 'fontsize',      8);
 cfg.fontweight        = ft_getopt(cfg, 'fontweight',    'normal');
 cfg.baseline          = ft_getopt(cfg, 'baseline',      'no'); %to avoid warning in timelock/freqbaseline
@@ -153,6 +153,15 @@ cfg.directionality    = ft_getopt(cfg, 'directionality',    []);
 cfg.channel           = ft_getopt(cfg, 'channel',           'all');
 cfg.figurename        = ft_getopt(cfg, 'figurename',        []);
 cfg.interpolatenan    = ft_getopt(cfg, 'interpolatenan',    'yes');
+
+% default commentpos
+if isempty(cfg,'commentpos')
+  if ~isempty(strcmp(cfg.layout.label,'COMNT')) % layout went through ft_prepare_layout in ft_topoplotER/TFR
+    cfg.commentpos = 'layout';
+  else
+    cfg.commentpos = 'leftbottom';
+  end
+end
 
 % compatibility for previous highlighting option
 if isnumeric(cfg.highlight)

--- a/private/topoplot_common.m
+++ b/private/topoplot_common.m
@@ -127,10 +127,10 @@ cfg.contournum        = ft_getopt(cfg, 'contournum',    6);
 cfg.colorbar          = ft_getopt(cfg, 'colorbar',      'no');
 cfg.shading           = ft_getopt(cfg, 'shading',       'flat');
 cfg.comment           = ft_getopt(cfg, 'comment',       'auto');
-cfg.commentpos        = ft_getopt(cfg, 'commentpos',    []);
+cfg.commentpos        = ft_getopt(cfg, 'commentpos',    []);  % default is handled further down
 cfg.fontsize          = ft_getopt(cfg, 'fontsize',      8);
 cfg.fontweight        = ft_getopt(cfg, 'fontweight',    'normal');
-cfg.baseline          = ft_getopt(cfg, 'baseline',      'no'); %to avoid warning in timelock/freqbaseline
+cfg.baseline          = ft_getopt(cfg, 'baseline',      'no'); % to avoid warning in timelock/freqbaseline
 cfg.trials            = ft_getopt(cfg, 'trials',        'all', 1);
 cfg.interactive       = ft_getopt(cfg, 'interactive',   'yes');
 cfg.hotkeys           = ft_getopt(cfg, 'hotkeys',       'no');
@@ -155,10 +155,13 @@ cfg.figurename        = ft_getopt(cfg, 'figurename',        []);
 cfg.interpolatenan    = ft_getopt(cfg, 'interpolatenan',    'yes');
 
 % default commentpos
-if isempty(cfg,'commentpos')
-  if ~isempty(strcmp(cfg.layout.label,'COMNT')) % layout went through ft_prepare_layout in ft_topoplotER/TFR
+if isempty(cfg, 'commentpos')
+  if ~isempty(strcmp(cfg.layout.label, 'COMNT')) 
+    % layout went through ft_prepare_layout in ft_topoplotER/TFR
+    % use the position that is specified in the layout
     cfg.commentpos = 'layout';
   else
+    % put it in the left bottom
     cfg.commentpos = 'leftbottom';
   end
 end


### PR DESCRIPTION
@robertoostenveld @StolkArjen 
This small commit fixes a bug visible in the ECoG pipeline figure 5, where in the second topo, the comment is annoying placed in the topo. This is because topoplot_common by default sets cfg.commentpos to leftbottom. 