### PR TITLE
bug3368

### DIFF
--- a/fileio/private/write_gdf.m
+++ b/fileio/private/write_gdf.m
@@ -77,6 +77,12 @@ end
 % will be terrible for appending data...
 digMin = double(min(data,[],2));
 digMax = double(max(data,[],2));
+
+% adjust the the digital min/max a bit, otherwise the biosig reading code
+% will return NaNs for the most extreme values
+digMin = digMin - 1e5.*eps(digMin);
+digMax = digMax + 1e5.*eps(digMax);
+
 physMin = digMin;
 physMax = digMax;
 

--- a/test/test_bug3368.m
+++ b/test/test_bug3368.m
@@ -23,3 +23,6 @@ test_ft_header    = ft_read_header(ieeg_name_gdf);
 % now check whether the loaded data are the same as the written data, 
 % the following should be zero:
 [ok,msg] = isalmostequal(ft_data.trial{1}, test_ft_data);
+
+indx = find(isfinite(test_ft_data));
+assert(isequal(test_ft_data(indx), ft_data.trial{1}(indx))); % ensure that at least all numerical data is equal


### PR DESCRIPTION
This is something reported by Dora. Apparently sread (from the biosig toolbox), which takes care of reading gdf files, applies a hard threshold to the data read, returning NaNs for these threshold exceeding data points. The thresholds are taken from the header. Even though using <= and >= for the thresholding (wher e upon writing these thresholds are set to be the channel-specific max and min across time), occasionally the reading function returns NaNs. I solved this by slightly loosening the threshold upon writing (1e5*eps(val))