### PR TITLE
BUGFIX - important for ft_preproc_polyremoval

### DIFF
--- a/specest/private/ft_preproc_polyremoval.m
+++ b/specest/private/ft_preproc_polyremoval.m
@@ -59,6 +59,7 @@ if nargin<5 || isempty(order)
 end
 
 % This does not work on integer data
+typ = class(dat);
 if ~isa(dat, 'double') && ~isa(dat, 'single')
   dat = cast(dat, 'double');
 end


### PR DESCRIPTION
typ hast to be set in line 62, since it is used in the last line in ft_preproc_polyremoval