### PR TITLE
Added more robust method for calculating dimensions of iEEG grids

### DIFF
--- a/fileio/private/write_bioimage_mgrid.m
+++ b/fileio/private/write_bioimage_mgrid.m
@@ -79,102 +79,10 @@ for g = 1:ngrids % grid loop
   fprintf(fid, '#Dimensions\n');
   
   % determine grid dimensions
-  if isequal(numel(Grid2Elec{g}), 256)
-    GridDim(1) = 16; GridDim(2) = 16;
-  elseif isequal(numel(Grid2Elec{g}), 64)
-    GridDim(1) = 8; GridDim(2) = 8;
-  elseif isequal(numel(Grid2Elec{g}), 48)
-    e6 = elec.elecpos(match_str(elec.label, [GridDescript{g} num2str(6)]),:);
-    e7 = elec.elecpos(match_str(elec.label, [GridDescript{g} num2str(7)]),:);
-    e8 = elec.elecpos(match_str(elec.label, [GridDescript{g} num2str(8)]),:);
-    e9 = elec.elecpos(match_str(elec.label, [GridDescript{g} num2str(9)]),:);
-    d6to7 = sqrt(sum((e6-e7).^2)); % distance of elec 6 to 7
-    d8to9 = sqrt(sum((e8-e9).^2)); % distance of elec 8 to 9
-    if d8to9 >= d6to7  % break between e8 and e9
-      GridDim(1) = 6; GridDim(2) = 8;
-    elseif d6to7 > d8to9 % break between e6 and e7
-      GridDim(1) = 8; GridDim(2) = 6;
-    end
-  elseif isequal(numel(Grid2Elec{g}), 32)
-    e4 = elec.elecpos(match_str(elec.label, [GridDescript{g} num2str(4)]),:);
-    e5 = elec.elecpos(match_str(elec.label, [GridDescript{g} num2str(5)]),:);
-    e8 = elec.elecpos(match_str(elec.label, [GridDescript{g} num2str(8)]),:);
-    e9 = elec.elecpos(match_str(elec.label, [GridDescript{g} num2str(9)]),:);
-    d4to5 = sqrt(sum((e4-e5).^2)); % distance of elec 4 to 5
-    d8to9 = sqrt(sum((e8-e9).^2)); % distance of elec 8 to 9
-    if d8to9 >= d4to5  % break between e8 and e9
-      GridDim(1) = 4; GridDim(2) = 8;
-    elseif d4to5 > d8to9 % break between e4 and e5
-      GridDim(1) = 8; GridDim(2) = 4;
-    end
-  elseif isequal(numel(Grid2Elec{g}), 24)
-    e4 = elec.elecpos(match_str(elec.label, [GridDescript{g} num2str(4)]),:);
-    e5 = elec.elecpos(match_str(elec.label, [GridDescript{g} num2str(5)]),:);
-    e6 = elec.elecpos(match_str(elec.label, [GridDescript{g} num2str(6)]),:);
-    e7 = elec.elecpos(match_str(elec.label, [GridDescript{g} num2str(7)]),:);
-    d4to5 = sqrt(sum((e4-e5).^2)); % distance of elec 4 to 5
-    d6to7 = sqrt(sum((e6-e7).^2)); % distance of elec 6 to 7
-    if d6to7 >= d4to5 % break between e6 and e7
-      GridDim(1) = 4; GridDim(2) = 6;
-    elseif d4to5 > d6to7 % break between e4 and e5
-      GridDim(1) = 6; GridDim(2) = 4;
-    end
-  elseif isequal(numel(Grid2Elec{g}), 20)
-    e4 = elec.elecpos(match_str(elec.label, [GridDescript{g} num2str(4)]),:);
-    e5 = elec.elecpos(match_str(elec.label, [GridDescript{g} num2str(5)]),:);
-    d4to5 = sqrt(sum((e4-e5).^2)); % distance of elec 4 to 5
-    d5to6 = sqrt(sum((e5-e6).^2)); % distance of elec 5 to 6
-    if d5to6 >= d4to5 % break between e5 and e6
-      GridDim(1) = 4; GridDim(2) = 5;
-    elseif d4to5 > d5to6 % break between e4 and e5
-      GridDim(1) = 5; GridDim(2) = 4;
-    end
-  elseif isequal(numel(Grid2Elec{g}), 16)
-    e4 = elec.elecpos(match_str(elec.label, [GridDescript{g} num2str(4)]),:);
-    e5 = elec.elecpos(match_str(elec.label, [GridDescript{g} num2str(5)]),:);
-    e8 = elec.elecpos(match_str(elec.label, [GridDescript{g} num2str(8)]),:);
-    e9 = elec.elecpos(match_str(elec.label, [GridDescript{g} num2str(9)]),:);
-    d4to5 = sqrt(sum((e4-e5).^2)); % distance of elec 4 to 5
-    d8to9 = sqrt(sum((e8-e9).^2)); % distance of elec 8 to 9
-    d4to8 = sqrt(sum((e4-e8).^2)); % distance of elec 4 to 8
-    if d8to9 > 2*d4to5 % break between e8 and e9
-      GridDim(1) = 2; GridDim(2) = 8;
-    elseif d4to5 > 2*d4to8 % break between e4 and e5
-      GridDim(1) = 4; GridDim(2) = 4;
-    else
-      GridDim(1) = 1; GridDim(2) = 16;
-    end
-  elseif isequal(numel(Grid2Elec{g}), 12)
-    e4 = elec.elecpos(match_str(elec.label, [GridDescript{g} num2str(4)]),:);
-    e5 = elec.elecpos(match_str(elec.label, [GridDescript{g} num2str(5)]),:);
-    e6 = elec.elecpos(match_str(elec.label, [GridDescript{g} num2str(6)]),:);
-    e7 = elec.elecpos(match_str(elec.label, [GridDescript{g} num2str(7)]),:);
-    d4to5 = sqrt(sum((e4-e5).^2)); % distance of elec 5 to 6
-    d5to6 = sqrt(sum((e5-e6).^2)); % distance of elec 5 to 6
-    d6to7 = sqrt(sum((e6-e7).^2)); % distance of elec 6 to 7
-    if d4to5 > 2*d5to6 % break between e4 and e5
-      GridDim(1) = 3; GridDim(2) = 4; % 4x3 unsuppported
-    elseif d6to7 > 2*d5to6 % break between e6 and e7
-      GridDim(1) = 2; GridDim(2) = 6;
-    else
-      GridDim(1) = 1; GridDim(2) = 12;
-    end
-  elseif isequal(numel(Grid2Elec{g}), 8)
-    e3 = elec.elecpos(match_str(elec.label, [GridDescript{g} num2str(3)]),:);
-    e4 = elec.elecpos(match_str(elec.label, [GridDescript{g} num2str(4)]),:);
-    e5 = elec.elecpos(match_str(elec.label, [GridDescript{g} num2str(5)]),:);
-    d3to4 = sqrt(sum((e3-e4).^2)); % distance of elec 3 to 4
-    d4to5 = sqrt(sum((e4-e5).^2)); % distance of elec 4 to 5
-    if d4to5 > 2*d3to4 % break between e4 and e5
-      GridDim(1) = 2; GridDim(2) = 4;
-    else
-      GridDim(1) = 1; GridDim(2) = 8;
-    end
-  else
-    GridDim(1) = 1; GridDim(2) = numel(Grid2Elec{g});
-    % ft_error('At least one of the electrode tracts or grids has dimensions that are not supported by write_bioimage_mgrid. If electrodes are missing from a grid, enter NaN(1,3) for electrode position');
-  end
-  fprintf('assuming %s has %d x %d dimensions\n', GridDescript{g}, GridDim(1), GridDim(2)); % feedback of the grid dimensions
+  elec_g = elec;
+  elec_g.label = elec.label(Grid2Elec{g});
+  elec_g.elecpos = elec.elecpos(Grid2Elec{g}, :);
+  GridDim = determine_griddim(elec_g);
 
   fprintf(fid, [' ' num2str(GridDim(1)) ' ' num2str(GridDim(2)) '\n']);
   fprintf(fid, '#Electrode Spacing\n');

--- a/private/determine_griddim.m
+++ b/private/determine_griddim.m
@@ -1,0 +1,115 @@
+function GridDim = determine_griddim(elec)
+% determine grid dimensions (1st dim: number of rows, 2nd dim: number of columns)
+% A. Stolk & S. Griffin, 2017
+
+digits = regexp(elec.label, '\d+', 'match');
+maxdigit = 1;
+for l=1:numel(digits)
+  ElecStrs{l,1} = regexprep(elec.label{l}, '\d+(?:_(?=\d))?', ''); % without electrode numbers
+  labels{l,1} = digits{l}{1}; % use first found digit
+  if str2num(digits{l}{1}) > maxdigit
+    maxdigit = str2num(digits{l}{1});
+  end
+end
+ElecStr = cell2mat(unique(ElecStrs));
+
+% determine if any electrodes appear to be cut out of this grid based on
+% the labels
+cutout = []; % index of electrodes that appear to be cut out
+dowarn = 0;
+for e = 1:maxdigit;
+  if isempty(match_str(labels, num2str(e)))
+    cutout(end+1) = e;
+    dowarn = 1;
+  end
+end
+if dowarn
+  ft_warning('%s appears to be missing electrodes %s or have electrodes that are labeled using an unconventional numbering system', elec.ElecStr, num2str(elec.cutout));
+end
+
+% determine if the labels are out of order and if they are, then re-order
+% electrode positions based on numbers in the label and replace
+% missing numbers with electrodes at position [NaN NaN NaN];
+labels_out_of_order = 0;
+for n = 1:numel(labels)-1
+  if str2num(cell2mat(labels(n+1))) ~= str2num(cell2mat(labels(n)))+1
+    labels_out_of_order = 1;
+  end
+end
+
+if labels_out_of_order
+  pos_ordered = NaN(maxdigit,3);
+  for e = 1:maxdigit;
+    if ~isempty(match_str(labels, num2str(e)))
+      pos_ordered(e, :) = elec.elecpos(match_str(labels, num2str(e)),:);
+    end
+  end
+  elec.elecpos = pos_ordered;
+end
+
+d_bwelec = [];
+for e = 1:size(elec.elecpos,1)-1;
+  d_bwelec(e) = sqrt(sum((elec.elecpos(e+1,:)-elec.elecpos(e,:)).^2));
+end
+
+% Find the electrode spacing
+d_bwelec(find(d_bwelec == 0)) = NaN;
+elec_space = nanmedian(d_bwelec); 
+
+
+% For each electrode, find the electrodes that are within 1.3*elec_space,
+% which should be the adjacent neighbors. Without considering the
+% electrodes in the same row (e.g., those that are numbered either +1 or -1 
+% to the given electrode), find the numbers of the electrodes in the
+% same column. Then, find the difference between the numbers of electrodes
+% in the same column. The most common difference should be the row length.
+vertical_skip = []; % n x 2 matrix where column 1 refers to a given electrode and column 1 refers to the difference in this electrode's number and the electrodes in the same column
+for n = 1:size(elec.elecpos,1)
+  adj_elec_nums = []; % numbers of the electrodes in the same row or column
+  for e = 1:size(elec.elecpos,1)
+    if n~=e && n~=e-1 && n~=e+1 && n<e
+      if sqrt(sum((elec.elecpos(e,:)-elec.elecpos(n,:)).^2)) < 1.3*elec_space
+        vertical_skip(end+1, 2) = abs(n-e);
+        vertical_skip(end, 1) = n;
+      end
+    end
+  end
+end
+
+isLshaped = 0;
+if ~isempty(vertical_skip) && size(vertical_skip,1)>2 % if this is a two dimensional set of electrodes
+  % try to determine if this is a square set of electrodes or L-shaped
+  uniq_skips = unique(vertical_skip(:,2));
+  count = zeros(numel(uniq_skips),1);
+  for k = 1:numel(uniq_skips)
+    count(k) = sum(vertical_skip(:,2)==uniq_skips(k));
+  end
+  mode1 = mode(vertical_skip(:,2));
+  n_mode = count(find(uniq_skips == mode1)); % the count of the mode
+  modes = uniq_skips(find(count > n_mode*0.75));
+  GridDim(2) = mode(vertical_skip(:,2));
+  GridDim(1) = ceil(maxdigit/GridDim(2));
+  
+  if numel(modes) == 2 && diff(modes) ~= 1 % this set of electrodes is derived from an L-shaped grid
+    LGridDim = NaN(2,2);
+    
+    mode2 = modes;
+    mode2(find(modes == mode(vertical_skip(:,2)))) = [];
+    e_kink = vertical_skip(find(vertical_skip(:,2) == mode2, 1),1) + mode(vertical_skip(:,2)) -1; % number of electrode on the interior where the L-shape starts
+    LGridDim(1, 2) = mode(vertical_skip(:,2));
+    LGridDim(1, 1) = ceil(e_kink/LGridDim(1, 2));
+    
+    LGridDim(2, 2) = mode2;
+    LGridDim(2, 1) = ceil((maxdigit-e_kink)/LGridDim(2,2));
+    ft_warning('%s appears to be a grid that is derived from an L-shaped structure and is best described as a %d x %d grid adjacent to a %d x %d grid', ElecStr, LGridDim(1,1), LGridDim(1,2), LGridDim(2,1), LGridDim(2,2));
+    isLshaped = 1;
+  end
+  
+else
+  elec.elecpos(find(isnan(elec.elecpos))) = []; % remove NaNs from elec.elecpos if they exist
+  GridDim(2) = size(elec.elecpos,1);
+  GridDim(1) = 1;
+end
+
+% Give feedback about the grid dimensions
+fprintf('assuming %s has %d x %d grid dimensions\n', ElecStr, GridDim(1), GridDim(2));

--- a/private/determine_griddim.m
+++ b/private/determine_griddim.m
@@ -70,7 +70,7 @@ for e = 1:maxdigit;
   end
 end
 if dowarn
-  ft_warning('%s appears to be missing electrodes %s or have electrodes that are labeled using an unconventional numbering system', ElecStr, num2str(elec.cutout));
+  ft_warning('%s appears to be missing electrodes %s or have electrodes that are labeled using an unconventional numbering system', ElecStr, num2str(cutout));
 end
 
 % determine if the labels are out of order and if they are, then re-order

--- a/private/determine_griddim.m
+++ b/private/determine_griddim.m
@@ -152,8 +152,7 @@ if ~isempty(vertical_skip) && size(vertical_skip,1)>2 % if this is a two dimensi
   end
   
 else
-  elec.elecpos(find(isnan(elec.elecpos))) = []; % remove NaNs from elec.elecpos if they exist
-  GridDim(2) = size(elec.elecpos,1);
+  GridDim(2) = maxdigit;
   GridDim(1) = 1;
 end
 

--- a/private/determine_griddim.m
+++ b/private/determine_griddim.m
@@ -1,4 +1,50 @@
 function GridDim = determine_griddim(elec)
+
+% DETERMINE_GRIDDIM uses the labels and positions of electrodes in elec to
+% determine the dimensions of each set of electroges (i.e., electrodes with
+% the same string, but different numbers)
+%
+% use as: 
+%   GridDim = determine_griddim(elec)
+%   where elec is a structure that contains an elecpos field and a label field
+%   and GridDim(1) = number of rows and GridDim(2) = number of columns
+%   
+%
+% See also FT_ELECTRODEREALIGN
+
+% Copyright (C) 2012-2017, Arjen Stolk, Sandon Griffin
+%
+% This program is free software; you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation; either version 2 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program; if not, write to the Free Software
+% Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+% This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
+% for the documentation and details.
+%
+%    FieldTrip is free software: you can redistribute it and/or modify
+%    it under the terms of the GNU General Public License as published by
+%    the Free Software Foundation, either version 3 of the License, or
+%    (at your option) any later version.
+%
+%    FieldTrip is distributed in the hope that it will be useful,
+%    but WITHOUT ANY WARRANTY; without even the implied warranty of
+%    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%    GNU General Public License for more details.
+%
+%    You should have received a copy of the GNU General Public License
+%    along with FieldTrip. If not, see <http://www.gnu.org/licenses/>.
+%
+% $Id$
 % determine grid dimensions (1st dim: number of rows, 2nd dim: number of columns)
 % A. Stolk & S. Griffin, 2017
 

--- a/private/determine_griddim.m
+++ b/private/determine_griddim.m
@@ -70,7 +70,7 @@ for e = 1:maxdigit;
   end
 end
 if dowarn
-  ft_warning('%s appears to be missing electrodes %s or have electrodes that are labeled using an unconventional numbering system', elec.ElecStr, num2str(elec.cutout));
+  ft_warning('%s appears to be missing electrodes %s or have electrodes that are labeled using an unconventional numbering system', ElecStr, num2str(elec.cutout));
 end
 
 % determine if the labels are out of order and if they are, then re-order

--- a/private/warp_dykstra2012.m
+++ b/private/warp_dykstra2012.m
@@ -58,12 +58,74 @@ cfg.feedback      = ft_getopt(cfg, 'feedback', 'no');
 cfg.pairmethod    = ft_getopt(cfg, 'pairmethod', 'pos'); % eletrode pairing based on electrode 'pos' or 'label' (for computing deformation energy)
 cfg.deformweight  = ft_getopt(cfg, 'deformweight',  1); % weight of deformation relative to shift energy cost
 
-% get starting coordinates
-coord0 = elec.elecpos;
-coord = elec.elecpos;
+if strcmp(cfg.pairmethod, 'label')
+  % determine if any electrodes are missing and
+  % re-order electrode positions based on numbers in the label and replace
+  % missing numbers with electrodes at position [NaN NaN NaN]
+  digits = regexp(elec.label, '\d+', 'match');
+  elec.maxdigit = 1;
+  for l=1:numel(digits)
+    ElecStrs{l,1} = regexprep(elec.label{l}, '\d+(?:_(?=\d))?', ''); % without electrode numbers
+    labels{l,1} = digits{l}{1}; % use first found digit
+    if str2num(digits{l}{1}) > elec.maxdigit
+      elec.maxdigit = str2num(digits{l}{1});
+    end
+  end
+  elec.ElecStr = cell2mat(unique(ElecStrs));
+  
+  pos_ordered = [];
+  labels_ordered = {};
+  elec.cutout = []; % index of electrodes that appear to be cut out
+  dowarn = 0;
+  for e = 1:elec.maxdigit;
+    labels_ordered{e} = [elec.ElecStr num2str(e)];
+    if ~isempty(match_str(labels, num2str(e)))
+      pos_ordered(e, :) = elec.elecpos(match_str(labels, num2str(e)),:);
+    else
+      elec.cutout(end+1) = e;
+      pos_ordered(e, :) = NaN(1,3);
+      dowarn = 1;
+    end
+  end
+  if dowarn
+    ft_warning('%s appears to be missing electrodes %s or have electrodes that are labeled using an unconventional numbering system', elec.ElecStr, num2str(elec.cutout));
+  end
+  elec.label = labels_ordered;
+  elec.elecpos = pos_ordered;
+end
 
 % compute pairs of neighbors
 pairs = create_elecpairs(elec, cfg.pairmethod);
+
+if strcmp(cfg.pairmethod, 'label')
+  % remove electrodes that are cut out from elec.elecpos and update the
+  % pairs list to reflect these removals
+  elec.elecpos(elec.cutout, :) = [];
+  for c = length(elec.cutout):-1:1 % for each of the cutout electrodes, starting with the highest numbered one
+    % find pairs that refered to elec.cutout(c) and remove them
+    for n = size(pairs, 1):-1:1 % for each of the rows in pairs, starting with the highest
+      if any(intersect(pairs(n, :), elec.cutout(c)));
+        pairs(n, :) = [];
+      end
+    end
+    
+    % subtract 1 from all the numbers in pairs that are higher than elec.cutout(c)
+    pairs(find(pairs > elec.cutout(c))) = pairs(find(pairs > elec.cutout(c)))-1;
+  end
+  
+  % remove any pairs that reference an electrode higher than the number of
+  % electrodes in elec.elecpos
+  for n = size(pairs, 1):-1:1 % for each of the rows in pairs, starting with the highest
+    if any(pairs(n, :) > size(elec.elecpos, 1));
+      pairs(n, :) = [];
+    end
+  end
+end
+
+
+% get starting coordinates
+coord0 = elec.elecpos;
+coord = elec.elecpos;
 
 % anonymous function handles
 efun = @(coord_snapped) energy_electrodesnap(coord_snapped, coord, pairs, cfg.deformweight);
@@ -95,6 +157,24 @@ end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % run minimization: efun (shift + deform energy) is minimized; cfun (surface distance) is a nonlinear constraint
 coord_snapped = fmincon(efun, coord0, [], [], [], [], [], [], cfun, options);
+
+if strcmp(cfg.pairmethod, 'label')
+  % return the order of the coordinates to its original order (before they
+  % were ordered sequentially)
+  
+  % first add back NaN's for the cutout electrodes
+  tmp = coord_snapped;
+  for c = 1:numel(elec.cutout)
+    if elec.cutout(c) < elec.maxdigit
+      tmp(elec.cutout(c)+1:end+1, :) = tmp(elec.cutout(c):end, :);
+      tmp(elec.cutout(c), :) = NaN(1,3);
+    end
+  end
+  
+  for n = 1:size(coord_snapped, 1)
+    coord_snapped(n, :) = tmp(str2num(cell2mat(labels(n))),:);
+  end
+end
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % SUBFUNCTION
@@ -142,6 +222,13 @@ if strcmp(method, 'label');
   % determine grid dimensions (1st dim: number of arrays, 2nd dim: number of elecs in an array)
   fprintf('creating electrode pairs based on electrode labels\n');
   GridDim = determine_griddim(elec);
+  if GridDim(1)*GridDim(2) ~= elec.maxdigit
+    warning('assuming %s has %d x %d grid dimensions, but the product of the dimensions does not equal the maximum digit in the electrode labels, so if incorrect, use cfg.pairmethod = ''pos'' instead\n', ElecStr, GridDim(1), GridDim(2));
+  elseif any(GridDim(:)==1) % if not because of strips, this could happen in case of missing electrodes
+    warning('assuming %s has %d x %d grid dimensions: if incorrect, use cfg.pairmethod = ''pos'' instead\n', elec.ElecStr, GridDim(1), GridDim(2));
+  else
+    fprintf('assuming %s has %d x %d grid dimensions\n', ElecStr, GridDim(1), GridDim(2));
+  end
   
   % create pairs based on dimensions
   diagonal = 1;
@@ -185,123 +272,6 @@ elseif strcmp(method, 'pos');
   fprintf('creating electrode pairs based on electrode positions\n');
   pairs = knn_pairs(elec.elecpos, 4);
   
-end
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% SUBFUNCTION
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-function GridDim = determine_griddim(elec)
-% assumes intact grids/strips and elec count starting at 1
-% A. Stolk, 2017
-
-% extract numbers from elec labels
-digits = regexp(elec.label, '\d+', 'match');
-for l=1:numel(digits)
-  labels{l,1} = digits{l}{1}; % use first found digit
-end
-
-% determine grid dimensions (1st dim: number of arrays, 2nd dim: number of elecs in an array)
-if isequal(numel(labels), 256)
-  GridDim(1) = 16; GridDim(2) = 16;
-elseif isequal(numel(labels), 64)
-  GridDim(1) = 8; GridDim(2) = 8;
-elseif isequal(numel(labels), 48)
-  e6 = elec.elecpos(match_str(labels, num2str(6)),:);
-  e7 = elec.elecpos(match_str(labels, num2str(7)),:);
-  e8 = elec.elecpos(match_str(labels, num2str(8)),:);
-  e9 = elec.elecpos(match_str(labels, num2str(9)),:);
-  d6to7 = sqrt(sum((e6-e7).^2)); % distance of elec 6 to 7
-  d8to9 = sqrt(sum((e8-e9).^2)); % distance of elec 8 to 9
-  if d8to9 >= d6to7  % break between e8 and e9
-    GridDim(1) = 6; GridDim(2) = 8;
-  elseif d6to7 > d8to9 % break between e6 and e7
-    GridDim(1) = 8; GridDim(2) = 6;
-  end
-elseif isequal(numel(labels), 32)
-  e4 = elec.elecpos(match_str(labels, num2str(4)),:);
-  e5 = elec.elecpos(match_str(labels, num2str(5)),:);
-  e8 = elec.elecpos(match_str(labels, num2str(8)),:);
-  e9 = elec.elecpos(match_str(labels, num2str(9)),:);
-  d4to5 = sqrt(sum((e4-e5).^2)); % distance of elec 4 to 5
-  d8to9 = sqrt(sum((e8-e9).^2)); % distance of elec 8 to 9
-  if d8to9 >= d4to5  % break between e8 and e9
-    GridDim(1) = 4; GridDim(2) = 8;
-  elseif d4to5 > d8to9 % break between e4 and e5
-    GridDim(1) = 8; GridDim(2) = 4;
-  end
-elseif isequal(numel(labels), 24)
-  e4 = elec.elecpos(match_str(labels, num2str(4)),:);
-  e5 = elec.elecpos(match_str(labels, num2str(5)),:);
-  e6 = elec.elecpos(match_str(labels, num2str(6)),:);
-  e7 = elec.elecpos(match_str(labels, num2str(7)),:);
-  d4to5 = sqrt(sum((e4-e5).^2)); % distance of elec 4 to 5
-  d6to7 = sqrt(sum((e6-e7).^2)); % distance of elec 6 to 7
-  if d6to7 >= d4to5 % break between e6 and e7
-    GridDim(1) = 4; GridDim(2) = 6;
-  elseif d4to5 > d6to7 % break between e4 and e5
-    GridDim(1) = 6; GridDim(2) = 4;
-  end
-elseif isequal(numel(labels), 20)
-  e4 = elec.elecpos(match_str(labels, num2str(4)),:);
-  e5 = elec.elecpos(match_str(labels, num2str(5)),:);
-  e6 = elec.elecpos(match_str(labels, num2str(6)),:);
-  d4to5 = sqrt(sum((e4-e5).^2)); % distance of elec 4 to 5
-  d5to6 = sqrt(sum((e5-e6).^2)); % distance of elec 5 to 6
-  if d5to6 >= d4to5 % break between e5 and e6
-    GridDim(1) = 4; GridDim(2) = 5;
-  elseif d4to5 > d5to6 % break between e4 and e5
-    GridDim(1) = 5; GridDim(2) = 4;
-  end
-elseif isequal(numel(labels), 16)
-  e4 = elec.elecpos(match_str(labels, num2str(4)),:);
-  e5 = elec.elecpos(match_str(labels, num2str(5)),:);
-  e8 = elec.elecpos(match_str(labels, num2str(8)),:);
-  e9 = elec.elecpos(match_str(labels, num2str(9)),:);
-  d4to5 = sqrt(sum((e4-e5).^2)); % distance of elec 4 to 5
-  d8to9 = sqrt(sum((e8-e9).^2)); % distance of elec 8 to 9
-  d4to8 = sqrt(sum((e4-e8).^2)); % distance of elec 4 to 8
-  if d8to9 > 2*d4to5 % break between e8 and e9
-    GridDim(1) = 2; GridDim(2) = 8;
-  elseif d4to5 > 2*d4to8 % break between e4 and e5
-    GridDim(1) = 4; GridDim(2) = 4;
-  else
-    GridDim(1) = 1; GridDim(2) = 16;
-  end
-elseif isequal(numel(labels), 12)
-  e4 = elec.elecpos(match_str(labels, num2str(4)),:);
-  e5 = elec.elecpos(match_str(labels, num2str(5)),:);
-  e6 = elec.elecpos(match_str(labels, num2str(6)),:);
-  e7 = elec.elecpos(match_str(labels, num2str(7)),:);
-  d4to5 = sqrt(sum((e4-e5).^2)); % distance of elec 4 to 5
-  d5to6 = sqrt(sum((e5-e6).^2)); % distance of elec 5 to 6
-  d6to7 = sqrt(sum((e6-e7).^2)); % distance of elec 6 to 7
-  if d4to5 > 2*d5to6 % break between e4 and e5
-    GridDim(1) = 3; GridDim(2) = 4; % 4x3 unsuppported
-  elseif d6to7 > 2*d5to6 % break between e6 and e7
-    GridDim(1) = 2; GridDim(2) = 6;
-  else
-    GridDim(1) = 1; GridDim(2) = 12;
-  end
-elseif isequal(numel(labels), 8)
-  e3 = elec.elecpos(match_str(labels, num2str(3)),:);
-  e4 = elec.elecpos(match_str(labels, num2str(4)),:);
-  e5 = elec.elecpos(match_str(labels, num2str(5)),:);
-  d3to4 = sqrt(sum((e3-e4).^2)); % distance of elec 3 to 4
-  d4to5 = sqrt(sum((e4-e5).^2)); % distance of elec 4 to 5
-  if d4to5 > 2*d3to4 % break between e4 and e5
-    GridDim(1) = 2; GridDim(2) = 4;
-  else
-    GridDim(1) = 1; GridDim(2) = 8;
-  end
-else
-  GridDim(1) = 1; GridDim(2) = numel(labels);
-end
-
-% provide feedback of what grid dimensions were found
-if any(GridDim==1) % if not because of strips, this could happen in case of missing electrodes
-  warning('assuming %d x %d grid dimensions: if incorrect, use cfg.pairmethod = ''pos'' instead\n', GridDim(1), GridDim(2));
-else
-  fprintf('assuming %d x %d grid dimensions\n', GridDim(1), GridDim(2));
 end
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
To enhance the recently added cfg.pairmethod = 'label' functionality of ft_electroderealign (PR #505 ), I created a more robust function for calculating the dimensions of sets of iEEG electrodes (grids, strips, depths) that takes into account electrode labels and positions. I have tested the function on over 50 different sets of iEEG electrodes, including depths, strips, and grids (both intact grids, and grids that have had several electrodes cut out). This function can also detect the dimensions of L-shaped grids, which are rarely used and still cannot be handled by warp_dykstra2012, but at the least, feedback is provided to the user for these cases.

Because determining grid dimensions is also a necessary part of write_bioimage_mgrid, I created a private function, determine_griddim, that is called by both warp_dykstra2012 and write_bioimage_mgrid, so that any updates to the method of determining grid dimensions can be centralized to this one private function.