### PR TITLE
FIX - fixing negative trigger values for neuromag failed 

### DIFF
--- a/fileio/private/read_trigger.m
+++ b/fileio/private/read_trigger.m
@@ -134,7 +134,7 @@ end
 % fix suggested by Ralph Huonker to deal with triggers that need to be
 % interpreted as unsigned integers, rather than signed
 if strncmpi(dataformat, 'neuromag', 8) && ~fixneuromag
-  if any(dat<0)
+  if any(dat(:)<0)
     tmpdat = zeros(size(dat));
     for k = 1:size(dat,1)
       tmpdat(k,:) = double(typecast(int16(dat(k,:)), 'uint16'));


### PR DESCRIPTION
when there are more than two binary trigger channels

as detected and debugged by @mcvinding