### PR TITLE
FIX #694 - improve the reading of eyelink asc files with missing values

### DIFF
--- a/fileio/private/read_eyelink_asc.m
+++ b/fileio/private/read_eyelink_asc.m
@@ -49,6 +49,7 @@ for i=1:numel(aline)
 
   if numel(tline) && any(tline(1)=='0':'9')
   % if regexp(tline, '^[0-9]')
+    tline   = strrep(tline, ' . ', ' NaN '); % replace missing values
     tmp     = sscanf(tline, '%f');
     nchan   = numel(tmp);
     current = current + 1;

--- a/test/test_pull694.m
+++ b/test/test_pull694.m
@@ -1,0 +1,42 @@
+function test_pull694
+
+% WALLTIME 00:20:00
+% MEM 3gb
+
+% TEST read_eyelink_asc
+
+cd(dccnpath('/home/common/matlab/fieldtrip/data/test/original/eyetracker/eyelink'));
+
+filename = {
+  'BP2D1_2.asc'
+  'ashcal.asc'
+  'sub-v31_acq-l2_task-hyperlink_eyetrack.asc'
+  };
+
+% the hard-coded numbers below related to the size of the data were determined prior to the suggested change
+
+%%
+i = 1;
+hdr = ft_read_header(filename{i});
+dat = ft_read_data(filename{i});
+evt = ft_read_event(filename{i});
+assert(isequal(size(dat), [4 782756]));
+assert(numel(evt)==11);
+
+%%
+i = 2;
+hdr = ft_read_header(filename{i});
+dat = ft_read_data(filename{i});
+evt = ft_read_event(filename{i});
+assert(isequal(size(dat), [7 104517]));
+assert(numel(evt)==210);
+
+%%
+i = 3;
+hdr = ft_read_header(filename{i});
+dat = ft_read_data(filename{i});
+evt = ft_read_event(filename{i});
+assert(isequal(size(dat), [4 1534424]));
+assert(numel(evt)==1975);
+
+

--- a/test/test_pull694.m
+++ b/test/test_pull694.m
@@ -11,6 +11,7 @@ filename = {
   'BP2D1_2.asc'
   'ashcal.asc'
   'sub-v31_acq-l2_task-hyperlink_eyetrack.asc'
+  'example_file.asc'
   };
 
 % the hard-coded numbers below related to the size of the data were determined prior to the suggested change


### PR DESCRIPTION
actually this is not pull request 694, but the suggested solution to issue 694. 