### PR TITLE
accelerate private function defaultID

### DIFF
--- a/utilities/private/defaultId.m
+++ b/utilities/private/defaultId.m
@@ -40,7 +40,9 @@ stack = stack(keep);
 
 % remove the non-FieldTrip functions from the path, these should not be part of the default message identifier
 keep = true(size(stack));
-[v, p] = ft_version;
+p = fileparts(mfilename('fullpath'));
+% strip away '/utilities/private' where this function is located
+p = p(1:end-18);
 for i=1:numel(stack)
   keep(i) = strncmp(p, stack(i).file, length(p));
 end


### PR DESCRIPTION
Calling ft_version in this function returns beside the desired path information also the fieldtrip version. This information is not used in this function, but effort to estimate it is 100 times higher compared to the path information. This small change in default ID accelerate the data processing significantly in functions where notification output is periodically generated.