### PR TITLE
added option to reset light position with key press for method = headshape

### DIFF
--- a/ft_electrodeplacement.m
+++ b/ft_electrodeplacement.m
@@ -952,6 +952,19 @@ if isempty(key)
   key = '';
 end
 
+if strcmp(opt.method, 'headshape')
+  % some keyboard commands apply only to the headshape method
+  
+  switch key
+    case 'v' % camlight angle reset
+      delete(findall(h,'Type','light')) % shut out the lights
+      camlight; lighting gouraud; % add a new light from the current camera position
+    otherwise
+      % do nothing
+      
+  end % switch key
+end
+
 % the following code is largely shared with FT_SOURCEPLOT
 switch key
   case {'' 'shift+shift' 'alt-alt' 'control+control' 'command-0'}


### PR DESCRIPTION
When users are placing electrodes on a headshape mesh, the default light position is directly above the brain, which causes shadows below and on the side of the brain. This can make placing electrodes more difficult when viewing the brain from an angle other than directly above (necessary for more lateral/inferior electrodes). Therefore, I added a hidden keyboard option that allows users to reset the position of the light to the current camera position by pressing the v key, which was previously not assigned. 

I structured the code in a way that would allow for the simple addition of other keyboard options that are specific to the headshape method, such as the w/a/s/d rotate functionality that is described in the command window when the function is called with cfg.method = 'headshape'.