### PR TITLE
FIX - Bug 3378 - all true mask in ft_singleplotTFR

### DIFF
--- a/ft_multiplotTFR.m
+++ b/ft_multiplotTFR.m
@@ -14,11 +14,14 @@ function [cfg] = ft_multiplotTFR(cfg, data)
 % The configuration can have the following parameters:
 %   cfg.parameter        = field to be represented as color (default depends on data.dimord)
 %                          'powspctrm' or 'cohspctrm'
-%   cfg.maskparameter    = field in the data to be used for opacity masking of data
-%   cfg.maskstyle        = style used to masking, 'opacity', 'saturation', 'outline' or 'colormix' (default = 'opacity')
-%                          use 'saturation' or 'outline' when saving to vector-format (like *.eps) to avoid all
-%                          sorts of image-problems (currently only possible with a white backgroud)
-%   cfg.maskalpha        = alpha value between 0 (transparant) and 1 (opaque) used for masking areas dictated by cfg.maskparameter (default = 1)
+%   cfg.maskparameter    = field in the data to be used for masking of data, can be logical (e.g. significant data points) or numerical (e.g. t-values).
+%                        (not possible for mean over multiple channels, or when input contains multiple subjects
+%                        or trials)
+%   cfg.maskstyle        = style used to masking, 'opacity', 'saturation', or 'outline' (default = 'opacity')
+%                        'outline' can only be used with a logical cfg.maskparameter
+%                        use 'saturation' or 'outline' when saving to vector-format (like *.eps) to avoid all sorts of image-problems
+%   cfg.maskalpha        = alpha value between 0 (transparent) and 1 (opaque) used for masking areas dictated by cfg.maskparameter (default = 1)
+%                        (will be ignored in case of numeric cfg.maskparameter or if cfg.maskstyle = 'outline')   
 %   cfg.masknans         = 'yes' or 'no' (default = 'yes')
 %   cfg.xlim             = 'maxmin' or [xmin xmax] (default = 'maxmin')
 %   cfg.ylim             = 'maxmin' or [ymin ymax] (default = 'maxmin')
@@ -401,9 +404,20 @@ datamatrix = datamatrix(selchan, sely, selx);
 if ~isempty(cfg.maskparameter)
     % one value for each channel-freq-time point
   maskmatrix = data.(cfg.maskparameter)(selchan, sely, selx);
-  if cfg.maskalpha ~= 1
-    maskmatrix( maskmatrix) = 1;
+  if islogical(maskmatrix) && any(strcmp(cfg.maskstyle, {'saturation', 'opacity'}))
+    maskmatrix = double(maskmatrix);
     maskmatrix(~maskmatrix) = cfg.maskalpha;
+  elseif isnumeric(maskmatrix)
+    if strcmp(cfg.maskstyle, 'outline')
+      error('Outline masking with a numeric cfg.maskparameter is not supported. Please use a logical mask instead.')
+    end
+    if cfg.maskalpha ~= 1
+      warning(sprintf('Using field "%s" for masking, cfg.maskalpha is ignored.', cfg.maskparameter))
+    end
+    % scale mask between 0 and 1
+    minval = min(maskmatrix(:));
+    maxval = max(maskmatrix(:));
+    maskmatrix = (maskmatrix - minval) / (maxval-minval);
   end
 else
   % create an Nx0x0 matrix

--- a/ft_singleplotTFR.m
+++ b/ft_singleplotTFR.m
@@ -11,12 +11,14 @@ function [cfg] = ft_singleplotTFR(cfg, data)
 %
 % The configuration can have the following parameters:
 %   cfg.parameter      = field to be plotted on z-axis, e.g. 'powspcrtrm' (default depends on data.dimord)
-%   cfg.maskparameter  = field in the data to be used for masking of data
+%   cfg.maskparameter  = field in the data to be used for masking of data, can be logical (e.g. significant data points) or numerical (e.g. t-values).
 %                        (not possible for mean over multiple channels, or when input contains multiple subjects
 %                        or trials)
-%   cfg.maskstyle      = style used to masking, 'opacity', 'saturation', 'outline' or 'colormix' (default = 'opacity')
+%   cfg.maskstyle      = style used to masking, 'opacity', 'saturation', or 'outline' (default = 'opacity')
+%                        'outline' can only be used with a logical cfg.maskparameter
 %                        use 'saturation' or 'outline' when saving to vector-format (like *.eps) to avoid all sorts of image-problems
-%   cfg.maskalpha      = alpha value between 0 (transparant) and 1 (opaque) used for masking areas dictated by cfg.maskparameter (default = 1)
+%   cfg.maskalpha      = alpha value between 0 (transparent) and 1 (opaque) used for masking areas dictated by cfg.maskparameter (default = 1)
+%                        (will be ignored in case of numeric cfg.maskparameter or if cfg.maskstyle = 'outline')   
 %   cfg.masknans       = 'yes' or 'no' (default = 'yes')
 %   cfg.xlim           = 'maxmin' or [xmin xmax] (default = 'maxmin')
 %   cfg.ylim           = 'maxmin' or [ymin ymax] (default = 'maxmin')
@@ -330,9 +332,20 @@ datamatrix = datamatrix(selchan, sely, selx);
 
 if ~isempty(cfg.maskparameter)
   maskmatrix = data.(cfg.maskparameter)(selchan, sely, selx);
-  if cfg.maskalpha ~= 1
+  if islogical(maskmatrix) && any(strcmp(cfg.maskstyle, {'saturation', 'opacity'}))
     maskmatrix = double(maskmatrix);
     maskmatrix(~maskmatrix) = cfg.maskalpha;
+  elseif isnumeric(maskmatrix)
+    if strcmp(cfg.maskstyle, 'outline')
+      error('Outline masking with a numeric cfg.maskparameter is not supported. Please use a logical mask instead.')
+    end
+    if cfg.maskalpha ~= 1
+      warning(sprintf('Using field "%s" for masking, cfg.maskalpha is ignored.', cfg.maskparameter))
+    end
+    % scale mask between 0 and 1
+    minval = min(maskmatrix(:));
+    maxval = max(maskmatrix(:));
+    maskmatrix = (maskmatrix - minval) / (maxval-minval);
   end
 else
   % create an Nx0x0 matrix

--- a/ft_singleplotTFR.m
+++ b/ft_singleplotTFR.m
@@ -331,7 +331,7 @@ datamatrix = datamatrix(selchan, sely, selx);
 if ~isempty(cfg.maskparameter)
   maskmatrix = data.(cfg.maskparameter)(selchan, sely, selx);
   if cfg.maskalpha ~= 1
-    maskmatrix( maskmatrix) = 1;
+    maskmatrix = double(maskmatrix);
     maskmatrix(~maskmatrix) = cfg.maskalpha;
   end
 else

--- a/test/test_bug3378.m
+++ b/test/test_bug3378.m
@@ -121,3 +121,129 @@ catch ME
     axis off
 end
 title('Numeric, alpha=1')
+
+%% multiplot
+load('easycapM25.mat')
+
+data = [];
+data.powspctrm = randn(23,10,20);
+data.time = 1:20;
+data.freq = 1:10;
+data.label = lay.label;
+data.dimord = 'chan_freq_time';
+data.mask = data.powspctrm>0;
+
+figure('units','normalized','outerposition',[0 0 1 1]);
+
+subplot(4,4,[5 6 9 10])
+cfg=[];
+cfg.layout = lay;
+cfg.colorbar = 'no';
+ft_multiplotTFR(cfg,data);
+title('Unmasked')
+
+% case 1: logical mask, maskalpha < 1, opacity masking
+cfg.maskparameter = 'mask';
+cfg.maskalpha = 0.2;
+subplot(4,4,3);
+try
+    ft_multiplotTFR(cfg, data); % this works as expected
+catch ME
+    disp(getReport(ME))
+    text(0,.5, 'not supported')
+    axis off
+end
+title('Logical, alpha~=1')
+
+% case 2: numeric mask, maskalpha < 1, opacity masking
+cfg.maskparameter = 'powspctrm';
+cfg.maskalpha = 0.2;
+subplot(4,4,4);
+try
+    ft_multiplotTFR(cfg, data); % this works as expected, warning is thrown
+catch ME
+    disp(getReport(ME))
+    text(0,.5, 'not supported')
+    axis off
+end
+title('Numeric, alpha~=1')
+
+% case 3: logical mask, maskalpha = 1, opacity masking
+cfg.maskparameter = 'mask';
+cfg.maskalpha = 1;
+subplot(4,4,7);
+try
+    ft_multiplotTFR(cfg, data); % this works as expected
+catch ME
+    disp(getReport(ME))
+    text(0,.5, 'not supported')
+    axis off
+end
+title('Logical, alpha=1')
+
+% case 4: numeric mask, maskalpha = 1, opacity masking
+cfg.maskparameter = 'powspctrm';
+cfg.maskalpha = 1;
+subplot(4,4,8);
+try
+    ft_multiplotTFR(cfg, data); % this works as expected, no warning with default maskalpha
+catch ME
+    disp(getReport(ME))
+    text(0,.5, 'not supported')
+    axis off
+end
+title('Numeric, alpha=1')
+
+% case 5: logical mask, maskalpha < 1, outline masking
+cfg.maskparameter = 'mask';
+cfg.maskalpha = 0.2;
+cfg.maskstyle = 'outline';
+subplot(4,4,11);
+try
+    ft_multiplotTFR(cfg, data); % this works as expected - maskalpha is ignored
+catch ME
+    disp(getReport(ME))
+    text(0,.5, 'not supported')
+    axis off
+end
+title('Logical, alpha~=1')
+
+% case 6: numeric mask, maskalpha < 1, outline masking
+cfg.maskparameter = 'powspctrm';
+cfg.maskalpha = 0.2;
+subplot(4,4,12);
+try
+    ft_multiplotTFR(cfg, data); 
+catch ME
+    disp(getReport(ME))
+    text(0,.5, 'not supported') % this works as expected
+    axis off
+end
+title('Numeric, alpha~=1')
+
+% case 7: logical mask, maskalpha = 1, outline masking
+cfg.maskparameter = 'mask';
+cfg.maskalpha = 1;
+subplot(4,4,15);
+try
+    ft_multiplotTFR(cfg, data); % this works as expected - maskalpha is ignored
+catch ME
+    disp(getReport(ME))
+    text(0,.5, 'not supported')
+    axis off
+end
+title('Logical, alpha=1')
+
+% case 8: numeric mask, maskalpha = 1, outline masking
+cfg.maskparameter = 'powspctrm';
+cfg.maskalpha = 1;
+cfg.maskstyle = 'outline';
+subplot(4,4,16);
+try
+    ft_multiplotTFR(cfg, data); 
+catch ME
+    disp(getReport(ME))
+    text(0,.5, 'not supported') % this works as expected
+    axis off
+end
+title('Numeric, alpha=1')

--- a/test/test_bug3378.m
+++ b/test/test_bug3378.m
@@ -1,0 +1,123 @@
+function test_bug3378
+
+data = [];
+data.powspctrm = randn(1,10,20);
+data.time = 1:20;
+data.freq = 1:10;
+data.label = {'chan01'};
+data.dimord = 'chan_freq_time';
+data.mask = data.powspctrm>0;
+
+figure('units','normalized','outerposition',[0 0 1 1]);
+
+subplot(4,4,[5 6 9 10])
+cfg=[];
+cfg.colorbar = 'no';
+ft_singleplotTFR(cfg,data);
+title('Unmasked')
+
+% case 1: logical mask, maskalpha < 1, opacity masking
+cfg.maskparameter = 'mask';
+cfg.maskalpha = 0.2;
+subplot(4,4,3);
+try
+    ft_singleplotTFR(cfg, data); % this works as expected
+catch ME
+    disp(getReport(ME))
+    text(0,.5, 'not supported')
+    axis off
+end
+title('Logical, alpha~=1')
+
+% case 2: numeric mask, maskalpha < 1, opacity masking
+cfg.maskparameter = 'powspctrm';
+cfg.maskalpha = 0.2;
+subplot(4,4,4);
+try
+    ft_singleplotTFR(cfg, data); % this works as expected, warning is thrown
+catch ME
+    disp(getReport(ME))
+    text(0,.5, 'not supported')
+    axis off
+end
+title('Numeric, alpha~=1')
+
+% case 3: logical mask, maskalpha = 1, opacity masking
+cfg.maskparameter = 'mask';
+cfg.maskalpha = 1;
+subplot(4,4,7);
+try
+    ft_singleplotTFR(cfg, data); % this works as expected
+catch ME
+    disp(getReport(ME))
+    text(0,.5, 'not supported')
+    axis off
+end
+title('Logical, alpha=1')
+
+% case 4: numeric mask, maskalpha = 1, opacity masking
+cfg.maskparameter = 'powspctrm';
+cfg.maskalpha = 1;
+subplot(4,4,8);
+try
+    ft_singleplotTFR(cfg, data); % this works as expected, no warning with default maskalpha
+catch ME
+    disp(getReport(ME))
+    text(0,.5, 'not supported')
+    axis off
+end
+title('Numeric, alpha=1')
+
+% case 5: logical mask, maskalpha < 1, outline masking
+cfg.maskparameter = 'mask';
+cfg.maskalpha = 0.2;
+cfg.maskstyle = 'outline';
+subplot(4,4,11);
+try
+    ft_singleplotTFR(cfg, data); % this works as expected - maskalpha is ignored
+catch ME
+    disp(getReport(ME))
+    text(0,.5, 'not supported')
+    axis off
+end
+title('Logical, alpha~=1')
+
+% case 6: numeric mask, maskalpha < 1, outline masking
+cfg.maskparameter = 'powspctrm';
+cfg.maskalpha = 0.2;
+subplot(4,4,12);
+try
+    ft_singleplotTFR(cfg, data); 
+catch ME
+    disp(getReport(ME))
+    text(0,.5, 'not supported') % this works as expected
+    axis off
+end
+title('Numeric, alpha~=1')
+
+% case 7: logical mask, maskalpha = 1, outline masking
+cfg.maskparameter = 'mask';
+cfg.maskalpha = 1;
+subplot(4,4,15);
+try
+    ft_singleplotTFR(cfg, data); % this works as expected - maskalpha is ignored
+catch ME
+    disp(getReport(ME))
+    text(0,.5, 'not supported')
+    axis off
+end
+title('Logical, alpha=1')
+
+% case 8: numeric mask, maskalpha = 1, outline masking
+cfg.maskparameter = 'powspctrm';
+cfg.maskalpha = 1;
+cfg.maskstyle = 'outline';
+subplot(4,4,16);
+try
+    ft_singleplotTFR(cfg, data); 
+catch ME
+    disp(getReport(ME))
+    text(0,.5, 'not supported') % this works as expected
+    axis off
+end
+title('Numeric, alpha=1')


### PR DESCRIPTION
This aims to fix conversion of alpha/saturation masking values to all ones when using a logical mask in ft_singleplotTFR.