### PR TITLE
bugfix: dissimilar structure error when loading dicom series

### DIFF
--- a/external/freesurfer/load_dicom_fl.m
+++ b/external/freesurfer/load_dicom_fl.m
@@ -15,7 +15,9 @@ function [vol, M, dcminfo, mr_parms] = load_dicom_fl(flist)
 %
 % Does not handle multiple frames correctly yet.
 %
-
+% Bugfix: added feature that ensures similar structures across a dicom 
+% series by removing fields not present in the first file of the series
+% Arjen Stolk, August 2017
 
 %
 % load_dicom_fl.m
@@ -64,6 +66,7 @@ for n = 1:nfiles
       fprintf('ERROR: series number inconsistency (%s)\n',fname);
       return;
     end
+    tmpinfo = checkstructsim(tmpinfo, dcminfo0); % avoid dissimilar structures
   end
   tmpinfo.fname = fname;
   dcminfo0(n) = tmpinfo;
@@ -194,4 +197,15 @@ function dcminfo2 = sort_by_sliceloc(dcminfo)
 return;
 
 %----------------------------------------------------------%
+function dcminfo = checkstructsim(dcminfo, dcminfolist)
+% this subfunction ensures similar structures across a dicom series by 
+% removing fields not present in the first file of the series
+% Arjen Stolk, 2017
 
+fields = fieldnames(dcminfo);
+fidx = find(ismember(fields, fieldnames(dcminfolist(1)))==0); % fields not present in dcminfolist
+if ~isempty(fidx)
+  dcminfo = rmfield(dcminfo, fields(fidx));
+end
+
+return;

--- a/external/freesurfer/load_dicom_series.m
+++ b/external/freesurfer/load_dicom_series.m
@@ -16,7 +16,9 @@ function [vol, M, tmpdcminfo, mr_parms] = load_dicom_series(seriesno,dcmdir,dcmf
 %
 % Bugs: will not load multiple frames or mosaics properly.
 %
-
+% Bugfix: added feature that ensures similar structures across a dicom 
+% series by removing fields not present in the first file of the series
+% Arjen Stolk, August 2017
 
 %
 % load_dicom_series.m
@@ -82,6 +84,9 @@ for n = 1:nfiles
     if(isfield(dcminfo,'SeriesNumber'))
       if(dcminfo.SeriesNumber == seriesno)
         seriesflist = strvcat(seriesflist,pathname);
+        if(nth > 1)
+          dcminfo = checkstructsim(dcminfo, dcminfolist); % avoid dissimilar structures
+        end
         dcminfolist(nth) = dcminfo;
         dcminfo0 = dcminfo;
         nth = nth+1;
@@ -121,6 +126,21 @@ if(~isempty(ind))
   end
 else
   dcmdir = '.';
+end
+
+return;
+
+
+%---------------------------------------------------%
+function dcminfo = checkstructsim(dcminfo, dcminfolist)
+% this subfunction ensures similar structures across a dicom series by 
+% removing fields not present in the first file of the series
+% Arjen Stolk, 2017
+
+fields = fieldnames(dcminfo);
+fidx = find(ismember(fields, fieldnames(dcminfolist(1)))==0); % fields not present in dcminfolist
+if ~isempty(fidx)
+  dcminfo = rmfield(dcminfo, fields(fidx));
 end
 
 return;


### PR DESCRIPTION
This fixes an (annoying) bug that prevented the reading of several dicom series. However, it's a fix in code from an external toolbox (freesurfer), and I don't see any way of fixing it somewhere else. What do you think, RO and/or JM?

The problem: when a dicom file in a series doesn't have exactly the same fields as any other file in that series, matlab will throw a 'Subscripted assignment between dissimilar structures' error. See also report here: http://bugzilla.fieldtriptoolbox.org/show_bug.cgi?id=1772 
The consequence is that this dicom series is lost for use with fieldtrip.

The fix: a subfunction in load_dicom_series and load_dicom_fl (checkstructsim) that removes fields from files not present in the first file of the series.  Ideally, this fix was implemented internally, as it may get lost when the external (freesurfer) code is updated. But I don't see how.