### PR TITLE
bugfix for bug3307 

### DIFF
--- a/fileio/private/read_trigger.m
+++ b/fileio/private/read_trigger.m
@@ -89,6 +89,12 @@ if denoise
 end
 
 if fixbiosemi
+  if ft_platform_supports('int32_logical_operations')
+    % convert to 32-bit integer representation and only preserve the lowest 24 bits
+    dat = bitand(int32(dat), 2^24-1);
+    % apparently the 24 bits are still shifted by one byte
+    dat = bitshift(dat,-8);
+  else
   % find indices of negative numbers
   signbit = find(dat < 0);
   % change type to double (otherwise bitcmp will fail)
@@ -101,6 +107,7 @@ if fixbiosemi
   dat(signbit) = dat(signbit)+(2^(24-1));
   % typecast the data to ensure that the status channel is represented in 32 bits
   dat = uint32(dat);
+  end
   
   byte1 = 2^8  - 1;
   byte2 = 2^16 - 1 - byte1;


### PR DESCRIPTION
see http://bugzilla.fieldtriptoolbox.org/show_bug.cgi?id=3307

Changed biosemi section in read_trigger to avoid call to bitcmp (arguments changed after matlab2012). It now matches the biosemi implementation for bdf files (in ft_read_events) more closely, with the only difference that apparently the status channel in biosemi .gdf files (at least in our research group) still require correction for having been shifted by one byte.

(see also: http://bugzilla.fieldtriptoolbox.org/show_bug.cgi?id=2409)