### PR TITLE
performance of ft_databrowser improved, adding faster viewmode

### DIFF
--- a/ft_prepare_layout.m
+++ b/ft_prepare_layout.m
@@ -139,7 +139,7 @@ hasdata = exist('data', 'var') && ~isempty(data);
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 if ~hasdata
   data = struct([]);
-else
+elseif ~ft_getopt(cfg, 'skipcheckdata', false)
   data = ft_checkdata(data);
 end
 


### PR DESCRIPTION
Called 'fastvertical'. It uses a single line() call, rather than nchan calls to ft_plot_vector. Also, it updates the line objects' data when channels have not changed between rendering calls, which is faster than recreating the line objects.

I think fastvertical could replace vertical, but adding it as a separate viewmode for now, because I'm unsure whether all functionality is retained (for sure channel-identification does not work, although the data cursor *does* work).