### PR TITLE
excluding cfg.grid from recursive size checking for massive speedup (bug 3419)

### DIFF
--- a/utilities/ft_checkconfig.m
+++ b/utilities/ft_checkconfig.m
@@ -725,7 +725,7 @@ if (s.bytes <= max_size)
 end
 
 % these fields should not be handled recursively
-norecursion = {'event', 'headmodel', 'leadfield'};
+norecursion = {'event', 'headmodel', 'leadfield', 'grid'};
 
 fieldsorig = fieldnames(cfg);
 for i=1:numel(fieldsorig)


### PR DESCRIPTION
See http://bugzilla.fieldtriptoolbox.org/show_bug.cgi?id=3419