### PR TITLE
fixed incorrect detection of cfg.time as data

### DIFF
--- a/utilities/private/ft_preamble_init.m
+++ b/utilities/private/ft_preamble_init.m
@@ -48,7 +48,7 @@ end % if nargin
 
 % check if there are fieldnames in the cfg that suggest as if the user
 % erroneously inputted a data argument
-checkdatafields = isfield(cfg, {'cfg' 'label' 'dimord' 'time' 'trialinfo' 'avg'});
+checkdatafields = isfield(cfg, {'cfg' 'label' 'dimord' 'trialinfo' 'avg' 'powspctrm'});
 if any(checkdatafields)
   stack = dbstack('-completenames');
   stack = stack(3);


### PR DESCRIPTION
this is valid in the cfg for ft_resampledata. 

Small change to options for imotions. 