### PR TITLE
bugfix - allow for NaNs in trialinfo/sampleinfo/cumsumcnt/cumtapcnt w…

### DIFF
--- a/private/append_common.m
+++ b/private/append_common.m
@@ -104,7 +104,7 @@ switch cfg.appenddim
     for i=1:numel(fn)
       keepfield = isfield(varargin{1}, fn{i});
       for j=1:numel(varargin)
-        if ~isfield(varargin{j}, fn{i}) || ~isequal(varargin{j}.(fn{i}), varargin{1}.(fn{i}))
+        if ~isfield(varargin{j}, fn{i}) || ~isequalwithequalnans(varargin{j}.(fn{i}), varargin{1}.(fn{i}))
           keepfield = false;
           break
         end


### PR DESCRIPTION
…hen appending datasets

NaNs can be useful in the trialinfo field, e.g. when a numeric trial type code is not defined for a subset of trials.

For sampleinfo/cumsumcnt/cumtapcnt, the other affect fields when appending using the new append_common.m, I see no immediate reason for having a meaningful NaN. But, in case there is a NaN in identical locations of the input datasets, then why not keep them and their field? Otherwise, an exception is also fine of course.
