### PR TITLE
added option to define ft_databrowser figure position

### DIFF
--- a/ft_databrowser.m
+++ b/ft_databrowser.m
@@ -53,6 +53,7 @@ function [cfg] = ft_databrowser(cfg, data)
 %                                 be passed to the selfun (default = 'selected')
 %   cfg.renderer                = string, 'opengl', 'zbuffer', 'painters', see MATLAB Figure Properties. If the databrowser
 %                                 crashes, you should try 'painters'.
+%   cfg.position                = location and size of the figure, specified as a vector of the form [left bottom width height].
 %
 % The following options for the scaling of the EEG, EOG, ECG, EMG and MEG channels is
 % optional and can be used to bring the absolute numbers of the different channel
@@ -661,7 +662,11 @@ end
 opt.changedchanflg = true; % trigger for redrawing channel labels and preparing layout again (see bug 2065 and 2878)
 
 % create fig
-h = figure;
+if isfield(cfg, 'position')
+    h = figure('Position', cfg.position);
+else
+    h = figure;
+end
 
 % put appdata in figure
 setappdata(h, 'opt', opt);


### PR DESCRIPTION
Hello,

As I frequently open several ft_databrowser figures on my screen (e.g., to compare different preprocessing strategies on the same data), I was struggling to position them properly. The use of set(gcf, 'Position', [a b c d]) was poorly working when running a script, as it was sometimes called before the the figure was actually displayed, and a pause wasn't always solving it; further, it was involving two displays of the figure (a first one at opening, and a second after defining the new position), thus it was a barely ok solution, but computationally inefficient.
With a very simple edit, one can now call ft_databrowser with cfg.position defined as a classic [left bottom width height] vector, and therefore get a clean figure positioning process.
Also briefly edited the ft_databrowser header to describe this functionality.

Best,
Ludovic