### PR TITLE
Bug3397

### DIFF
--- a/test/test_bug3397.m
+++ b/test/test_bug3397.m
@@ -1,0 +1,33 @@
+function test_bug3397
+
+% WALLTIME 00:10:00
+% MEM 1gb
+% TEST ft_appenddata ft_preamble_init
+
+data       = [];
+data.label = {'chan01';'chan02';'chan03'};
+for k = 1:10
+trial{k} = randn(3,100);
+time{k}  = (0:99)./100;
+end
+data.time  = time;
+data.trial = trial;
+ 
+alldata{1} = data;
+alldata{2} = data;
+alldata{3} = data;
+
+tmp = ft_appenddata([], alldata{:});
+assert(numel(tmp.trial)==30);
+
+try
+  ft_appenddata(alldata{:});
+catch ME
+  if strncmp(ME.message,'It seems as if the first', 24)
+    % this is the expected error
+  else
+    rethrow(ME);
+  end
+end
+
+

--- a/utilities/private/ft_preamble_init.m
+++ b/utilities/private/ft_preamble_init.m
@@ -48,7 +48,7 @@ end % if nargin
 
 % check if there are fieldnames in the cfg that suggest as if the user
 % erroneously inputted a data argument
-checkdatafields = isfield(cfg, {'label' 'dimord' 'time' 'trialinfo' 'avg'});
+checkdatafields = isfield(cfg, {'cfg' 'label' 'dimord' 'time' 'trialinfo' 'avg'});
 if any(checkdatafields)
   stack = dbstack('-completenames');
   stack = stack(3);

--- a/utilities/private/ft_preamble_init.m
+++ b/utilities/private/ft_preamble_init.m
@@ -46,6 +46,20 @@ if ft_nargin==0
   error(msg);
 end % if nargin
 
+% check if there are fieldnames in the cfg that suggest as if the user
+% erroneously inputted a data argument
+checkdatafields = isfield(cfg, {'label' 'dimord' 'time' 'trialinfo' 'avg'});
+if any(checkdatafields)
+  stack = dbstack('-completenames');
+  stack = stack(3);
+  help(stack.name);
+  % throw the error as if it happened in the original function
+  msg.message     = 'It seems as if the first input argument is a FieldTrip data structure, while a cfg is expected';
+  msg.identifier  = '';
+  msg.stack       = stack;
+  error(msg);
+end
+
 % convert automatically from cell-array to structure
 if iscell(cfg)
   cfg = ft_keyval2cfg(cfg);


### PR DESCRIPTION
This is an attempt to generically do a check on the first input argument into an FT-function, to avoid that the user can silently get away with inputting a data objects as first argument into functions like ft_appenddata, ft_timelockstatistics etc, which then happily provide output with the first data structure omitted from the computation