### PR TITLE
nutmegtrip: add vector plotting feature (for orientations, etc.)

### DIFF
--- a/contrib/nutmegtrip/nmt_sourceoriplot.m
+++ b/contrib/nutmegtrip/nmt_sourceoriplot.m
@@ -1,0 +1,51 @@
+function nmt_sourceoriplot(cfg,source)
+% NMT_SOURCEORIPLOT
+% plots functional source orientation data on slices or on
+% a surface, optionally as an overlay on anatomical MRI data, where
+% statistical data can be used to determine the opacity of the mask. Input
+% data comes from FT_SOURCEANALYSIS.
+%
+% Use as
+%   ft_sourceoriplot(cfg, data)
+%
+% No cfg options are implemented yet.
+%
+% Requires spm_ov_quivernmt.m to be installed as SPM plugin in
+% spm_orthviews subdirectory
+
+global st
+
+% check that spm_ov_quivernmt has been installed in the SPM plug-in directory
+if(~exist('spm_orthviews/spm_ov_quivernmt.m','file'))
+    error(['Please move or link ' which('spm_ov_quivernmt') ' to: ' fileparts(which('spm_ov_reorient.m'))])
+end
+
+ori = cell2mat(source.avg.ori)';
+
+fname{1} = fullfile(tempdir,'oriX.nii');
+fname{2} = fullfile(tempdir,'oriY.nii');
+fname{3} = fullfile(tempdir,'oriZ.nii');
+fname{4} = fullfile(tempdir,'orimask.nii');
+
+
+for ii=1:3
+    oriwrapped{ii} = st.vols{1}.blobs{1}.vol;
+    oriwrapped{ii}(st.nmt.cfg.inside_idx) = ori(:,ii);
+end
+oriwrapped{4} = double(isfinite(oriwrapped{1}));
+
+for ii=1:4
+    vol.fname = fname{ii};
+    vol.dim = size(st.vols{1}.blobs{1}.vol);
+    vol.mat = st.vols{1}.blobs{1}.mat;
+    vol.dt = [16 0];
+    spm_write_vol(vol,oriwrapped{ii});
+end
+
+%%
+for ii=1:3
+    orivol{ii}=spm_vol(fname{ii});
+end
+orimaskvol=spm_vol(fname{4});
+spm_orthviews('quivernmt','init',1,orivol,orimaskvol)
+spm_orthviews('redraw')

--- a/contrib/nutmegtrip/nmt_tbxdti_quiver3.m
+++ b/contrib/nutmegtrip/nmt_tbxdti_quiver3.m
@@ -1,0 +1,172 @@
+function hh = tbxdti_quiver3(varargin)
+%QUIVER3 3-D quiver plot.
+%   QUIVER3(X,Y,Z,U,V,W) plots velocity vectors as arrows with components
+%   (u,v,w) at the points (x,y,z).  The matrices X,Y,Z,U,V,W must all be
+%   the same size and contain the corresponding position and velocity
+%   components.  QUIVER3 automatically scales the arrows to fit.
+%
+%   QUIVER3(Z,U,V,W) plots velocity vectors at the equally spaced
+%   surface points specified by the matrix Z.
+%
+%   QUIVER3(Z,U,V,W,S) or QUIVER3(X,Y,Z,U,V,W,S) automatically
+%   scales the arrows to fit and then stretches them by S.
+%   Use S=0 to plot the arrows without the automatic scaling.
+%
+%   QUIVER3(...,LINESPEC) uses the plot linestyle specified for
+%   the velocity vectors.  Any marker in LINESPEC is drawn at the base
+%   instead of an arrow on the tip.  Use a marker of '.' to specify
+%   no marker at all.  See PLOT for other possibilities.
+%
+%   QUIVER3(...,'filled') fills any markers specified.
+%
+%   H = QUIVER3(...) returns a vector of line handles.
+%
+%   Example:
+%       [x,y] = meshgrid(-2:.2:2,-1:.15:1);
+%       z = x .* exp(-x.^2 - y.^2);
+%       [u,v,w] = surfnorm(x,y,z);
+%       quiver3(x,y,z,u,v,w); hold on, surf(x,y,z), hold off
+%
+%   See also QUIVER, PLOT, PLOT3, SCATTER.
+%
+% Courtesy of SPM Tools / tbxDiffusion:
+% https://sourceforge.net/projects/spmtools/
+
+%   Clay M. Thompson 3-3-94
+%   Copyright 1984-2000 The MathWorks, Inc. 
+%   $Revision$  $Date$
+
+% Arrow head parameters
+alpha = 0.33; % Size of arrow head relative to the length of the vector
+beta = 0.33;  % Width of the base of the arrow head relative to the length
+autoscale = 1; % Autoscale if ~= 0 then scale by this.
+plotarrows = 1;
+
+filled = 0;
+ls = '-';
+ms = '';
+col = '';
+
+nin = nargin;
+% Parse the string inputs
+while ischar(varargin{nin}),
+  vv = varargin{nin};
+  if ~isempty(vv) && strcmpi(vv(1),'f')
+    filled = 1;
+    nin = nin-1;
+  else
+    [l,c,m,msg] = colstyle(vv);
+    if ~isempty(msg), 
+      error('Unknown option "%s".',vv);
+    end
+    if ~isempty(l), ls = l; end
+    if ~isempty(c), col = c; end
+    if ~isempty(m), ms = m; plotarrows = 0; end
+    if isequal(m,'.'), ms = ''; end % Don't plot '.'
+    nin = nin-1;
+  end
+end
+
+if(nin < 4 | nin < 7)
+    error('Incorrect number of input arguments to tbxdt_quiver3.')
+end
+
+% Check numeric input arguments
+if nin<6, % quiver3(z,u,v,w) or quiver3(z,u,v,w,s)
+  [msg,x,y,z] = xyzchk(varargin{1});
+  u = varargin{2};
+  v = varargin{3};
+  w = varargin{4};
+else % quiver3(x,y,z,u,v,w) or quiver3(x,y,z,u,v,w,s)
+  [msg,x,y,z] = xyzchk(varargin{1:3});
+  u = varargin{4};
+  v = varargin{5};
+  w = varargin{6};
+end
+if ~isempty(msg), error(msg); end
+
+% Scalar expand u,v,w.
+if numel(u)==1, u = u(ones(size(x))); end
+if numel(v)==1, v = v(ones(size(u))); end
+if numel(w)==1, w = w(ones(size(v))); end
+
+% Check sizes
+if ~isequal(size(x),size(y),size(z),size(u),size(v),size(w))
+  error('The sizes of X,Y,Z,U,V, and W must all be the same.');
+end
+
+% Get autoscale value if present
+if nin==5 || nin==7, % quiver3(z,u,v,w,s) or quiver3(x,y,z,u,v,w,s)
+  autoscale = varargin{nin};
+end
+
+if length(autoscale)>1,
+  error('S must be a scalar.');
+end
+
+if autoscale,
+  % Base autoscale value on average spacing in the x and y
+  % directions.  Estimate number of points in each direction as
+  % either the size of the input arrays or the effective square
+  % spacing if x and y are vectors.
+  if min(size(x))==1, n=sqrt(numel(x)); m=n; else [m,n]=size(x); end
+  delx = diff([min(x(:)) max(x(:))])/n; 
+  dely = diff([min(y(:)) max(y(:))])/m;
+  delz = diff([min(z(:)) max(y(:))])/max(m,n);
+  del = sqrt(delx.^2 + dely.^2 + delz.^2);
+  if del>0
+    len = sqrt((u/del).^2 + (v/del).^2 + (w/del).^2);
+    maxlen = max(len(:));
+  else
+    maxlen = 0;
+  end
+  
+  if maxlen>0
+    autoscale = autoscale*0.9 / maxlen;
+  else
+    autoscale = autoscale*0.9;
+  end
+  u = u*autoscale; v = v*autoscale; w = w*autoscale;
+end
+
+ax = newplot;
+next = lower(get(ax,'NextPlot'));
+hold_state = ishold;
+
+% Make velocity vectors
+x = x(:).'; y = y(:).'; z = z(:).';
+u = u(:).'; v = v(:).'; w = w(:).';
+uu = [x-.5*u;x+.5*u;NaN(size(u))];
+vv = [y-.5*v;y+.5*v;NaN(size(u))];
+ww = [z-.5*w;z+.5*w;NaN(size(u))];
+
+h1 = plot3(uu(:),vv(:),ww(:),[col ls]);
+
+if plotarrows,
+  beta = beta * sqrt(u.*u + v.*v + w.*w) ./ (sqrt(u.*u + v.*v) + eps);
+
+  % Make arrow heads and plot them
+  hu = [x+u-alpha*(u+beta.*(v+eps));x+u; ...
+        x+u-alpha*(u-beta.*(v+eps));NaN(size(u))];
+  hv = [y+v-alpha*(v-beta.*(u+eps));y+v; ...
+        y+v-alpha*(v+beta.*(u+eps));NaN(size(v))];
+  hw = [z+w-alpha*w;z+w;z+w-alpha*w;NaN(size(w))];
+
+  hold on
+  h2 = plot3(hu(:),hv(:),hw(:),[col ls]);
+else
+  h2 = [];
+end
+
+if ~isempty(ms), % Plot marker on base
+  hu = x; hv = y; hw = z;
+  hold on
+  h3 = plot3(hu(:),hv(:),hw(:),[col ms]);
+  if filled, set(h3,'markerfacecolor',get(h1,'color')); end
+else
+  h3 = [];
+end
+
+if ~hold_state, hold off, view(3); grid on, set(ax,'NextPlot',next); end
+
+if nargout>0, hh = [h1;h2;h3]; end

--- a/contrib/nutmegtrip/spm_ov_quivernmt.m
+++ b/contrib/nutmegtrip/spm_ov_quivernmt.m
@@ -1,0 +1,335 @@
+function ret = spm_ov_quivernmt(varargin)
+% This routine is a plugin to spm_orthviews for SPM12 / SPM8.
+% Used by NutmegTrip / nmt_sourceoriplot.m to plot vector fields
+% (e.g., orientations) on MRI
+%
+% For general help about
+% spm_orthviews and plugins type
+%             help spm_orthviews
+% at the matlab prompt.
+%_______________________________________________________________________
+%
+% adapted from spm_ov_quiver.m disributed with SPM Tools / tbxDiffusion:
+% https://sourceforge.net/projects/spmtools/
+
+
+
+global st;
+
+if isempty(st)
+    error('quivernmt: This routine can only be called as a plugin for spm_orthviews!');
+end;
+
+if nargin < 2
+    error('quivernmt: Wrong number of arguments. Usage: spm_orthviews(''quivernmt'', cmd, volhandle, varargin)');
+end;
+
+cmd = lower(varargin{1});
+volhandle = varargin{2};
+switch cmd
+    case 'init'     %function addquiver(handle, Vqfnames, Vmaskfname, varargin)
+        if nargin < 4
+            error('spm_orthviews(''quivernmt'', ''init'',...): Not enough arguments');
+        end;
+        Vq = spm_vol(varargin{3});
+        Vmask = spm_vol(varargin{4});
+        if length(Vq) == 3
+            st.vols{volhandle}.quivernmt = struct('qx',Vq(1),'qy',Vq(2),'qz',Vq(3), ...
+                'mask',Vmask, 'fa',[], 'thresh', [.1 Inf], 'ls','y.', ...
+                'qst',3,'ql',1,'qht',[],'qhc',[],'qhs',[], 'qw', .5);
+        else
+            error('spm_orthviews(''quivernmt'', ''init'',...): Please specify 3 images!');
+        end;
+        if nargin > 4
+            if ~isempty(varargin{5})
+                st.vols{volhandle}.quivernmt.fa = spm_vol(varargin{5});
+            end;
+        end;
+        if nargin > 5
+            if ~isempty(varargin{6})
+                st.vols{volhandle}.quivernmt.thresh(1) = varargin{6};
+            end;
+        end;
+        if nargin > 6
+            if ~isempty(varargin{7})
+                st.vols{volhandle}.quivernmt.thresh(2) = varargin{7};
+            end;
+        end;
+        if nargin > 7
+            if ischar(varargin{8})
+                st.vols{volhandle}.quivernmt.ls = varargin{8};
+            end;
+        end;
+        if nargin > 8
+            if ~isempty(varargin{9})
+                st.vols{volhandle}.quivernmt.qst = varargin{9};
+            end;
+        end;
+        if isempty(st.vols{volhandle}.quivernmt.fa)
+            st.vols{volhandle}.quivernmt.ql = 1;
+        end;
+        if nargin > 9
+            if ~isempty(varargin{10})
+                st.vols{volhandle}.quivernmt.ql = varargin{10};
+            end;
+        end;
+        if nargin > 10
+            if ~isempty(varargin{11})
+                st.vols{volhandle}.quivernmt.qw = varargin{11};
+            end;
+        end;
+
+    case 'redraw'
+        TM0 = varargin{3};
+        TD  = varargin{4};
+        CM0 = varargin{5};
+        CD  = varargin{6};
+        SM0 = varargin{7};
+        SD  = varargin{8};
+        if isfield(st.vols{volhandle},'quivernmt')
+            % need to delete old quiver lines before redrawing
+            delete(st.vols{volhandle}.quivernmt.qht);
+            delete(st.vols{volhandle}.quivernmt.qhc);
+            delete(st.vols{volhandle}.quivernmt.qhs);
+
+            qx  = st.vols{volhandle}.quivernmt.qx;
+            qy  = st.vols{volhandle}.quivernmt.qy;
+            qz  = st.vols{volhandle}.quivernmt.qz;
+            mask = st.vols{volhandle}.quivernmt.mask;
+            fa = st.vols{volhandle}.quivernmt.fa;
+            thresh(1) = st.vols{volhandle}.quivernmt.thresh(1);
+            thresh(2) = st.vols{volhandle}.quivernmt.thresh(2);
+            ls = st.vols{volhandle}.quivernmt.ls;
+
+            % step size for selection of locations
+            prm = spm_imatrix(st.Space);
+            qst = ceil(st.vols{volhandle}.quivernmt.qst/prm(7));
+            qst = st.vols{1}.quivernmt.qx.mat(1,1); % get voxel/grid spacing from the transformation matrix
+            ql = st.vols{volhandle}.quivernmt.ql; % scaling of arrow length
+            qst1 = ceil(qst/2);
+
+            Mx   = st.vols{volhandle}.premul*qx.mat;
+            My   = st.vols{volhandle}.premul*qy.mat;
+            Mz   = st.vols{volhandle}.premul*qz.mat;
+            Mm   = st.vols{volhandle}.premul*mask.mat;
+            if ~isempty(fa)
+                fat = spm_slice_vol(fa,inv(TM0*(st.Space\Mx)),TD,0)';
+            else
+                fat = 1;
+            end;
+            rqt = cat(3, spm_slice_vol(qx,inv(TM0*(st.Space\Mx)),TD,0)', ...
+                spm_slice_vol(qy,inv(TM0*(st.Space\My)),TD,0)', ...
+                spm_slice_vol(qz,inv(TM0*(st.Space\Mz)),TD,0)');
+            rqt = st.Space(1:3,1:3)*st.vols{volhandle}.premul(1:3,1:3)*reshape(rqt,TD(1)*TD(2),3)';
+            qxt = fat.*reshape(rqt(1,:)',TD(2),TD(1));
+            qyt = fat.*reshape(rqt(2,:)',TD(2),TD(1));
+            qzt = fat.*reshape(rqt(3,:)',TD(2),TD(1));
+
+            maskt = spm_slice_vol(mask,inv(TM0*(st.Space\Mm)),TD,0)';
+            xt = (1:TD(1))-.5;
+            yt = (1:TD(2))-.5;
+            zt = zeros(size(qxt));
+            zt((maskt < thresh(1))|(maskt > thresh(2))) = NaN;
+            zt((qxt == 0) & (qyt == 0) & (qzt == 0)) = NaN;
+
+            if ~isempty(fa)
+                fac = spm_slice_vol(fa,inv(CM0*(st.Space\Mx)),CD,0)';
+            else
+                fac = 1;
+            end;
+            rqc = cat(3, spm_slice_vol(qx,inv(CM0*(st.Space\Mx)),CD,0)', ...
+                spm_slice_vol(qy,inv(CM0*(st.Space\My)),CD,0)', ...
+                spm_slice_vol(qz,inv(CM0*(st.Space\Mz)),CD,0)');
+            rqc = st.Space(1:3,1:3)*st.vols{volhandle}.premul(1:3,1:3)*reshape(rqc,CD(1)*CD(2),3)';
+            qxc = fac.*reshape(rqc(1,:)',CD(2),CD(1));
+            qyc = fac.*reshape(rqc(2,:)',CD(2),CD(1));
+            qzc = fac.*reshape(rqc(3,:)',CD(2),CD(1));
+
+            maskc = spm_slice_vol(mask,inv(CM0*(st.Space\Mm)),CD,0)';
+            xc = (1:CD(1))-.5;
+            yc = (1:CD(2))-.5;
+            zc = zeros(size(qxc));
+            zc((maskc < thresh(1))|(maskc > thresh(2))) = NaN;
+            zc((qxc == 0) & (qyc == 0) & (qzc == 0)) = NaN;
+
+            if ~isempty(fa)
+                fas = spm_slice_vol(fa,inv(SM0*(st.Space\Mx)),SD,0)';
+            else
+                fas = 1;
+            end;
+            rqs = cat(3, spm_slice_vol(qx,inv(SM0*(st.Space\Mx)),SD,0)', ...
+                spm_slice_vol(qy,inv(SM0*(st.Space\My)),SD,0)', ...
+                spm_slice_vol(qz,inv(SM0*(st.Space\Mz)),SD,0)');
+            rqs = st.Space(1:3,1:3)*st.vols{volhandle}.premul(1:3,1:3)*reshape(rqs,SD(1)*SD(2),3)';
+            qxs = fas.*reshape(rqs(1,:)',SD(2),SD(1));
+            qys = fas.*reshape(rqs(2,:)',SD(2),SD(1));
+            qzs = fas.*reshape(rqs(3,:)',SD(2),SD(1));
+
+            masks = spm_slice_vol(mask,inv(SM0*(st.Space\Mm)),SD,0)';
+            xs = (1:SD(1))-.5;
+            ys = (1:SD(2))-.5;
+            zs = zeros(size(qxs));
+            zs((masks < thresh(1))|(masks > thresh(2))) = NaN;
+            zs((qxs == 0) & (qys == 0) & (qzs == 0)) = NaN;
+
+            % check for availability of "centered" quiver function
+            if exist('nmt_tbxdti_quiver3.m','file')
+                quiverfun = @nmt_tbxdti_quiver3;
+            else % fallback
+                quiverfun = @quiver3;
+                warning('Function "tbxdti_quiver3.m" not found!\n Using standard Matlab routine "quiver3.m" instead.\n This may not give  nice quiver plots.');
+            end;
+            if spm_flip_analyze_images
+                flipx = -1;
+            else
+                flipx = 1;
+            end;
+
+            % transversal - plot (x y z)
+            np = get(st.vols{volhandle}.ax{1}.ax,'NextPlot');
+            set(st.vols{volhandle}.ax{1}.ax,'NextPlot','add');
+            axes(st.vols{volhandle}.ax{1}.ax);
+            x=xt(qst1:qst:end);
+            y=yt(qst1:qst:end);
+            z=zt(qst1:qst:end,qst1:qst:end);
+            u=flipx*qxt(qst1:qst:end,qst1:qst:end);
+            v=      qyt(qst1:qst:end,qst1:qst:end);
+            w=      qzt(qst1:qst:end,qst1:qst:end);
+            xtt=repmat(x,size(z,1),1);
+            ytt=repmat(y',1,size(z,2));
+            st.vols{volhandle}.quivernmt.qht = feval(quiverfun,xtt,ytt,z,u,v,w,ql,ls);
+            set(st.vols{volhandle}.ax{1}.ax,'NextPlot',np);
+            set(st.vols{volhandle}.quivernmt.qht, ...
+                'Parent',st.vols{volhandle}.ax{1}.ax, 'HitTest','off', ...
+                'Linewidth',st.vols{volhandle}.quivernmt.qw );
+
+            % coronal - plot (x z y)
+            np = get(st.vols{volhandle}.ax{2}.ax,'NextPlot');
+            set(st.vols{volhandle}.ax{2}.ax,'NextPlot','add');
+            axes(st.vols{volhandle}.ax{2}.ax);
+            x=xc(qst1:qst:end);
+            y=yc(qst1:qst:end);
+            z=zc(qst1:qst:end,qst1:qst:end);
+            u=flipx*qxc(qst1:qst:end,qst1:qst:end);
+            v=      qzc(qst1:qst:end,qst1:qst:end);
+            w=      qyc(qst1:qst:end,qst1:qst:end);
+            xtt=repmat(x,size(z,1),1);
+            ytt=repmat(y',1,size(z,2));
+            st.vols{volhandle}.quivernmt.qhc = feval(quiverfun,xtt,ytt,z,u,v,w,ql,ls);
+            set(st.vols{volhandle}.ax{2}.ax,'NextPlot',np);
+            set(st.vols{volhandle}.quivernmt.qhc, ...
+                'Parent',st.vols{volhandle}.ax{2}.ax, 'HitTest','off', ...
+                'Linewidth',st.vols{volhandle}.quivernmt.qw );
+
+            % sagittal - plot (-y z x)
+            np = get(st.vols{volhandle}.ax{3}.ax,'NextPlot');
+            set(st.vols{volhandle}.ax{3}.ax,'NextPlot','add');
+            axes(st.vols{volhandle}.ax{3}.ax);
+            x=xs(qst1:qst:end);
+            y=ys(qst1:qst:end);
+            z=zs(qst1:qst:end,qst1:qst:end);
+            u=     -qys(qst1:qst:end,qst1:qst:end);
+            v=      qzs(qst1:qst:end,qst1:qst:end);
+            w=flipx*qxs(qst1:qst:end,qst1:qst:end);
+            xtt=repmat(x,size(z,1),1);
+            ytt=repmat(y',1,size(z,2));
+            st.vols{volhandle}.quivernmt.qhs = feval(quiverfun,xtt,ytt,z,u,v,w,ql,ls);
+            set(st.vols{volhandle}.ax{3}.ax,'NextPlot',np);
+            set(st.vols{volhandle}.quivernmt.qhs, ...
+                'Parent',st.vols{volhandle}.ax{3}.ax, 'HitTest','off', ...
+                'Linewidth',st.vols{volhandle}.quivernmt.qw );
+        end; %quiver
+
+    case 'delete'
+        if isfield(st.vols{volhandle},'quiver'),
+            delete(st.vols{volhandle}.quivernmt.qht);
+            delete(st.vols{volhandle}.quivernmt.qhc);
+            delete(st.vols{volhandle}.quivernmt.qhs);
+            st.vols{volhandle} = rmfield(st.vols{volhandle},'quiver');
+        end;
+        %-------------------------------------------------------------------------
+        % Context menu and callbacks
+    case 'context_menu'
+        item0 = uimenu(varargin{3}, 'Label', 'Quiver');
+        item1 = uimenu(item0, 'Label', 'Add', 'Callback', ...
+            ['feval(''spm_ov_quivernmt'',''context_init'', ', ...
+            num2str(volhandle), ');'], 'Tag', ['QUIVER_0_', num2str(volhandle)]);
+        item2 = uimenu(item0, 'Label', 'Properties', ...
+            'Visible', 'off', 'Tag', ['QUIVER_1_', num2str(volhandle)]);
+        item2_1 = uimenu(item2, 'Label', 'Mask threshold', 'Callback', ...
+            ['feval(''spm_ov_quivernmt'',''context_edit'',', ...
+            num2str(volhandle), ',''thresh'');']);
+        item2_2 = uimenu(item2, 'Label', 'Linestyle', 'Callback', ...
+            ['feval(''spm_ov_quivernmt'',''context_edit'',', ...
+            num2str(volhandle), ',''ls'');']);
+        item2_3 = uimenu(item2, 'Label', 'Quiver distance', 'Callback', ...
+            ['feval(''spm_ov_quivernmt'',''context_edit'',', ...
+            num2str(volhandle), ',''qst'');']);
+        item2_4 = uimenu(item2, 'Label', 'Quiver length', 'Callback', ...
+            ['feval(''spm_ov_quivernmt'',''context_edit'',', ...
+            num2str(volhandle), ',''ql'');']);
+        item2_5 = uimenu(item2, 'Label', 'Linewidth', 'Callback', ...
+            ['feval(''spm_ov_quivernmt'',''context_edit'',', ...
+            num2str(volhandle), ',''qw'');']);
+        item3 = uimenu(item0, 'Label', 'Remove', 'Callback', ...
+            ['feval(''spm_ov_quivernmt'',''context_delete'', ', ...
+            num2str(volhandle), ');'], 'Visible', 'off', ...
+            'Tag', ['QUIVER_1_', num2str(volhandle)]);
+
+    case 'context_init'
+        Finter = spm_figure('FindWin', 'Interactive');
+        spm_input('!DeleteInputObj',Finter);
+        [Vqfnames, sts] = spm_select(3, 'image',...
+            'Components of 1st eigenvector',[], ...
+            pwd, 'evec1.*');
+        if ~sts
+            return;
+        end;
+        [Vmaskfname, sts] = spm_select(1,'image', 'Mask image');
+        if ~sts
+            return;
+        end;
+        Vfafname = spm_select(Inf,'image', 'Fractional anisotropy image', [], ...
+            pwd, 'fa.*');
+        feval('spm_ov_quivernmt','init',volhandle,Vqfnames,Vmaskfname,Vfafname);
+        obj = findobj(0, 'Tag',  ['QUIVER_1_', num2str(volhandle)]);
+        set(obj, 'Visible', 'on');
+        obj = findobj(0, 'Tag',  ['QUIVER_0_', num2str(volhandle)]);
+        set(obj, 'Visible', 'off');
+        spm_orthviews('redraw');
+
+    case 'context_edit'
+        Finter = spm_figure('FindWin', 'Interactive');
+        spm_input('!DeleteInputObj',Finter);
+        switch varargin{3}
+            case 'thresh'
+                in = spm_input('Mask threshold {min max}','!+1','e', ...
+                    num2str(st.vols{volhandle}.quivernmt.thresh), [1 2]);
+            case 'ls'
+                in = spm_input('Line style','!+1','s', ...
+                    st.vols{volhandle}.quivernmt.ls);
+            case 'qst'
+                in = spm_input('Quiver distance','!+1','e', ...
+                    num2str(st.vols{volhandle}.quivernmt.qst), 1);
+            case 'ql'
+                in = spm_input('Quiver length','!+1','e', ...
+                    num2str(st.vols{volhandle}.quivernmt.ql), 1);
+            case 'qw'
+                in = spm_input('Linewidth','!+1','e', ...
+                    num2str(st.vols{volhandle}.quivernmt.qw), 1);
+        end;
+        spm_input('!DeleteInputObj',Finter);
+        st.vols{volhandle}.quivernmt.(varargin{3}) = in;
+        spm_orthviews('redraw');
+
+    case 'context_delete'
+        feval('spm_ov_quivernmt','delete',volhandle);
+        obj = findobj(0, 'Tag',  ['QUIVER_1_', num2str(volhandle)]);
+        set(obj, 'Visible', 'off');
+        obj = findobj(0, 'Tag',  ['QUIVER_0_', num2str(volhandle)]);
+        set(obj, 'Visible', 'on');
+
+    otherwise
+
+        fprintf('spm_orthviews(''quiver'',...): Unknown action string %s', cmd);
+end;


### PR DESCRIPTION
Adapts functionality from spm_ov_quiver.m plugin (originally designed for DTI) to plot arbitrary 3D vectors, e.g., orientation information from source orientations.