### PR TITLE
FIX - avoid misleading/useless warning relating to ft_rejectartifacts

### DIFF
--- a/ft_rejectartifact.m
+++ b/ft_rejectartifact.m
@@ -517,6 +517,7 @@ else
   if hasdata && ~strcmp(cfg.artfctdef.reject, 'nan') % Skip this step to avoid removing parts that should be filled with nans
     % apply the updated trial definition on the data
     tmpcfg     = keepfields(cfg, {'trl', 'showcallinfo'});
+    data       = rmfield(data, {'trialinfo'});
     data       = ft_redefinetrial(tmpcfg, data);
     if isfield(data, 'offset')
       data = rmfield(data, 'offset');


### PR DESCRIPTION
ft_rejectartifact – field trialinfo from original data removed in line 520 to avoid the appeareance of the in this case misleading warning - Original data has trialinfo, using user specified trialinfo instead – in ft_redefinetrial.