### PR TITLE
FIX regression error detected in test_bug3267 due to timelock structures now having a sampleinfo field.

### DIFF
--- a/ft_appenddata.m
+++ b/ft_appenddata.m
@@ -34,7 +34,7 @@ function [data] = ft_appenddata(cfg, varargin)
 % cell array for this particular function.
 %
 % See also FT_PREPROCESSING, FT_DATAYPE_RAW, FT_APPENDTIMELOCK, FT_APPENDFREQ,
-% FT_APPENDSENS, FT_APPENDSOURCE
+% FT_APPENDSOURCE, FT_APPENDSENS
 
 % Copyright (C) 2005-2008, Robert Oostenveld
 % Copyright (C) 2009-2011, Jan-Mathijs Schoffelen
@@ -77,8 +77,7 @@ end
 
 % check if the input data is valid for this function
 for i=1:length(varargin)
-  % FIXME: raw+comp is not always dealt with correctly
-  varargin{i} = ft_checkdata(varargin{i}, 'datatype', {'raw', 'raw+comp'}, 'feedback', 'no');
+  varargin{i} = ft_checkdata(varargin{i}, 'datatype', {'raw', 'raw+comp'}, 'feedback', 'no', 'hassampleinfo', 'no');
 end
 
 % set the defaults

--- a/ft_appendfreq.m
+++ b/ft_appendfreq.m
@@ -68,7 +68,6 @@ end
 
 % check if the input data is valid for this function
 for i=1:length(varargin)
-  % FIXME: what about freq+comp?
   varargin{i} = ft_checkdata(varargin{i}, 'datatype', {'freq', 'freq+comp'}, 'feedback', 'yes');
 end
 
@@ -107,7 +106,7 @@ if isempty(cfg.appenddim) || strcmp(cfg.appenddim, 'auto')
     end
   end
 end
-fprintf('concatenating over the "%s" dimension\n', cfg.appenddim);
+ft_info('concatenating over the "%s" dimension\n', cfg.appenddim);
 
 if isempty(cfg.parameter)
   fn = fieldnames(varargin{1});

--- a/ft_appendsource.m
+++ b/ft_appendsource.m
@@ -1,21 +1,22 @@
 function [source] = ft_appendsource(cfg, varargin)
 
-% FT_APPENDSOURCE concatenates multiple volumetric source reconstruction
-% data structures that have been processed seperately.
+% FT_APPENDSOURCE concatenates multiple volumetric source reconstruction data
+% structures that have been processed seperately.
 %
-% If the source reconstructions were computed for different ROIs or
-% different slabs of a regular 3D grid (as indicated by the source
-% positions), the data will be concatenated along the spatial dimension.
+% If the source reconstructions were computed for different ROIs or different slabs
+% of a regular 3D grid (as indicated by the source positions), the data will be
+% concatenated along the spatial dimension.
 %
-% If the source reconstructions were computed on the same source
-% positions, but for different frequencies and/or latencies, e.g. for
-% time-frequency spectrally decomposed data, the data will be concatenared
-% along the frequency and/or time dimension.
+% If the source reconstructions were computed on the same source positions, but for
+% different frequencies and/or latencies, e.g. for time-frequency spectrally
+% decomposed data, the data will be concatenared along the frequency and/or time
+% dimension.
 %
 % Use as
 %   combined = ft_appendsource(cfg, source1, source2, ...)
 %
-% See also FT_SOURCEANALYSIS, FT_APPENDDATA, FT_APPENDFREQ, FT_APPENDSOURCE
+% See also FT_SOURCEANALYSIS, FT_DATATYPE_SOURCE, FT_APPENDDATA, T_APPENDTIMELOCK,
+% FT_APPENDFREQ
 
 % Copyright (C) 2011, Robert Oostenveld
 %

--- a/ft_appendtimelock.m
+++ b/ft_appendtimelock.m
@@ -16,7 +16,7 @@ function [timelock] = ft_appendtimelock(cfg, varargin)
 %                    are allowed to still be considered compatible (default = 1e-5)
 %
 % See also FT_TIMELOCKANALYSIS, FT_DATATYPE_TIMELOCK, FT_APPENDDATA, FT_APPENDFREQ,
-% FT_APPENDSENS, FT_APPENDSOURCE
+% FT_APPENDSOURCE, FT_APPENDSENS
 
 % Copyright (C) 2011-2017, Robert Oostenveld
 %
@@ -58,8 +58,7 @@ end
 
 % check if the input data is valid for this function
 for i=1:length(varargin)
-  % FIXME: what about timelock+comp?
-  varargin{i} = ft_checkdata(varargin{i}, 'datatype', {'timelock', 'timelock+comp'}, 'feedback', 'yes', 'hassampleinfo', 'ifmakessense');
+  varargin{i} = ft_checkdata(varargin{i}, 'datatype', {'timelock', 'timelock+comp'}, 'feedback', 'yes', 'hassampleinfo', 'no');
 end
 
 % set the defaults
@@ -82,7 +81,7 @@ if isempty(cfg.appenddim) || strcmp(cfg.appenddim, 'auto')
     ft_error('cfg.appenddim should be specified');
   end
 end
-fprintf('concatenating over the "%s" dimension\n', cfg.appenddim);
+ft_info('concatenating over the "%s" dimension\n', cfg.appenddim);
 
 if isempty(cfg.parameter)
   fn = fieldnames(varargin{1});

--- a/test/test_bug3267.m
+++ b/test/test_bug3267.m
@@ -71,9 +71,9 @@ timelockAppend = ft_appendtimelock(cfg, timelockFIC, timelockFC);
 
 %% compare the two versions
 
-% these should not have sampleinfo as per specification in FT_DATATYPE_TIMELOCK
-assert(~isfield(timelockAppend, 'sampleinfo'));
-assert(~isfield(timelockAll,    'sampleinfo'));
+
+assert(~isfield(timelockAppend, 'sampleinfo')); % this should not have it
+assert( isfield(timelockAll,    'sampleinfo')); % and this one should
 
 % the order should be different
 assert(~isequal(timelockAll.trialinfo,  timelockAppend.trialinfo));

--- a/utilities/ft_checkdata.m
+++ b/utilities/ft_checkdata.m
@@ -23,7 +23,7 @@ function [data] = ft_checkdata(data, varargin)
 %   isnirs             = yes, no
 %   hasunit            = yes, no
 %   hascoordsys        = yes, no
-%   hassampleinfo      = yes, no, ifmakessense (only applies to raw data)
+%   hassampleinfo      = yes, no, ifmakessense (applies to raw and timelock data)
 %   hascumtapcnt       = yes, no (only applies to freq data)
 %   hasdim             = yes, no
 %   hasdof             = yes, no
@@ -263,7 +263,7 @@ if iscomp % this should go before israw/istimelock/isfreq
 elseif israw
   data = ft_datatype_raw(data, 'hassampleinfo', hassampleinfo);
 elseif istimelock
-  data = ft_datatype_timelock(data);
+  data = ft_datatype_timelock(data, 'hassampleinfo', hassampleinfo);
 elseif isfreq
   data = ft_datatype_freq(data);
 elseif isspike
@@ -397,7 +397,7 @@ if ~isempty(dtype)
       okflag = 1;
     elseif isequal(dtype(iCell), {'timelock+comp'}) && israw && iscomp
       data = raw2timelock(data);
-      data = ft_datatype_timelock(data);
+      data = ft_datatype_timelock(data, 'hassampleinfo', hassampleinfo);
       istimelock = 1;
       iscomp = 1;
       israw = 0;
@@ -420,19 +420,19 @@ if ~isempty(dtype)
       okflag = 1;
     elseif isequal(dtype(iCell), {'comp'}) && israw  && iscomp
       data = keepfields(data, {'label', 'topo', 'topolabel', 'unmixing', 'elec', 'grad', 'cfg'}); % these are the only relevant fields
-      data = ft_datatype_comp(data);
+      data = ft_datatype_comp(data, 'hassampleinfo', hassampleinfo);
       israw = 0;
       iscomp = 1;
       okflag = 1;
     elseif isequal(dtype(iCell), {'comp'}) && istimelock && iscomp
       data = keepfields(data, {'label', 'topo', 'topolabel', 'unmixing', 'elec', 'grad', 'cfg'}); % these are the only relevant fields
-      data = ft_datatype_comp(data);
+      data = ft_datatype_comp(data, 'hassampleinfo', hassampleinfo);
       istimelock = 0;
       iscomp = 1;
       okflag = 1;
     elseif isequal(dtype(iCell), {'comp'}) && isfreq && iscomp
       data = keepfields(data, {'label', 'topo', 'topolabel', 'unmixing', 'elec', 'grad', 'cfg'}); % these are the only relevant fields
-      data = ft_datatype_comp(data);
+      data = ft_datatype_comp(data, 'hassampleinfo', 'no'); % freq data does not have sampleinfo
       isfreq = 0;
       iscomp = 1;
       okflag = 1;
@@ -441,14 +441,14 @@ if ~isempty(dtype)
         data = removefields(data, {'topo', 'topolabel', 'unmixing'}); % these fields are not desired
         iscomp = 0;
       end
-      data = ft_datatype_raw(data);
+      data = ft_datatype_raw(data, 'hassampleinfo', hassampleinfo);
       okflag = 1;
     elseif isequal(dtype(iCell), {'timelock'}) && istimelock
       if iscomp
         data = removefields(data, {'topo', 'topolabel', 'unmixing'}); % these fields are not desired
         iscomp = 0;
       end
-      data = ft_datatype_timelock(data);
+      data = ft_datatype_timelock(data, 'hassampleinfo', hassampleinfo);
       okflag = 1;
     elseif isequal(dtype(iCell), {'freq'}) && isfreq
       if iscomp
@@ -463,7 +463,7 @@ if ~isempty(dtype)
         iscomp = 0;
       end
       data = raw2timelock(data);
-      data = ft_datatype_timelock(data);
+      data = ft_datatype_timelock(data, 'hassampleinfo', hassampleinfo);
       israw = 0;
       istimelock = 1;
       okflag = 1;
@@ -481,13 +481,13 @@ if ~isempty(dtype)
     elseif isequal(dtype(iCell), {'raw'}) && ischan
       data = chan2timelock(data);
       data = timelock2raw(data);
-      data = ft_datatype_raw(data);
+      data = ft_datatype_raw(data, 'hassampleinfo', hassampleinfo);
       ischan = 0;
       israw = 1;
       okflag = 1;
     elseif isequal(dtype(iCell), {'timelock'}) && ischan
       data = chan2timelock(data);
-      data = ft_datatype_timelock(data);
+      data = ft_datatype_timelock(data, 'hassampleinfo', hassampleinfo);
       ischan = 0;
       istimelock = 1;
       okflag = 1;

--- a/utilities/ft_datatype_freq.m
+++ b/utilities/ft_datatype_freq.m
@@ -6,7 +6,7 @@ function [freq] = ft_datatype_freq(freq, varargin)
 % channel-level data. This data structure is usually generated with the
 % FT_FREQANALYSIS function.
 %
-% An example of a freq structure containing the powerspectrum for 306 channels
+% An example of a freq data structure containing the powerspectrum for 306 channels
 % and 120 frequencies is
 %
 %       dimord: 'chan_freq'          defines how the numeric data should be interpreted
@@ -15,7 +15,7 @@ function [freq] = ft_datatype_freq(freq, varargin)
 %         freq: [1x120 double]       the frequencies expressed in Hz
 %          cfg: [1x1 struct]         the configuration used by the function that generated this data structure
 %
-% An example of a freq structure containing the time-frequency resolved
+% An example of a freq data structure containing the time-frequency resolved
 % spectral estimates of power (i.e. TFR) for 306 channels, 120 frequencies
 % and 60 timepoints is
 %
@@ -37,11 +37,6 @@ function [freq] = ft_datatype_freq(freq, varargin)
 %
 % Obsoleted fields:
 %   - <none>
-%
-% Historical fields:
-%   - cfg, crsspctrm, cumsumcnt, cumtapcnt, dimord, elec, foi,
-%   fourierspctrm, freq, grad, label, labelcmb, powspctrm, time, toi, see
-%   bug2513
 %
 % Revision history:
 %
@@ -113,16 +108,17 @@ end
 switch version
   case '2011'
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    % ensure that the sensor structures are up to date
     if isfield(freq, 'grad')
-      % ensure that the gradiometer structure is up to date
       freq.grad = ft_datatype_sens(freq.grad);
     end
-
     if isfield(freq, 'elec')
-      % ensure that the electrode structure is up to date
       freq.elec = ft_datatype_sens(freq.elec);
     end
-
+    if isfield(freq, 'opto')
+      freq.opto = ft_datatype_sens(freq.opto);
+    end
+    
     if isfield(freq, 'foi') && ~isfield(freq, 'freq')
       % this was still the case in early 2006
       freq.freq = freq.foi;

--- a/utilities/ft_datatype_mvar.m
+++ b/utilities/ft_datatype_mvar.m
@@ -7,8 +7,8 @@ function [mvar] = ft_datatype_mvar(mvar, varargin)
 % in the frequency-domain. This is usually obtained from FT_MVARANALYSIS,
 % optionally in combination with FT_FREQANALYSIS.
 %
-% The following is an example of sensor level MVAR model data in the time
-% domain
+% The following is an example of sensor level MVAR model data in the time domain
+%
 %        dimord: 'chan_chan_lag'     defines how the numeric data should be interpreted
 %         label: {3x1 cell}          the channel labels
 %        coeffs: [3x3x5 double]      numeric data (MVAR model coefficients 3 channels x 3 channels x 5 time lags)
@@ -17,8 +17,8 @@ function [mvar] = ft_datatype_mvar(mvar, varargin)
 %   fsampleorig: 200
 %           cfg: [1x1 struct]
 %
-% The following is an example of sensor-level MVAR model data in the frequency
-% domain
+% The following is an example of sensor-level MVAR model data in the frequency domain
+%
 %        dimord: 'chan_chan_freq'    defines how the numeric data should be interpreted
 %         label: {3x1 cell}          the channel labels
 %          freq: [1x101 double]      the frequencies, expressed in Hz
@@ -86,14 +86,15 @@ end
 switch version
   case '2011'
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    % ensure that the sensor structures are up to date
     if isfield(mvar, 'grad')
-      % ensure that the gradiometer structure is up to date
       mvar.grad = ft_datatype_sens(mvar.grad);
     end
-
     if isfield(mvar, 'elec')
-      % ensure that the electrode structure is up to date
       mvar.elec = ft_datatype_sens(mvar.elec);
+    end
+    if isfield(mvar, 'opto')
+      mvar.opto = ft_datatype_sens(mvar.opto);
     end
 
   case '2008'

--- a/utilities/ft_datatype_raw.m
+++ b/utilities/ft_datatype_raw.m
@@ -16,23 +16,19 @@ function [data] = ft_datatype_raw(data, varargin)
 %      trialinfo: [266x1 double]    optional trigger or condition codes for each trial
 %            hdr: [1x1 struct]      the full header information of the original dataset on disk
 %           grad: [1x1 struct]      information about the sensor array (for EEG it is called elec)
-%            cfg: [1x1 struct]      the configuration used by the function that generated this data structure
+%           cfg: [1x1 struct]       the configuration used by the function that generated this data structure
 %
 % Required fields:
 %   - time, trial, label
 %
 % Optional fields:
-%   - sampleinfo, trialinfo, grad, elec, hdr, cfg
+%   - sampleinfo, trialinfo, grad, elec, opto, hdr, cfg
 %
 % Deprecated fields:
 %   - fsample
 %
 % Obsoleted fields:
 %   - offset
-%
-% Historical fields:
-%   - cfg, elec, fsample, grad, hdr, label, offset, sampleinfo, time,
-%   trial, trialdef, see bug2513
 %
 % Revision history:
 %
@@ -136,14 +132,15 @@ end
 switch version
   case '2011'
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    % ensure that the sensor structures are up to date
     if isfield(data, 'grad')
-      % ensure that the gradiometer structure is up to date
       data.grad = ft_datatype_sens(data.grad);
     end
-    
     if isfield(data, 'elec')
-      % ensure that the electrode structure is up to date
       data.elec = ft_datatype_sens(data.elec);
+    end
+    if isfield(data, 'opto')
+      data.opto = ft_datatype_sens(data.opto);
     end
     
     if ~isfield(data, 'fsample')

--- a/utilities/ft_datatype_source.m
+++ b/utilities/ft_datatype_source.m
@@ -31,10 +31,6 @@ function [source] = ft_datatype_source(source, varargin)
 % Obsoleted fields:
 %   - xgrid, ygrid, zgrid, transform, latency, frequency
 %
-% Historical fields:
-%   - avg, cfg, cumtapcnt, df, dim, freq, frequency, inside, method,
-%   outside, pos, time, trial, vol, see bug2513
-%
 % Revision history:
 %
 % (2014) The subfields in the avg and trial fields are now present in the

--- a/utilities/ft_datatype_timelock.m
+++ b/utilities/ft_datatype_timelock.m
@@ -2,37 +2,31 @@ function [timelock] = ft_datatype_timelock(timelock, varargin)
 
 % FT_DATATYPE_TIMELOCK describes the FieldTrip MATLAB structure for timelock data
 %
-% The timelock data structure represents averaged or non-averaged
-% event-releted potentials (ERPs, in case of EEG) or ERFs (in case
-% of MEG). This data structure is usually generated with the
-% FT_TIMELOCKANALYSIS or FT_TIMELOCKGRANDAVERAGE function.
+% The timelock data structure represents averaged or non-averaged event-releted
+% potentials (ERPs, in case of EEG) or ERFs (in case of MEG). This data structure is
+% usually generated with the FT_TIMELOCKANALYSIS or FT_TIMELOCKGRANDAVERAGE function.
 %
-% An example of a timelock structure containing the ERF for 151 channels
-% MEG data is
+% An example of a timelock structure containing the ERF for 151 channels MEG data is
 %
 %     dimord: 'chan_time'       defines how the numeric data should be interpreted
-%        avg: [151x600 double]  the numeric data (in this example it contains the average values of the activity for 151 channels x 600 timepoints)
+%        avg: [151x600 double]  the average values of the activity for 151 channels x 600 timepoints
+%        var: [151x600 double]  the variance of the activity for 151 channels x 600 timepoints
 %      label: {151x1 cell}      the channel labels (e.g. 'MRC13')
 %       time: [1x600 double]    the timepoints in seconds
-%        var: [151x600 double]  the variance of the activity for 151 channels x 600 timepoints
-%       grad: [1x1 struct]      information about the sensor array (for EEG-data it is called elec)
-%        cfg: [1x1 struct]      configuration structure used by the invoking FieldTrip function
+%       grad: [1x1 struct]      information about the sensor array (for EEG data it is called elec)
+%        cfg: [1x1 struct]      the configuration used by the function that generated this data structure
 %
 % Required fields:
 %   - label, dimord, time
 %
 % Optional fields:
-%   - avg, var, dof, cov, trial, grad, elec, cfg
+%   - avg, var, dof, cov, trial, trialinfo, sampleinfo, grad, elec, opto, cfg
 %
 % Deprecated fields:
 %   - <none>
 %
 % Obsoleted fields:
 %   - fsample
-%
-% Historical fields:
-%   - avg, cfg, cov, dimord, dof, dofvec, elec, fsample, grad, label,
-% numcovsamples, numsamples, time, trial, var, see bug2513
 %
 % Revision history:
 %
@@ -69,7 +63,43 @@ function [timelock] = ft_datatype_timelock(timelock, varargin)
 % $Id$
 
 % get the optional input arguments, which should be specified as key-value pairs
-version = ft_getopt(varargin, 'version', 'latest');
+version       = ft_getopt(varargin, 'version', 'latest');
+hassampleinfo = ft_getopt(varargin, 'hassampleinfo', 'ifmakessense'); % can be yes/no/ifmakessense
+hastrialinfo  = ft_getopt(varargin, 'hastrialinfo',  'ifmakessense'); % can be yes/no/ifmakessense
+
+if isequal(hassampleinfo, 'ifmakessense')
+  hassampleinfo = 'no'; % default to not adding it
+  if isfield(timelock, 'sampleinfo') && isfield(timelock, 'trial') && size(timelock.sampleinfo,1)~=size(timelock.trial,1)
+    % it does not make sense, so don't keep it
+    hassampleinfo = 'no';
+  end
+  if isfield(timelock, 'sampleinfo') && isfield(timelock, 'trial')
+    hassampleinfo = 'yes'; % if it's already there, consider keeping it
+    numsmp = timelock.sampleinfo(:,2)-timelock.sampleinfo(:,1)+1;
+    if ~all(size(timelock.trial,3)==numsmp)
+      % it does not make sense, so don't keep it
+      hassampleinfo = 'no';
+      % the actual removal will be done further down
+      ft_warning('removing inconsistent sampleinfo');
+    end
+  end
+end
+
+if isequal(hastrialinfo, 'ifmakessense')
+  hastrialinfo = 'no';
+  if isfield(timelock, 'trialinfo') && isfield(timelock, 'trial')
+    hastrialinfo = 'yes';
+    if size(timelock.trialinfo,1)~=size(timelock.trial,1)
+      % it does not make sense, so don't keep it
+      hastrialinfo = 'no';
+      ft_warning('removing inconsistent trialinfo');
+    end
+  end
+end
+
+% convert it into true/false
+hassampleinfo = istrue(hassampleinfo);
+hastrialinfo  = istrue(hastrialinfo);
 
 if strcmp(version, 'latest')
   version = '2017';
@@ -99,9 +129,16 @@ end
 
 switch version
   case '2017'
-    if isfield(timelock, 'sampleinfo'), sampleinfo = timelock.sampleinfo; end
-    timelock = ft_datatype_timelock(timelock, 'version', '2011v2');
-    if exist('sampleinfo', 'var'), timelock.sampleinfo = sampleinfo; end
+    % ensure that the sensor structures are up to date
+    if isfield(timelock, 'grad')
+      timelock.grad = ft_datatype_sens(timelock.grad);
+    end
+    if isfield(timelock, 'elec')
+      timelock.elec = ft_datatype_sens(timelock.elec);
+    end
+    if isfield(timelock, 'opto')
+      timelock.opto = ft_datatype_sens(timelock.opto);
+    end
     
     fn = fieldnames(timelock);
     fn = setdiff(fn, ignorefields('appendtimelock'));
@@ -126,16 +163,30 @@ switch version
       end
     end
     
-  case '2011v2'
-    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-    if isfield(timelock, 'grad')
-      % ensure that the gradiometer structure is up to date
-      timelock.grad = ft_datatype_sens(timelock.grad);
+    if (hassampleinfo && ~isfield(timelock, 'sampleinfo')) || (hastrialinfo && ~isfield(timelock, 'trialinfo'))
+      % try to reconstruct the sampleinfo and trialinfo
+      timelock = fixsampleinfo(timelock);
     end
     
+    if ~hassampleinfo && isfield(timelock, 'sampleinfo')
+      timelock = rmfield(timelock, 'sampleinfo');
+    end
+    
+    if ~hastrialinfo && isfield(timelock, 'trialinfo')
+      timelock = rmfield(timelock, 'trialinfo');
+    end
+
+  case '2011v2'
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    % ensure that the sensor structures are up to date
+    if isfield(timelock, 'grad')
+      timelock.grad = ft_datatype_sens(timelock.grad);
+    end
     if isfield(timelock, 'elec')
-      % ensure that the electrode structure is up to date
       timelock.elec = ft_datatype_sens(timelock.elec);
+    end
+    if isfield(timelock, 'opto')
+      timelock.opto = ft_datatype_sens(timelock.opto);
     end
     
     % these fields can be present in raw data, but not desired in timelock data

--- a/utilities/private/fixsampleinfo.m
+++ b/utilities/private/fixsampleinfo.m
@@ -40,7 +40,7 @@ if hastrial
   end
 else
   ntrial = dimlength(data, 'rpt');
-  if ~isfinite(ntrial) && strcmp(data.dimord(1:6), 'rpttap') && isfield(data, 'cumtapcnt'),
+  if ~isfinite(ntrial) && strcmp(data.dimord(1:6), 'rpttap') && isfield(data, 'cumtapcnt')
     ntrial = numel(data.cumtapcnt);
   elseif ~isfinite(ntrial)
     ntrial = 1;
@@ -84,7 +84,7 @@ if isempty(trl) || ~all(nsmp==trl(:,2)-trl(:,1)+1)
   ft_warning('reconstructing sampleinfo by assuming that the trials are consecutive segments of a continuous recording');
   % construct a trial definition on the fly, assume that the trials are
   % consecutive segments of a continuous recording
-  if ntrial==1,
+  if ntrial==1
     begsample = 1;
   else
     begsample = cat(1, 0, cumsum(nsmp(1:end-1))) + 1;
@@ -94,8 +94,8 @@ if isempty(trl) || ~all(nsmp==trl(:,2)-trl(:,1)+1)
   if istimelock
     offset = ones(ntrial,1) .* time2offset(data.time, data.fsample);
   else
-    offset    = zeros(ntrial,1);
-    if hastime,
+    offset = zeros(ntrial,1);
+    if hastime
       for i=1:ntrial
         offset(i) = time2offset(data.time{i}, data.fsample);
       end
@@ -111,7 +111,7 @@ elseif ~isfield(data, 'sampleinfo') && isempty(trl)
   ft_warning('failed to create sampleinfo field');
 end
 
-if (~isfield(data, 'trialinfo') || isempty(data.trialinfo)) && ~isempty(trl) && size(trl, 2) > 3,
+if (~isfield(data, 'trialinfo') || isempty(data.trialinfo)) && ~isempty(trl) && size(trl, 2) > 3
   data.trialinfo = trl(:, 4:end);
 end
 


### PR DESCRIPTION
For this I had to make the sampleinfo handling consistent between ft_dataype_raw, comp and timelock and ensure that it is consistently called from within ft_checkdata. 

In ft_appenddata and ft_appendtimelock I am now explicitly passing hassampleinfo=no  to ft_checkdata (which passes it to the ft_datatype_xxx functions). 

So appended timelock structures will not have sampleinfo. 

