### PR TITLE
ENH: cfg.refmethod = 'bipolar'

### DIFF
--- a/ft_preprocessing.m
+++ b/ft_preprocessing.m
@@ -104,7 +104,7 @@ function [data] = ft_preprocessing(cfg, data)
 % Preprocessing options that you should only use for EEG data are
 %   cfg.reref         = 'no' or 'yes' (default = 'no')
 %   cfg.refchannel    = cell-array with new EEG reference channel(s), this can be 'all' for a common average reference
-%   cfg.refmethod     = 'avg' or 'median' (default = 'avg')
+%   cfg.refmethod     = 'avg', 'median', or 'bipolar' for bipolar derivation of consecutive channels (default = 'avg')
 %   cfg.implicitref   = 'label' or empty, add the implicit EEG reference as zeros (default = [])
 %   cfg.montage       = 'no' or a montage structure, see FT_APPLY_MONTAGE (default = 'no')
 %
@@ -672,7 +672,7 @@ if strcmp(cfg.updatesens, 'yes')
       dataout.grad = ft_apply_montage(dataout.grad, montage, 'feedback', 'none', 'keepunused', 'no', 'balancename', bname);
     end
     if isfield(dataout, 'elec')
-      ft_info('applying the montage to the grad structure\n');
+      ft_info('applying the montage to the elec structure\n');
       dataout.elec = ft_apply_montage(dataout.elec, montage, 'feedback', 'none', 'keepunused', 'no', 'balancename', bname);
     end
     if isfield(dataout, 'opto')

--- a/ft_preprocessing.m
+++ b/ft_preprocessing.m
@@ -104,7 +104,7 @@ function [data] = ft_preprocessing(cfg, data)
 % Preprocessing options that you should only use for EEG data are
 %   cfg.reref         = 'no' or 'yes' (default = 'no')
 %   cfg.refchannel    = cell-array with new EEG reference channel(s), this can be 'all' for a common average reference
-%   cfg.refmethod     = 'avg', 'median', or 'bipolar' for bipolar derivation of consecutive channels (default = 'avg')
+%   cfg.refmethod     = 'avg', 'median', or 'sequential' for bipolar derivation of sequential channels (default = 'avg')
 %   cfg.implicitref   = 'label' or empty, add the implicit EEG reference as zeros (default = [])
 %   cfg.montage       = 'no' or a montage structure, see FT_APPLY_MONTAGE (default = 'no')
 %

--- a/private/preproc.m
+++ b/private/preproc.m
@@ -98,7 +98,7 @@ function [dat, label, time, cfg] = preproc(dat, label, time, cfg, begpadding, en
 % Preprocessing options that you should only use for EEG data are
 %   cfg.reref         = 'no' or 'yes' (default = 'no')
 %   cfg.refchannel    = cell-array with new EEG reference channel(s)
-%   cfg.refmethod     = 'avg', 'median', or 'bipolar' for bipolar derivation of consecutive channels (default = 'avg')
+%   cfg.refmethod     = 'avg', 'median', or 'sequential' for bipolar derivation of sequential channels (default = 'avg')
 %   cfg.implicitref   = 'label' or empty, add the implicit EEG reference as zeros (default = [])
 %   cfg.montage       = 'no' or a montage structure (default = 'no')
 %
@@ -262,7 +262,7 @@ if ~isempty(cfg.implicitref) && ~any(match_str(cfg.implicitref,label))
 end
 
 if strcmp(cfg.reref, 'yes')
-  if strcmp(cfg.refmethod, 'bipolar') % bipolar derivation of consecutive channels
+  if strcmp(cfg.refmethod, 'sequential') % bipolar derivation of sequential channels
     cfg.montage            = [];
     cfg.montage.labelold   = cfg.channel;
     cfg.montage.labelnew   = strcat(cfg.channel(1:end-1),'-',cfg.channel(2:end));
@@ -270,7 +270,7 @@ if strcmp(cfg.reref, 'yes')
     tra_plus               = diag(ones(numel(cfg.channel)-1,1),-1);
     cfg.montage.tra        = tra_neg(1:end-1,:)+tra_plus(2:end,:);
     cfg.reref              = 'no'; % cfg.reref and cfg.montage are mutually exclusive
-  else % derivation based on specified or all channels
+  else % mean or median based derivation of specified or all channels
     cfg.refchannel = ft_channelselection(cfg.refchannel, label);
     refindx = match_str(label, cfg.refchannel);
     if isempty(refindx)


### PR DESCRIPTION
Following a great suggestion by an anonymous referee, this PR adds the possibility to specify cfg.refmethod = 'bipolar'. As a result, a cfg.montage is created on the fly in preproc.m to create bipolar combinations between consecutive channels. This addition avoids users having to design eyesoring weight matrices (from a manuscript point of view) in order to simply combine consecutive channels.    