### PR TITLE
minor semantic FIX, it was noted during the tutorial yesterday that for cfg.comment options <xlim>, <ylim> and <zlim> comme…

### DIFF
--- a/private/topoplot_common.m
+++ b/private/topoplot_common.m
@@ -564,19 +564,19 @@ switch cfg.comment
       comment = sprintf('%0s\n%0s=[%.3g %.3g]', comment, cfg.parameter, zmin, zmax);
     end
   case 'xlim'
-    comment = date;
+    comment = '';
     if ~isempty(xparam)
-      comment = sprintf('%0s\n%0s=[%.3g %.3g]', comment, xparam, xmin, xmax);
+      comment = sprintf('%0s=[%.3g %.3g]', xparam, xmin, xmax);
     end
   case 'ylim'
-    comment = date;
+    comment = '';
     if ~isempty(yparam)
-      comment = sprintf('%0s\n%0s=[%.3g %.3g]', comment, yparam, ymin, ymax);
+      comment = sprintf('%0s=[%.3g %.3g]', yparam, ymin, ymax);
     end
   case 'zlim'
-    comment = date;
+    comment = '';
     if ~isempty(yparam)
-      comment = sprintf('%0s\n%0s=[%.3g %.3g]', comment, cfg.parameter, zmin, zmax);
+      comment = sprintf('%0s=[%.3g %.3g]', cfg.parameter, zmin, zmax);
     end
   otherwise
     comment = '';


### PR DESCRIPTION
…nt variable printed the date string along with parameter limits, but it should not (according to ft_topoplotER documentation). Initialized as empty string in this PR. If printing the date in topoplot comments by default along with <xlim> etc. is desired ploting behaviour (I wouldn't think so), then this PR can be closed.