### PR TITLE
FIX - implemented a work-around for the broken trial-selection in ft_multiplotER

### DIFF
--- a/private/rejectvisual_summary.m
+++ b/private/rejectvisual_summary.m
@@ -611,10 +611,17 @@ cfg_mp.layout  = info.cfg.layout;
 cfg_mp.channel = info.data.label(info.chansel);
 currfig = gcf;
 for n = 1:length(trls)
+  % ft_multiplotER should be able to make the selection, but fails due to http://bugzilla.fieldtriptoolbox.org/show_bug.cgi?id=2978
+  % that bug is hard to fix, hence it is solved here with a work-around
+  cfg_sd = [];
+  cfg_sd.trials = trls(n);
+  cfg_sd.avgoverrpt = 'yes';
+  cfg_sd.keeprpt = 'no';
+  tmpdata = ft_selectdata(cfg_sd, info.data);
+  
   figure()
-  cfg_mp.trials = trls(n);
   cfg_mp.interactive = 'yes';
-  ft_multiplotER(cfg_mp, info.data);
+  ft_multiplotER(cfg_mp, tmpdata);
   title(sprintf('Trial %i', trls(n)));
 end
 figure(currfig);

--- a/test/inspect_bug2978.m
+++ b/test/inspect_bug2978.m
@@ -1,0 +1,82 @@
+function inspect_bug2978
+
+ntrial = 5;
+
+%%
+
+data = [];
+data.label = {'1', '2', '3'};
+for i=1:ntrial
+  t = (1:1000)/1000;
+  s = sin(i*2*pi*t); % make a sine with 1, 2, 3, ... Hz
+  data.time{i} = t;
+  data.trial{i} = 0.1*randn(3,1000);
+  data.trial{i}(1,:) = s;  % insert it in the first channel
+end
+
+%%
+
+cfg = [];
+timelock = ft_timelockanalysis(cfg, data);
+
+cfg = [];
+cfg.layout = 'vertical';
+figure
+ft_multiplotER(cfg, timelock); % it should show a mix
+
+
+cfg = [];
+cfg.trials = 1;
+timelock1 = ft_timelockanalysis(cfg, data);
+
+cfg = [];
+cfg.trials = 2;
+timelock2 = ft_timelockanalysis(cfg, data);
+
+cfg = [];
+cfg.layout = 'vertical';
+figure
+ft_multiplotER(cfg, timelock1, timelock2); % it should show 1 and 2 Hz
+
+%%
+
+cfg = [];
+cfg.keeptrials = 'yes';
+timelock_all = ft_timelockanalysis(cfg, data);
+
+cfg = [];
+cfg.avgoverrpt = 'yes';
+cfg.trials = 1;
+timelock1 = ft_selectdata(cfg, timelock_all);
+
+figure
+plot(timelock1.time, timelock1.avg) % this stays the same, i.e. a frequency mix
+figure
+plot(timelock1.time, timelock1.trial) % this should show 1 Hz
+
+
+
+
+%%
+% THESE TWO ARE STILL FAILING ON 19 May 2017
+
+if false
+  
+  cfg = [];
+  cfg.layout = 'vertical';
+  cfg.trials = 1;
+  figure
+  ft_multiplotER(cfg, data); % it should show 1Hz
+  
+  cfg.trials = 2;
+  figure
+  ft_multiplotER(cfg, data); % it should show 2Hz
+  
+end
+
+%%
+
+cfg = [];
+cfg.layout = 'vertical';
+cfg.method = 'summary';
+ft_rejectvisual(cfg, data);


### PR DESCRIPTION
This causes ft_rejectvisual to show the average over trials. See http://bugzilla.fieldtriptoolbox.org/show_bug.cgi?id=2978.

The solution here is to use ft_selectdata to make a single-trial data structure and to pass that into ft_multiplotER