### PR TITLE
Colormix colorbar

### DIFF
--- a/ft_sourceplot.m
+++ b/ft_sourceplot.m
@@ -1267,9 +1267,6 @@ switch cfg.method
             set(hc, 'YLim', [fcolmin fcolmax]);
         else
             % functional values have been transformed to be scaled
-            set(hc,'ticks',(0:0.1:1));
-            set(hc,'ticklabels',round(100*linspace(fcolmin,fcolmax,numel(get(hc,'ticks'))'))./100);
-            set(hc,'limits',[0 1]);
         end
       else
         ft_warning('no colorbar possible without functional data')

--- a/plotting/ft_plot_mesh.m
+++ b/plotting/ft_plot_mesh.m
@@ -315,6 +315,7 @@ switch maskstyle
     bgcolor = repmat(facecolor, [numel(vertexcolor) 1]);
     rgb     = bg_rgba2rgb(bgcolor, vertexcolor, cmap, clim, facealpha, alphamapping, alphalim);
     set(hs, 'FaceVertexCData', rgb, 'facecolor', 'interp');
+    if ~isempty(clim); caxis(clim); end % set colorbar scale to match [fcolmin fcolmax]
 end
 
 if faceindex


### PR DESCRIPTION
@schoffelen This should now do for correctly setting the colorbar when 'colormix' is selected. Caxis is set in ft_plot_mesh.