### PR TITLE
fix handle errors with multiple ft_databrowser figures open

### DIFF
--- a/plotting/ft_select_range.m
+++ b/plotting/ft_select_range.m
@@ -129,7 +129,7 @@ end
 % setup contextmenu
 if ~isempty(contextmenu)
   if isempty(get(handle,'uicontextmenu'))
-    hcmenu    = uicontextmenu;
+    hcmenu    = uicontextmenu(handle);
     hcmenuopt = nan(1,numel(contextmenu));
     for icmenu = 1:numel(contextmenu)
       hcmenuopt(icmenu) = uimenu(hcmenu, 'label', contextmenu{icmenu}, 'callback', {@evalcontextcallback, callback{:}, []}); % empty matrix is placeholder, will be updated to userdata.range


### PR DESCRIPTION
Hello,

For preprocessing my data I usually open several ft_databrowser figures (for raw signal, filtered, etc..) on the same screen, and I noticed that when I passed the mouse cursor over these figures I had errors, re-appearing with each cursor move, so basically spamming the command window. As I have an interactive script for data preprocessing, it made this process very annoying.

So I went into the code and identified what happened: when the mouse cursor passes over a ft_databrowser figure, it calls ft_select_range.m which adds a uicontextmenu. But when another figure has been open after the ft_databrowser one and before the mouse cursor move, the mouse cursor moves triggers the addition of uicontextmenu to this new figure (as no handle was specified, line 132 of ft_select_range.m). Thus, when at line 147 of ft_select_range.m the 'uicontextmenu' property is addressed, it doesn't exist in the ft_databrowser figure and an error is returned ("The UIContextMenu's parent figure is not the same as the parent figure of this object"). Logically, this stops when I click on somewhere inside the ft_databrowser figure.

Correcting line 132 by specifying a handle (so that 'uicontextmenu' is added to the ft_databrowser parent figure) gets rid of this bug.

Please find attached a quick example to reproduce this bug.

Thank you,
Ludovic

[multiDataBrowserFix_example.txt](https://github.com/fieldtrip/fieldtrip/files/1452066/multiDataBrowserFix_example.txt)
