### PR TITLE
only include FieldTrip functions in default message ID

### DIFF
--- a/fileio/ft_read_header.m
+++ b/fileio/ft_read_header.m
@@ -284,7 +284,7 @@ switch headerformat
     hdr.nTrials     = orig.TotalEpochs;
     hdr.label       = orig.ChannelOrder(:);
     [hdr.grad, elec] = bti2grad(orig);
-    if ~isempty(elec),
+    if ~isempty(elec)
       hdr.elec = elec;
     end
     
@@ -888,7 +888,7 @@ switch headerformat
     end
     
     % get hdr info from xml files
-    ws = warning('off', 'MATLAB:REGEXP:deprecated') % due to some small code xml2struct
+    ws = warning('off', 'MATLAB:REGEXP:deprecated'); % due to some small code xml2struct
     xmlfiles = dir( fullfile(filename, '*.xml'));
     disp('reading xml files to obtain header info...')
     for i = 1:numel(xmlfiles)
@@ -965,7 +965,8 @@ switch headerformat
           % this should be consistent with ft_senslabel
           hdr.label{iSens} = ['E' num2str(iSens)];
         end
-      else ft_warning('found less lables in xml.sensorLayout than channels in signal 1, thus can not use info in sensorLayout, creating labels on the fly')
+      else
+        ft_warning('found less lables in xml.sensorLayout than channels in signal 1, thus can not use info in sensorLayout, creating labels on the fly')
         for iSens = 1:orig.signal(1).blockhdr(1).nsignals
           % this should be consistent with ft_senslabel
           hdr.label{iSens} = ['E' num2str(iSens)];
@@ -985,7 +986,8 @@ switch headerformat
             for iSens = length(hdr.label)+1 : orig.signal(1).blockhdr(1).nsignals + orig.signal(2).blockhdr(1).nsignals
               hdr.label{iSens} = ['s2_unknown', num2str(iSens)];
             end
-          else ft_warning('found more lables in xml.pnsSet than channels in signal 2, thus can not use info in pnsSet, and labeling with s2_eN instead')
+          else
+            ft_warning('found more lables in xml.pnsSet than channels in signal 2, thus can not use info in pnsSet, and labeling with s2_eN instead')
             for iSens = orig.signal(1).blockhdr(1).nsignals+1 : orig.signal(1).blockhdr(1).nsignals + orig.signal(2).blockhdr(1).nsignals
               hdr.label{iSens} = ['s2_E', num2str(iSens)];
             end
@@ -1784,7 +1786,7 @@ switch headerformat
       info.epochs     = epochs;  % this is used by read_data to get the actual data, i.e. to prevent re-reading
       
     elseif isaverage
-      try,
+      try
         evoked_data    = fiff_read_evoked_all(filename);
         vartriallength = any(diff([evoked_data.evoked.first])) || any(diff([evoked_data.evoked.last]));
         if vartriallength

--- a/utilities/private/ft_notification.m
+++ b/utilities/private/ft_notification.m
@@ -64,8 +64,16 @@ switch stack(2).name
     error('this function cannot be called from %s', stack(2).name);
 end
 
-% remove this function itself and the calling function
+% remove this function itself and the ft_xxx calling function
 stack = stack(3:end);
+
+% remove the non-FieldTrip functions from the path, these should not be part of the default message identifier
+keep = true(size(stack));
+[v, p] = ft_version;
+for i=1:numel(stack)
+  keep(i) = strncmp(p, stack(i).file, length(p));
+end
+stack = stack(keep);
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% handle the defaults
@@ -384,7 +392,11 @@ switch varargin{1}
       
       % decide whether a verboe message should be shown
       if istrue(getstate(s, 'verbose'))
-        fprintf('Type "ft_%s off %s" to suppress this message.\n', level, msgId)
+        if ~isempty(msgId)
+          fprintf('Type "ft_%s off %s" to suppress this message.\n', level, msgId)
+        else
+          fprintf('Type "ft_%s off" to suppress this message.\n', level)
+        end
       end
       
     end % if msgState is on


### PR DESCRIPTION
for warnings. See http://bugzilla.fieldtriptoolbox.org/show_bug.cgi?id=3324#c1 and thanks to @gllmflndn 

The ft_read_header commit has nothing to do with it, but I just encountered a minor bug when testing this commit. 