### PR TITLE
fix a crosshair bug in ft_volumerealign top and bottom left plots

### DIFF
--- a/ft_volumerealign.m
+++ b/ft_volumerealign.m
@@ -1909,10 +1909,10 @@ if opt.viewresult
 end
 
 if ~isempty(tag) && ~opt.init
-  if strcmp(tag, 'ik')
+  if strcmp(tag, 'ij')
     opt.ijk([1 3])  = round(pos([1 3]));
     opt.update = [1 1 1];
-  elseif strcmp(tag, 'ij')
+  elseif strcmp(tag, 'ik')
     opt.ijk([1 2])  = round(pos([1 2]));
     opt.update = [1 1 1];
   elseif strcmp(tag, 'jk')

--- a/ft_volumerealign.m
+++ b/ft_volumerealign.m
@@ -1105,9 +1105,9 @@ if viewresult
   h2 = axes('position', [0.06+0.06+h1size(1) 0.06+0.06+h3size(2) h2size(1) h2size(2)]);
   h3 = axes('position', [0.06                0.06                h3size(1) h3size(2)]);
   
-  set(h1, 'Tag', 'ik', 'Visible', 'off', 'XAxisLocation', 'top');
+  set(h1, 'Tag', 'ij', 'Visible', 'off', 'XAxisLocation', 'top');
   set(h2, 'Tag', 'jk', 'Visible', 'off', 'YAxisLocation', 'right'); % after rotating in ft_plot_ortho this becomes top
-  set(h3, 'Tag', 'ij', 'Visible', 'off');
+  set(h3, 'Tag', 'ik', 'Visible', 'off');
   
   set(h1, 'DataAspectRatio', 1./[voxlen1 voxlen2 voxlen3]);
   set(h2, 'DataAspectRatio', 1./[voxlen1 voxlen2 voxlen3]);
@@ -1909,10 +1909,10 @@ if opt.viewresult
 end
 
 if ~isempty(tag) && ~opt.init
-  if strcmp(tag, 'ij')
+  if strcmp(tag, 'ik')
     opt.ijk([1 3])  = round(pos([1 3]));
     opt.update = [1 1 1];
-  elseif strcmp(tag, 'ik')
+  elseif strcmp(tag, 'ij')
     opt.ijk([1 2])  = round(pos([1 2]));
     opt.update = [1 1 1];
   elseif strcmp(tag, 'jk')


### PR DESCRIPTION
Hey there,
While exploring co-registration outputs using the figure produced by ft_volumerealign, I noticed that clicking in the top left or bottom left subplots didn't update the crosshair at the expected location; everything worked fine for the top right subplot though. Took some time to figure out where it was coming from but it happens the fix is extremely simple!
Best,
Ludovic