### PR TITLE
Bug3379

### DIFF
--- a/test/test_bug3379.m
+++ b/test/test_bug3379.m
@@ -9,17 +9,20 @@ load(dccnpath('/home/common/matlab/fieldtrip/data/test/bug3379.mat'));
 
 
 assert(isequal(tmpcfg.trl(:,1:2), testdata.sampleinfo(setdiff(1:93, [5 6]),:)));
-% since the tmpcfg.trl is the same as testdata.sampleinfo, the call to
+
+% Since the tmpcfg.trl is the same as testdata.sampleinfo, the call to
 % ft_redefinetrial is expected to lead to the same data, which it doesn't
 % note: the data contains overlapping trials.
 % Yet, the overlapping segments of the data are not identical, which should
 % have led to an error in ft_fetch_data, which it didn't. This has now been
 % fixed in ft_fetch_data, so ft_redefinetrial correctly returns an error
 % now, since the discrepancy is detected in ft_fetch_data
+
 try
   testdata2 = ft_redefinetrial(tmpcfg, testdata);
-  error('at this point, there should have been an informative error in FieldTrip');
-catch ME
-  fprintf([ME.message '\n']);
-  assert(isequal(ME.message,'some of the requested samples occur twice in the data and have conflicting values'));
+  % at this point, there should have been an informative error in FieldTrip
+  failed = false;
+catch
+  failed = true;
 end
+assert(failed,'some of the requested samples occur twice in the data and have conflicting values');

--- a/test/test_bug3379.m
+++ b/test/test_bug3379.m
@@ -1,0 +1,25 @@
+function test_bug3379
+
+% WALLTIME 00:10:00
+% MEM 1gb
+
+% TEST ft_redefinetrial ft_fetch_data
+
+load(dccnpath('/home/common/matlab/fieldtrip/data/test/bug3379.mat'));
+
+
+assert(isequal(tmpcfg.trl(:,1:2), testdata.sampleinfo(setdiff(1:93, [5 6]),:)));
+% since the tmpcfg.trl is the same as testdata.sampleinfo, the call to
+% ft_redefinetrial is expected to lead to the same data, which it doesn't
+% note: the data contains overlapping trials.
+% Yet, the overlapping segments of the data are not identical, which should
+% have led to an error in ft_fetch_data, which it didn't. This has now been
+% fixed in ft_fetch_data, so ft_redefinetrial correctly returns an error
+% now, since the discrepancy is detected in ft_fetch_data
+try
+  testdata2 = ft_redefinetrial(tmpcfg, testdata);
+  error('at this point, there should have been an informative error in FieldTrip');
+catch ME
+  fprintf([ME.message '\n']);
+  assert(isequal(ME.message,'some of the requested samples occur twice in the data and have conflicting values'));
+end

--- a/utilities/ft_fetch_data.m
+++ b/utilities/ft_fetch_data.m
@@ -132,8 +132,9 @@ if trlnum>1
       sel = find(count>1); % must be row vector
       for smplop=sel
         % find in which trials the sample occurs
-        seltrl = find(smplop>=trl(:,1) & smplop<=trl(:,2));  % which trials
-        selsmp = smplop - trl(seltrl,1) + 1;                 % which sample in each of the trials
+        seltrl = find(smplop>=trl(:,1) + 1 - begsample & ... 
+                      smplop<=trl(:,2) + 1 - begsample);  % which trials, requires the adjustment with begsample, if different from 1, JM 20180116
+        selsmp = smplop - trl(seltrl,1) + begsample; % which sample in each of the trials, requires the adjustment with begsample, rather than 1
         for i=2:length(seltrl)
           % compare all occurences to the first one
           if ~all(data.trial{seltrl(i)}(:,selsmp(i)) == data.trial{seltrl(1)}(:,selsmp(1)))


### PR DESCRIPTION
This addresses an issue in ft_fetch_data, which before did not correctly non-identical overlapping sampled data.