### PR TITLE
FIX: ft_timelockstat/freqstat dont copy over elec and the like from the input

### DIFF
--- a/ft_freqstatistics.m
+++ b/ft_freqstatistics.m
@@ -223,7 +223,7 @@ end
 stat.dimord = cfg.dimord;
 
 % copy the descripive fields into the output
-stat = copyfields(varargin{1}, stat, {'freq', 'time', 'label'});
+stat = copyfields(varargin{1}, stat, {'freq', 'time', 'label', 'elec', 'grad', 'opto'});
 
 % these were only present to inform the low-level functions
 cfg = removefields(cfg, {'dim', 'dimord'});

--- a/ft_timelockstatistics.m
+++ b/ft_timelockstatistics.m
@@ -214,7 +214,7 @@ end
 stat.dimord = cfg.dimord;
 
 % copy the descripive fields into the output
-stat = copyfields(varargin{1}, stat, {'time', 'label'});
+stat = copyfields(varargin{1}, stat, {'time', 'label', 'elec', 'grad', 'opto'});
 
 % these were only present to inform the low-level functions
 cfg = removefields(cfg, {'dim', 'dimord'});


### PR DESCRIPTION
Which is useful for plotting, particularly in the context of iEEG data where the elec structure is kept consistent with the neural data throughout the pipeline.

I didn't implement the same fix in ft_sourcestatistics since source structures should already have a pos field.


  