### PR TITLE
ft_databrowser timestamp

### DIFF
--- a/ft_databrowser.m
+++ b/ft_databrowser.m
@@ -2203,7 +2203,7 @@ end % function parseKeyboardEvent
 % SUBFUNCTION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 function cursortext = datacursortext(obj, event_obj)
-pos = get(event_obj, 'position');
+pos = get(event_obj, 'Position');
 
 linetype = getappdata(event_obj.Target, 'ft_databrowser_linetype');
 


### PR DESCRIPTION
Hi,
Here is a very simple fix of a bug preventing the proper display of custom data cursor text in ft_databrowser (see attached picture). Now I can get accurate timing of interesting events super easily! =)
Best,
Ludovic

![ft_databrowsertimestampfix](https://user-images.githubusercontent.com/28165157/28480198-6d99bd84-6e14-11e7-89be-1b2d7b81e2bb.png)
