### PR TITLE
FIX+OCTAVE: use ft_warning with parenthesis, because without them Octave throws a syntax error

### DIFF
--- a/fileio/private/ft_hastoolbox.m
+++ b/fileio/private/ft_hastoolbox.m
@@ -495,9 +495,9 @@ if isdeployed
   status = 1;
 elseif exist(toolbox, 'dir')
   if ~silent
-    ft_warning off backtrace
+    ft_warning('off','backtrace');
     ft_warning('adding %s toolbox to your MATLAB path', toolbox);
-    ft_warning on backtrace
+    ft_warning('on','backtrace');
   end
   if any(~cellfun(@isempty, regexp(toolbox, {'spm2', 'spm5', 'spm8', 'spm12'})))
     % SPM needs to be added with the subdirectories

--- a/forward/private/ft_hastoolbox.m
+++ b/forward/private/ft_hastoolbox.m
@@ -495,9 +495,9 @@ if isdeployed
   status = 1;
 elseif exist(toolbox, 'dir')
   if ~silent
-    ft_warning off backtrace
+    ft_warning('off','backtrace');
     ft_warning('adding %s toolbox to your MATLAB path', toolbox);
-    ft_warning on backtrace
+    ft_warning('on','backtrace');
   end
   if any(~cellfun(@isempty, regexp(toolbox, {'spm2', 'spm5', 'spm8', 'spm12'})))
     % SPM needs to be added with the subdirectories

--- a/inverse/private/ft_hastoolbox.m
+++ b/inverse/private/ft_hastoolbox.m
@@ -495,9 +495,9 @@ if isdeployed
   status = 1;
 elseif exist(toolbox, 'dir')
   if ~silent
-    ft_warning off backtrace
+    ft_warning('off','backtrace');
     ft_warning('adding %s toolbox to your MATLAB path', toolbox);
-    ft_warning on backtrace
+    ft_warning('on','backtrace');
   end
   if any(~cellfun(@isempty, regexp(toolbox, {'spm2', 'spm5', 'spm8', 'spm12'})))
     % SPM needs to be added with the subdirectories

--- a/preproc/ft_preproc_bandpassfilter.m
+++ b/preproc/ft_preproc_bandpassfilter.m
@@ -294,16 +294,16 @@ catch
     case 'no'
       rethrow(lasterror);
     case 'reduce'
-      ft_warning off backtrace
+      ft_warning('off','backtrace');
       ft_warning('instability detected - reducing the %dth order filter to an %dth order filter', N, N-1);
-      ft_warning on backtrace
+      ft_warning('on','backtrace');
       filt = ft_preproc_bandpassfilter(dat,Fs,Fbp,N-1,type,dir,instabilityfix);
     case 'split'
       N1 = ceil(N/2);
       N2 = floor(N/2);
-      ft_warning off backtrace
+      ft_warning('off','backtrace');
       ft_warning('instability detected - splitting the %dth order filter in a sequential %dth and a %dth order filter', N, N1, N2);
-      ft_warning on backtrace
+      ft_warning('on','backtrace');
       filt = ft_preproc_bandpassfilter(dat ,Fs,Fbp,N1,type,dir,instabilityfix);
       filt = ft_preproc_bandpassfilter(filt,Fs,Fbp,N2,type,dir,instabilityfix);
     otherwise

--- a/preproc/ft_preproc_bandstopfilter.m
+++ b/preproc/ft_preproc_bandstopfilter.m
@@ -291,16 +291,16 @@ catch
     case 'no'
       rethrow(lasterror);
     case 'reduce'
-      ft_warning off backtrace
+      ft_warning('off','backtrace');
       ft_warning('instability detected - reducing the %dth order filter to an %dth order filter', N, N-1);
-      ft_warning on backtrace
+      ft_warning('on','backtrace');
       filt = ft_preproc_bandstopfilter(dat,Fs,Fbp,N-1,type,dir,instabilityfix);
     case 'split'
       N1 = ceil(N/2);
       N2 = floor(N/2);
-      ft_warning off backtrace
+      ft_warning('off','backtrace');
       ft_warning('instability detected - splitting the %dth order filter in a sequential %dth and a %dth order filter', N, N1, N2);
-      ft_warning on backtrace
+      ft_warning('on','backtrace');
       filt1 = ft_preproc_bandstopfilter(dat  ,Fs,Fbp,N1,type,dir,instabilityfix);
       filt  = ft_preproc_bandstopfilter(filt1,Fs,Fbp,N2,type,dir,instabilityfix);
     otherwise

--- a/preproc/ft_preproc_highpassfilter.m
+++ b/preproc/ft_preproc_highpassfilter.m
@@ -285,16 +285,16 @@ catch
     case 'no'
       rethrow(lasterror);
     case 'reduce'
-      ft_warning off backtrace
+      ft_warning('off','backtrace');
       ft_warning('filter instability detected - reducing the %dth order filter to an %dth order filter', N, N-1);
-      ft_warning on backtrace
+      ft_warning('on','backtrace');
       filt = ft_preproc_highpassfilter(dat,Fs,Fhp,N-1,type,dir,instabilityfix);
     case 'split'
       N1 = ceil(N/2);
       N2 = floor(N/2);
-      ft_warning off backtrace
+      ft_warning('off','backtrace');
       ft_warning('filter instability detected - splitting the %dth order filter in a sequential %dth and a %dth order filter', N, N1, N2);
-      ft_warning on backtrace
+      ft_warning('on','backtrace');
       filt = ft_preproc_highpassfilter(dat ,Fs,Fhp,N1,type,dir,instabilityfix);
       filt = ft_preproc_highpassfilter(filt,Fs,Fhp,N2,type,dir,instabilityfix);
     otherwise

--- a/preproc/ft_preproc_lowpassfilter.m
+++ b/preproc/ft_preproc_lowpassfilter.m
@@ -287,16 +287,16 @@ catch
     case 'no'
       rethrow(lasterror);
     case 'reduce'
-      ft_warning off backtrace
+      ft_warning('off','backtrace');
       ft_warning('instability detected - reducing the %dth order filter to an %dth order filter', N, N-1);
-      ft_warning on backtrace
+      ft_warning('on','backtrace');
       filt = ft_preproc_lowpassfilter(dat,Fs,Flp,N-1,type,dir,instabilityfix);
     case 'split'
       N1 = ceil(N/2);
       N2 = floor(N/2);
-      ft_warning off backtrace
+      ft_warning('off','backtrace');
       ft_warning('instability detected - splitting the %dth order filter in a sequential %dth and a %dth order filter', N, N1, N2);
-      ft_warning on backtrace
+      ft_warning('on','backtrace');
       filt = ft_preproc_lowpassfilter(dat ,Fs,Flp,N1,type,dir,instabilityfix);
       filt = ft_preproc_lowpassfilter(filt,Fs,Flp,N2,type,dir,instabilityfix);
     otherwise

--- a/specest/private/ft_preproc_bandpassfilter.m
+++ b/specest/private/ft_preproc_bandpassfilter.m
@@ -294,16 +294,16 @@ catch
     case 'no'
       rethrow(lasterror);
     case 'reduce'
-      ft_warning off backtrace
+      ft_warning('off','backtrace');
       ft_warning('instability detected - reducing the %dth order filter to an %dth order filter', N, N-1);
-      ft_warning on backtrace
+      ft_warning('on','backtrace');
       filt = ft_preproc_bandpassfilter(dat,Fs,Fbp,N-1,type,dir,instabilityfix);
     case 'split'
       N1 = ceil(N/2);
       N2 = floor(N/2);
-      ft_warning off backtrace
+      ft_warning('off','backtrace');
       ft_warning('instability detected - splitting the %dth order filter in a sequential %dth and a %dth order filter', N, N1, N2);
-      ft_warning on backtrace
+      ft_warning('on','backtrace');
       filt = ft_preproc_bandpassfilter(dat ,Fs,Fbp,N1,type,dir,instabilityfix);
       filt = ft_preproc_bandpassfilter(filt,Fs,Fbp,N2,type,dir,instabilityfix);
     otherwise

--- a/utilities/ft_hastoolbox.m
+++ b/utilities/ft_hastoolbox.m
@@ -495,9 +495,9 @@ if isdeployed
   status = 1;
 elseif exist(toolbox, 'dir')
   if ~silent
-    ft_warning off backtrace
+    ft_warning('off','backtrace');
     ft_warning('adding %s toolbox to your MATLAB path', toolbox);
-    ft_warning on backtrace
+    ft_warning('on','backtrace');
   end
   if any(~cellfun(@isempty, regexp(toolbox, {'spm2', 'spm5', 'spm8', 'spm12'})))
     % SPM needs to be added with the subdirectories


### PR DESCRIPTION
Recent tests using Travs of FieldTrip results in failures (e.g. https://travis-ci.org/CoSMoMVPA/CoSMoMVPA/jobs/276506018)

This is because expressions such as 
```
ft_warning backtrace on
```
give an error in Octave when used inside a function. Using the functional form, as in 
```
ft_warning('backtrace','on');
```
works fine.

Commit e1519009c97585bfcb2c923590e7bcd6ff826c96 introduced the use ft_warning without parenthesis. 

This PR partially reverts that commit.