### PR TITLE
enh: added options that may improve the fitting procedure

### DIFF
--- a/ft_electroderealign.m
+++ b/ft_electroderealign.m
@@ -99,8 +99,7 @@ function [elec_realigned] = ft_electroderealign(cfg, elec_original)
 %   cfg.headshape      = a filename containing headshape, a structure containing a
 %                        single triangulated boundary, or a Nx3 matrix with surface
 %                        points
-%   cfg.feedback       = 'yes' or 'no' (feedback includes the output of the iteration
-%                        procedure.
+%   cfg.feedback       = 'yes' or 'no' (default), feedback of the iteration procedure
 %
 % If you want to move the electrodes inward, you should specify
 %   cfg.moveinward     = number, the distance that the electrode should be moved
@@ -408,7 +407,7 @@ elseif strcmp(cfg.method, 'headshape')
   
   norm.label = elec.label;
   if strcmp(cfg.warp, 'dykstra2012')
-    norm.elecpos = warp_dykstra2012(elec.elecpos, headshape, cfg.feedback);
+    norm.elecpos = warp_dykstra2012(cfg, elec, headshape);
   elseif strcmp(cfg.warp, 'fsaverage')
     subj_pial = ft_read_headshape(cfg.headshape);
     [PATHSTR, NAME] = fileparts(cfg.headshape); % lh or rh

--- a/private/warp_dykstra2012.m
+++ b/private/warp_dykstra2012.m
@@ -1,4 +1,4 @@
-function [coord_snapped] = warp_dykstra2012(coord, surf, feedback)
+function [coord_snapped] = warp_dykstra2012(cfg, elec, surf)
 
 % WARP_DYKSTRA2012 projects the ECoG grid / strip onto a cortex hull
 % while minimizing the distance from original positions and the
@@ -12,7 +12,7 @@ function [coord_snapped] = warp_dykstra2012(coord, surf, feedback)
 %
 % See also FT_ELECTRODEREALIGN, FT_PREPARE_MESH
 
-% Copyright (C) 2012-2016, Gio Piantoni, Andrew Dykstra
+% Copyright (C) 2012-2017, Arjen Stolk, Gio Piantoni, Andrew Dykstra
 %
 % This program is free software; you can redistribute it and/or modify
 % it under the terms of the GNU General Public License as published by
@@ -49,16 +49,24 @@ function [coord_snapped] = warp_dykstra2012(coord, surf, feedback)
 % determine whether the MATLAB Optimization toolbox is available and can be used
 ft_hastoolbox('optim', 1);
 
-disp('Please cite: Dykstra et al. 2012 Neuroimage PMID: 22155045')
+disp('using warp algorithm described in Dykstra et al. 2012 Neuroimage PMID: 22155045')
+
+% set the defaults
+cfg.feedback      = ft_getopt(cfg, 'feedback', 'no');
+
+% undocumented local options
+cfg.pairingmethod = ft_getopt(cfg, 'pairingmethod', 'pos'); % eletrode pairing based on electrode 'pos' or 'label' (for computing deformation energy)
+cfg.deformweight  = ft_getopt(cfg, 'deformweight',  1); % weight of deformation relative to shift energy cost
 
 % get starting coordinates
-coord0 = coord;
+coord0 = elec.elecpos;
+coord = elec.elecpos;
 
 % compute pairs of neighbors
-pairs = knn_pairs(coord, 4);
+pairs = create_elecpairs(elec, cfg.pairingmethod);
 
 % anonymous function handles
-efun = @(coord_snapped) energy_electrodesnap(coord_snapped, coord, pairs);
+efun = @(coord_snapped) energy_electrodesnap(coord_snapped, coord, pairs, cfg.deformweight);
 cfun = @(coord_snapped) dist_to_surface(coord_snapped, surf);
 
 % options
@@ -76,45 +84,44 @@ options = optimset('Algorithm','active-set',...
   'Diagnostics', 'off',...
   'RelLineSrchBnd',1);
 
-
-if strcmp(feedback, 'yes')
+if strcmp(cfg.feedback, 'yes')
   options = optimset(options, 'Display', 'iter');
 else
   options = optimset(options, 'Display', 'final');
 end
 
-% run minimization
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Energy Minimization
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% run minimization: efun (shift + deform energy) is minimized; cfun (surface distance) is a nonlinear constraint
 coord_snapped = fmincon(efun, coord0, [], [], [], [], [], [], cfun, options);
 
-end
-
-function [energy, denergy] = energy_electrodesnap(coord, coord_orig, pairs)
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% SUBFUNCTION
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+function energy = energy_electrodesnap(coord, coord_orig, pairs, deformweight) % (minimized) energy function
 % ENERGY_ELECTRODESNAP compute energy to be minimized, based on deformation
 % and distance of the electrodes from original distance
 
+% energy needed to move electrodes to the surface
 energy_eshift = sum((coord - coord_orig).^2, 2);
-energy_deform = deformation_energy(coord, coord_orig, pairs);
-energy = mean(energy_eshift) + mean(energy_deform.^2);
 
-denergy=[];
+% energy needed to deform grid shape
+dist = sqrt(sum((coord(pairs(:, 1), :) - coord(pairs(:, 2), :)).^2, 2));
+dist_orig = sqrt(sum((coord_orig(pairs(:, 1), :) - coord_orig(pairs(:, 2), :)).^2, 2));
+energy_deform = (dist - dist_orig).^2;
 
-end
+% (weighted) sum of the above
+energy = mean(energy_eshift) + (deformweight * mean(energy_deform.^2));
 
-function energy = deformation_energy(coord, coord_orig, pairs)
-% DEFORMATION_ENERGY measure energy due to grid deformation
-
-dist = sqrt(sum((coord(pairs(:, 1), :) - coord(pairs(:, 2), :)) .^ 2, 2));
-dist_orig = sqrt(sum((coord_orig(pairs(:, 1), :) - coord_orig(pairs(:, 2), :)) .^ 2, 2));
-
-energy = (dist - dist_orig) .^2;
-end
-
-function [c, dist] = dist_to_surface(coord, surf)
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% SUBFUNCTION
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+function [c, dist] = dist_to_surface(coord, surf) % (nonlinear) constraint function
 % DIST_TO_SURFACE Compute distance to surface, this is the fastest way to run
 % it, although running the loops in other directions might be more intuitive.
 
 c = [];
-
 dist = zeros(size(coord, 1), 1);
 for i0 = 1:size(coord, 1)
   dist_one_elec = zeros(size(surf.pos, 1), 1);
@@ -125,8 +132,161 @@ for i0 = 1:size(coord, 1)
 end
 dist = sqrt(dist);
 
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% SUBFUNCTION
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+function pairs = create_elecpairs(elec, method)
+
+if strcmp(method, 'label'); 
+  
+  % determine grid dimensions (1st dim: number of arrays, 2nd dim: number of elecs in an array)
+  fprintf('creating electrode pairs based on electrode labels\n');
+  GridDim = determine_griddim(elec);
+  
+  % create pairs based on dimensions
+  diagonal = 1;
+  pairs = [];
+  for e = 1:GridDim(1)*GridDim(2)   
+    if isequal(mod(e,GridDim(2)), 1) % begin of each elec array
+      pairs(end+1,:) = [e e+1]; % following elec
+      pairs(end+1,:) = [e e-GridDim(2)]; % adjacent preceding elec
+      pairs(end+1,:) = [e e+GridDim(2)]; % adjacent following elec
+      if diagonal
+        pairs(end+1,:) = [e e-GridDim(2)+1]; % adjacent preceding elec
+        pairs(end+1,:) = [e e+GridDim(2)+1]; % adjacent following elec
+      end
+    elseif isequal(mod(e,GridDim(2)), 0) % end of each elec array
+      pairs(end+1,:) = [e e-1]; % preceding elec
+      pairs(end+1,:) = [e e-GridDim(2)]; % adjacent preceding elec
+      pairs(end+1,:) = [e e+GridDim(2)]; % adjacent following elec
+      if diagonal
+        pairs(end+1,:) = [e e-GridDim(2)-1]; % adjacent preceding elec
+        pairs(end+1,:) = [e e+GridDim(2)-1]; % adjacent following elec
+      end
+    else
+      pairs(end+1,:) = [e e-1]; % preceding elec
+      pairs(end+1,:) = [e e+1]; % following elec
+      pairs(end+1,:) = [e e-GridDim(2)]; % adjacent preceding elec
+      pairs(end+1,:) = [e e+GridDim(2)]; % adjacent following elec
+      if diagonal
+        pairs(end+1,:) = [e e-GridDim(2)-1]; % adjacent preceding elec
+        pairs(end+1,:) = [e e+GridDim(2)-1]; % adjacent following elec
+        pairs(end+1,:) = [e e-GridDim(2)+1]; % adjacent preceding elec
+        pairs(end+1,:) = [e e+GridDim(2)+1]; % adjacent following elec
+      end
+    end
+  end
+  pairs( pairs(:,2)<1 | pairs(:,2)>GridDim(1)*GridDim(2) ,:) = []; % out of bounds
+  pairs = unique(sort(pairs,2),'rows'); % unique pairs
+ 
+elseif strcmp(method, 'pos');
+  
+  % KNN_PAIRS compute pairs of neighbors of the grid
+  fprintf('creating electrode pairs based on electrode positions\n');
+  pairs = knn_pairs(elec.elecpos, 4);
+  
 end
 
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% SUBFUNCTION
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+function GridDim = determine_griddim(elec)
+% inspired by write_bioimage_mgrid, assumes intact grids and elec count starting at 1
+
+% extract numbers from elec labels
+labels = regexp(elec.label, '\d+', 'match');
+labels = [labels{:}]';
+
+% determine grid dimensions (1st dim: number of arrays, 2nd dim: number of elecs in an array)
+if isequal(numel(labels), 256)
+  GridDim(1) = 16; GridDim(2) = 16;
+elseif isequal(numel(labels), 64)
+  GridDim(1) = 8; GridDim(2) = 8;
+elseif isequal(numel(labels), 48)
+  e6 = elec.elecpos(match_str(labels, num2str(6)),:);
+  e7 = elec.elecpos(match_str(labels, num2str(7)),:);
+  e8 = elec.elecpos(match_str(labels, num2str(8)),:);
+  e9 = elec.elecpos(match_str(labels, num2str(9)),:);
+  d6to7 = sqrt(sum((e6-e7).^2)); % distance of elec 6 to 7
+  d8to9 = sqrt(sum((e8-e9).^2)); % distance of elec 8 to 9
+  if d8to9 >= d6to7  % break between e8 and e9
+    GridDim(1) = 6; GridDim(2) = 8;
+  elseif d6to7 > d8to9 % break between e6 and e7
+    GridDim(1) = 8; GridDim(2) = 6;
+  end
+elseif isequal(numel(labels), 32)
+  e4 = elec.elecpos(match_str(labels, num2str(4)),:);
+  e5 = elec.elecpos(match_str(labels, num2str(5)),:);
+  e8 = elec.elecpos(match_str(labels, num2str(8)),:);
+  e9 = elec.elecpos(match_str(labels, num2str(9)),:);
+  d4to5 = sqrt(sum((e4-e5).^2)); % distance of elec 4 to 5
+  d8to9 = sqrt(sum((e8-e9).^2)); % distance of elec 8 to 9
+  if d8to9 >= d4to5  % break between e8 and e9
+    GridDim(1) = 4; GridDim(2) = 8;
+  elseif d4to5 > d8to9 % break between e4 and e5
+    GridDim(1) = 8; GridDim(2) = 4;
+  end
+elseif isequal(numel(labels), 20)
+  e4 = elec.elecpos(match_str(labels, num2str(4)),:);
+  e5 = elec.elecpos(match_str(labels, num2str(5)),:);
+  e6 = elec.elecpos(match_str(labels, num2str(6)),:);
+  d4to5 = sqrt(sum((e4-e5).^2)); % distance of elec 4 to 5
+  d5to6 = sqrt(sum((e5-e6).^2)); % distance of elec 5 to 6
+  if d5to6 >= d4to5 % break between e5 and e6
+    GridDim(1) = 4; GridDim(2) = 5;
+  elseif d4to5 > d5to6 % break between e4 and e5
+    GridDim(1) = 5; GridDim(2) = 4;
+  end
+elseif isequal(numel(labels), 16)
+  e4 = elec.elecpos(match_str(labels, num2str(4)),:);
+  e5 = elec.elecpos(match_str(labels, num2str(5)),:);
+  e8 = elec.elecpos(match_str(labels, num2str(8)),:);
+  e9 = elec.elecpos(match_str(labels, num2str(9)),:);
+  d4to5 = sqrt(sum((e4-e5).^2)); % distance of elec 4 to 5
+  d8to9 = sqrt(sum((e8-e9).^2)); % distance of elec 8 to 9
+  if d8to9 > 2*d4to5 % break between e8 and e9
+    GridDim(1) = 2; GridDim(2) = 8;
+  elseif d4to5 > 2*d8to9 % break between e4 and e5
+    GridDim(1) = 4; GridDim(2) = 4;
+  else
+    GridDim(1) = 1; GridDim(2) = 16;
+  end
+elseif isequal(numel(labels), 12) % neglecting 3x4 and 4x3
+  e5 = elec.elecpos(match_str(labels, num2str(5)),:);
+  e6 = elec.elecpos(match_str(labels, num2str(6)),:);
+  e7 = elec.elecpos(match_str(labels, num2str(7)),:);
+  d5to6 = sqrt(sum((e5-e6).^2)); % distance of elec 5 to 6
+  d6to7 = sqrt(sum((e6-e7).^2)); % distance of elec 6 to 7
+  if d6to7 > 2*d5to6 % break between e6 and e7
+    GridDim(1) = 2; GridDim(2) = 6;
+  else
+    GridDim(1) = 1; GridDim(2) = 12;
+  end
+elseif isequal(numel(labels), 8)
+  e3 = elec.elecpos(match_str(labels, num2str(3)),:);
+  e4 = elec.elecpos(match_str(labels, num2str(4)),:);
+  e5 = elec.elecpos(match_str(labels, num2str(5)),:);
+  d3to4 = sqrt(sum((e3-e4).^2)); % distance of elec 3 to 4
+  d4to5 = sqrt(sum((e4-e5).^2)); % distance of elec 4 to 5
+  if d4to5 > 2*d3to4 % break between e4 and e5
+    GridDim(1) = 2; GridDim(2) = 4;
+  else
+    GridDim(1) = 1; GridDim(2) = 8;
+  end
+else
+  GridDim(1) = 1; GridDim(2) = numel(labels);
+end
+
+% provide feedback of what grid dimensions were found
+if any(GridDim==1) % if not because of strips, this could happen in case of missing electrodes
+  warning('assuming grid dimensions are %d by %d: if incorrect, use cfg.pairingmethod = ''pos'' instead\n', GridDim(1), GridDim(2));
+else
+  fprintf('assuming grid dimensions are %d by %d\n', GridDim(1), GridDim(2));
+end
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% SUBFUNCTION
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 function pairs = knn_pairs(coord, k)
 % KNN_PAIRS compute pairs of neighbors of the grid
 
@@ -136,8 +296,9 @@ pairs = permute(pairs,[3 1 2]);
 pairs = sort(reshape(pairs,2,[]),1)';
 pairs = unique(pairs,'rows');
 
-end
-
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% SUBFUNCTION
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 function idx = knn_search(Q, R, K)
 %KNN_SEARCH perform search using k-Nearest Neighbors algorithm
 
@@ -155,6 +316,4 @@ for k = 1:N
   [s, t] = sort(d);
   idx(k, :) = t(1:K);
   D(k, :)= s(1:K);
-end
-
 end


### PR DESCRIPTION
Changed documentation and function structure, and added the following features:

% undocumented local options
cfg.pairingmethod = ft_getopt(cfg, 'pairingmethod', 'pos'); % eletrode pairing based on electrode 'pos' or 'label' (for computing deformation energy)
cfg.deformweight  = ft_getopt(cfg, 'deformweight',  1); % weight of deformation relative to shift energy cost

Despite that the added features may benefit the fitting procedure, for now all default behavior of the function remains the same. Future changes therein are dependent on feedback following use internally and externally.
 