### PR TITLE
prevention: ft_selecdata cannot deal with beta in the output of ft_re…

### DIFF
--- a/ft_regressconfound.m
+++ b/ft_regressconfound.m
@@ -25,7 +25,7 @@ function [data] = ft_regressconfound(cfg, datain)
 %   cfg.statistics  = string, 'yes' or 'no', whether to add the statistics
 %                     on the regression weights to the output (default = 'no')
 %   cfg.beta        = string, 'yes' or 'no', whether to add the beta
-%                     values as a field to the output (default = 'yes')
+%                     values as a field to the output (default = 'no')
 %   cfg.model       = string, 'yes' or 'no', whether to add the model to
 %                     the output (default = 'no')
 %   cfg.ftest       = string array, {N X Nconfounds}, to F-test whether
@@ -96,7 +96,7 @@ cfg.reject     = ft_getopt(cfg, 'reject', 'all');
 cfg.normalize  = ft_getopt(cfg, 'normalize', 'yes');
 cfg.model      = ft_getopt(cfg, 'model', 'no');
 cfg.statistics = ft_getopt(cfg, 'statistics', 'no');
-cfg.beta       = ft_getopt(cfg, 'beta', 'yes');
+cfg.beta       = ft_getopt(cfg, 'beta', 'no');
 cfg.ftest      = ft_getopt(cfg, 'ftest');
 cfg.parameter  = ft_getopt(cfg, 'parameter'); % the default is handled further down
 


### PR DESCRIPTION
…gressconfound. setting default to no for the moment

This is a temporary, not necessarily undesired, solution to prevent short term problems. 

For the long term, ft_selectdata should know how to deal with the beta field in the output of ft_regressconfound. The problem, as stated in https://github.com/fieldtrip/fieldtrip/pull/359, is that ft_selectdata with cfg.trials doesnt work on the beta field, simply because the beta is calculated across trials (i.e. regression analysis). 

There's the option in ft_selectdata to prevent certain fields from being touched upon, 'xtrafield' at line 178. However, if we add beta to it (which could be fine for a solution), it won't be possible to select channels or timepoints in it either. Moreover, ft_regressconfound also has the possibility of spitting out a stats and prob field related to the beta. If we're going the way described here, then we should maybe rename those fields into betastat and betaprob, so that stat and prob fields originating from the stats functions are not interfered with (when adding m to the xtrafield array).

Alternatively, ft_selectdata should ignore cfg.trials for the beta field but still allow for selecting channel and timepoints. But this seems to be more a complex fix given the current implementation.