### PR TITLE
Update markers for compatibility with mne

### DIFF
--- a/fieldtrip2fiff.m
+++ b/fieldtrip2fiff.m
@@ -312,14 +312,14 @@ for i1 = 1:numel(ev_type)
     
     if any(i_type & i_value)
       eve(i_type & i_value, 1) = [event(i_type & i_value).sample];
-      eve(i_type & i_value, 2) = marker;
+      eve(i_type & i_value, 3) = marker;
     end
     
   end
 end
 
 % report event coding
-newev = unique(eve(:,2));
+newev = unique(eve(:,3));
 fprintf('EVENTS have been coded as:\n')
 for i = 1:numel(newev)
   i_type = floor(newev(i)/10);


### PR DESCRIPTION
I've updated the events matrix to [timesample 0 marker] instead of [timesample marker 0], to match what mne expects. This fixed an error given by mne after reading the converted files and extracting epochs with mne.Epochs() :

\epochs.py in __init__(***failed resolving arguments***)
    252                            '(event id %i)' % (key, val))
    253                     if on_missing == 'error':
--> 254                         raise ValueError(msg)
    255                     elif on_missing == 'warning':
    256                         warn(msg)

ValueError: No matching events found for xxx (event id xxx)