### PR TITLE
Adopt to OpenMEEG 2.4

### DIFF
--- a/external/openmeeg/openmeeg_sensinterpolmat.m
+++ b/external/openmeeg/openmeeg_sensinterpolmat.m
@@ -1,0 +1,128 @@
+function [gain] = openmeeg_sensinterpolmat(elec, vol)
+
+% openmeeg_sensinterpolmat computes the OpenMEEG sensor interpolation matrix
+% adopted from openmeeg_DSM
+
+% store the current path and change folder to the temporary one
+tmpfolder = cd;
+om_checkombin;
+
+bndom = vol.bnd;
+
+try
+    cd(tempdir)
+
+    % write the triangulations to file
+    bndfile = {};
+    for i=1:length(vol.bnd)
+        [~,tname] = fileparts(tempname);
+        bndfile{i} = [tname '.tri'];
+        ok = checknormals(bndom(i));
+        if ~ok
+          bndom(i).tri = fliplr(bndom(i).tri);
+        end
+        om_save_tri(bndfile{i}, bndom(i).pos, bndom(i).tri);
+    end
+    
+    % these will hold the shell script and the inverted system matrix
+    [~,tname] = fileparts(tempname);
+    if ~ispc
+      exefile = [tname '.sh'];
+    else
+      exefile = [tname '.bat'];
+    end
+
+    [~,tname] = fileparts(tempname);
+    condfile = [tname '.cond'];
+    [~,tname] = fileparts(tempname);
+    geomfile = [tname '.geom'];
+    [~,tname] = fileparts(tempname);
+    electrodefile = [tname '.elec'];
+    [~,tname] = fileparts(tempname);
+    h2mfile = [tname '.bin'];
+
+    % write conductivity and geometry files
+    om_write_geom(geomfile,bndfile);
+    om_write_cond(condfile,vol.cond);
+
+    % handle electrode file
+    elec=ft_convert_units(elec,vol.unit);
+    om_save_full(elec.elecpos,electrodefile,'ascii');
+
+    % Exe file
+    efid = fopen(exefile, 'w');
+    omp_num_threads = feature('numCores');
+
+    str = ' -H2EM';
+
+    if ~ispc
+      fprintf(efid,'#!/usr/bin/env bash\n');
+      fprintf(efid,['export OMP_NUM_THREADS=',num2str(omp_num_threads),'\n']);
+      fprintf(efid,['om_assemble' str ' ./',geomfile,' ./',condfile,' ./',electrodefile,' ./',h2mfile,' 2>&1 > /dev/null\n']);
+    else
+      fprintf(efid,['om_assemble' str ' ./',geomfile,' ./',condfile,' ./',electrodefile,' ./',h2mfile,'\n']);
+    end
+    
+    fclose(efid);
+    if ~ispc
+      dos(sprintf('chmod +x %s', exefile));
+    end
+catch
+    cd(tmpfolder)
+    rethrow(lasterror)
+end
+
+try
+    % execute OpenMEEG and read the resulting file
+    disp(['Assembling OpenMEEG Sensor Interpolation matrix']);
+    stopwatch = tic;
+    if ispc
+        dos([exefile]);
+    else
+        dos(['./' exefile]);
+    end
+    gain = om_load_sparse(h2mfile,'binary');
+    toc(stopwatch);
+    cleaner(vol,bndfile,condfile,geomfile,exefile,electrodefile,h2mfile)
+    cd(tmpfolder)
+catch
+    warning('an error ocurred while running OpenMEEG');
+    disp(lasterr);
+    cleaner(vol,bndfile,condfile,geomfile,exefile,electrodefile,h2mfile)
+    cd(tmpfolder)
+end
+
+function cleaner(vol,bndfile,condfile,geomfile,exefile,electrodefile,h2mfile)
+% delete the temporary files
+for i=1:length(vol.bnd)
+    if exist(bndfile{i},'file'),delete(bndfile{i}),end
+end
+if exist(condfile,'file'),delete(condfile);end
+if exist(geomfile,'file'),delete(geomfile);end
+if exist(exefile,'file'),delete(exefile);end
+if exist(electrodefile,'file'),delete(electrodefile);end
+if exist(h2mfile,'file'),delete(h2mfile);end
+
+function ok = checknormals(bnd)
+% FIXME: this method is rigorous only for star shaped surfaces
+ok = 0;
+pnt = bnd.pos;
+tri = bnd.tri;
+% translate to the center
+org = mean(pnt,1);
+pnt(:,1) = pnt(:,1) - org(1);
+pnt(:,2) = pnt(:,2) - org(2);
+pnt(:,3) = pnt(:,3) - org(3);
+
+w = sum(solid_angle(pnt, tri));
+
+if w<0 && (abs(w)-4*pi)<1000*eps
+  ok = 0;
+%   warning('your normals are outwards oriented\n')
+elseif w>0 && (abs(w)-4*pi)<1000*eps
+  ok = 1;
+%   warning('your normals are inwards oriented')
+else
+  error('your surface probably is irregular\n')
+  ok = 0;
+end

--- a/forward/ft_prepare_vol_sens.m
+++ b/forward/ft_prepare_vol_sens.m
@@ -419,7 +419,7 @@ elseif iseeg
       end
       sens.elecpos = pos;
       
-    case {'bem', 'dipoli', 'asa', 'bemcp', 'openmeeg'}
+    case {'bem', 'dipoli', 'asa', 'bemcp'}
       %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
       % do postprocessing of volume and electrodes in case of BEM model
       %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -466,23 +466,19 @@ elseif iseeg
           % this speeds up the subsequent repeated leadfield computations
           fprintf('combining electrode transfer and system matrix\n');
           
-          if strcmp(ft_voltype(headmodel), 'openmeeg')
-            % check that the external toolbox is present
-            ft_hastoolbox('openmeeg', 1);
-            nb_points_external_surface = size(headmodel.bnd(headmodel.skin_surface).pos,1);
-            headmodel.mat = headmodel.mat((end-nb_points_external_surface+1):end,:);
-            headmodel.mat = interp(:,1:nb_points_external_surface) * headmodel.mat;
-            
-          else
-            % convert to sparse matrix to speed up the subsequent multiplication
-            interp  = sparse(interp);
-            headmodel.mat = interp * headmodel.mat;
-            % ensure that the model potential will be average referenced
-            avg = mean(headmodel.mat, 1);
-            headmodel.mat = headmodel.mat - repmat(avg, size(headmodel.mat,1), 1);
-          end
+          % convert to sparse matrix to speed up the subsequent multiplication
+          interp  = sparse(interp);
+          headmodel.mat = interp * headmodel.mat;
+          % ensure that the model potential will be average referenced
+          avg = mean(headmodel.mat, 1);
+          headmodel.mat = headmodel.mat - repmat(avg, size(headmodel.mat,1), 1);
         end
       end
+    case  'openmeeg' 
+      if ~isfield(headmodel, 'tra') && (isfield(headmodel, 'mat') && ~isempty(headmodel.mat))
+            SensInterPol=openmeeg_sensinterpolmat(sens,headmodel);
+            headmodel.mat =SensInterPol * headmodel.mat;
+      end  
       
     case 'fns'
       if isfield(headmodel,'bnd')


### PR DESCRIPTION
The new version of OpenMEEG (2.4) has changed its output because it can now handle also nested topologies. The order of the variables in the system matrix has changed. The sensor interpolations done in ft_prepare_vol don't work anymore and lead to wrong results.
Using the sensor interpolations calculated by OpenMEEG itself solves this for all versions as it is always matching the head matrix. Additionally it might bring qualitative improvements as it is directly derived from the head model.
You will need an additional function `openmeeg_sensinterpolmat` which I am happy to provide (within this branch).
Note: The polarity of the voltages flip but this is now correct as it was wrong before (validated with FEM head models).
Closes #674