### PR TITLE
commented out some lines which seem to be unnecessary and cause loss …

### DIFF
--- a/fileio/private/read_nihonkohden_hdr.m
+++ b/fileio/private/read_nihonkohden_hdr.m
@@ -91,12 +91,12 @@ hdr.nSamplesPre = 0;
 
 dc = textscan(fid,'%f',hdr.nChans*hdr.nSamples,'delimiter','\n','headerlines',0);
 df = dc{1};clear dc;
-df = df.*10; % multiply by 10, don't forget to divide when reading in data!
-fprintf('converting ASCII floats to 16-bit signed ints');
+%df = df.*10; % multiply by 10, don't forget to divide when reading in data!
+%fprintf('converting ASCII floats to 16-bit signed ints');
 
 dat = reshape(df,hdr.nChans,hdr.nSamples);
-clear df;
-dat = int16(dat)./10;
+%clear df;
+%dat = int16(dat)./10;
 hdr.dat = double(dat);
 clear dat;
 

--- a/fileio/private/read_nihonkohden_m00.m
+++ b/fileio/private/read_nihonkohden_m00.m
@@ -54,14 +54,14 @@ fprintf('\nWill read from %d to %d sample points: %d seconds \n',begsample,endsa
 
 dc = textscan(fid,'%f',hdr.nChans*nsmp,'delimiter','\n','headerlines',begsample-1);
 df = dc{1};clear dc;
-df = df.*mult; % multiply by 10, don't forget to divide when reading in data!
+%df = df.*mult; % multiply by 10, don't forget to divide when reading in data!
 
-fprintf('converting ASCII floats to 16-bit signed ints');
+%fprintf('converting ASCII floats to 16-bit signed ints');
 
 dat = reshape(df,hdr.nChans,nsmp);
-clear df;
-dat = int16(dat)./mult;
-dat = double(dat);
+%clear df;
+%dat = int16(dat)./mult;
+%dat = double(dat);
 % should we double it? No clue why the int16 and the multiplier.
 % Later convert data has to be multiplied to transform it into microvolts
 % nkdata.eeg=nkdata.eeg./nkdata.multiplier; (Diego)


### PR DESCRIPTION
…in precision

I got a user complaint that when converting data to SPM all the values are whole numbers  whereas in the original file which is ASCII they are floats with two digits after the decimal point. I looked at the code and it seems that there are some weird and unnecessary manipulations there where data are read from ASCII as floats, then converted to int16 and then back to floats and as a result, there is some loss of precision. I don't see the point of these manipulations so I just commented them out and everything seems to work as well.