### PR TITLE
speedup elec conversion

### DIFF
--- a/imotions2fieldtrip.m
+++ b/imotions2fieldtrip.m
@@ -100,7 +100,7 @@ for i=1:numel(label)
   end
   
   % try converting the first 20 elements
-  if numel(time)>10
+  if numel(time)>20
     str = dat.table.(label{i})(1:20);
     val = str2double(str);
     if any(~cellfun(@isempty, str) & isnan(val))

--- a/utilities/ft_datatype_sens.m
+++ b/utilities/ft_datatype_sens.m
@@ -161,7 +161,8 @@ switch version
     sens = fixoldorg(sens, false);
     
     % ensure that all numbers are represented in double precision
-    sens = ft_struct2double(sens);
+    % this only affects the top-level fields and does not recurse
+    sens = ft_struct2double(sens, 1);
     
     % in version 2011v2 this was optional, now it is required
     if ~isfield(sens, 'chantype') || all(strcmp(sens.chantype, 'unknown'))

--- a/utilities/ft_struct2double.m
+++ b/utilities/ft_struct2double.m
@@ -50,7 +50,8 @@ x = convert(x, 0, maxdepth);
 function [a] = convert(a, depth, maxdepth)
 
 if depth>maxdepth
-  ft_error('recursive depth exceeded');
+  % only convert up to the specified level
+  return
 end
 
 switch class(a)
@@ -67,21 +68,21 @@ switch class(a)
         a(j) = setfield(a(j), fn, ra);
       end
     end
-
+    
   case 'cell'
     % process all elements of the cell-array recursively
     % warning, this is a recursive call to traverse nested structures
     for i=1:length(a(:))
       a{i} = convert(a{i}, depth+1, maxdepth);
     end
-
+    
   case {'single' 'int64' 'uint64' 'int32' 'uint32' 'int16' 'uint16' 'int8' 'uint8'}
     % convert the values to double precision
     a = double(a);
-
+    
   case 'double'
     % keep as it is
-
+    
   otherwise
     % do nothing
 end


### PR DESCRIPTION
as discussed with @StolkArjen over email. The struct2double only needs to be done for the data fields, not for the provenance.