### PR TITLE
Fix error when giving single TPMs as string

### DIFF
--- a/ft_volumesegment.m
+++ b/ft_volumesegment.m
@@ -426,7 +426,7 @@ if dotpm
         
       elseif strcmp(cfg.spmmethod, 'new') || strcmp(cfg.spmmethod, 'mars')
         cfg.tpm = ft_getopt(cfg, 'tpm');
-        cfg.tpm = char(cfg.tpm(:));
+        cfg.tpm = char(cfg.tpm);
         if ~isfield(cfg, 'tpm') || isempty(cfg.tpm)
           cfg.tpm = fullfile(spm('dir'),'tpm','TPM.nii');
         end


### PR DESCRIPTION
If cfg.tpm is a single string, char(cfg.tpm(:)) results in a long column of single characters, which SPM interprets as one TPM each.

char(cfg.tpm) behaves as intended for cell-arrays of strings but works also for a single string.

Tested with single strings and cell arrays of strings on Matlab2015b/Windows 7 and Matlab2016b/Linux.