### PR TITLE
fixed bug in source analysis due to pos being all ones, but not logical

### DIFF
--- a/ft_prepare_leadfield.m
+++ b/ft_prepare_leadfield.m
@@ -134,7 +134,7 @@ cfg = ft_checkconfig(cfg, 'createsubcfg',  {'grid'});
 
 % this code expects the inside to be represented as a logical array
 cfg.grid = ft_checkconfig(cfg.grid, 'renamed',  {'pnt' 'pos'});
-cfg = ft_checkconfig(cfg, 'index2logical', 'yes');
+cfg = ft_checkconfig(cfg, 'inside2logical', 'yes');
 
 if strcmp(cfg.sel50p, 'yes') && strcmp(cfg.lbex, 'yes')
   ft_error('subspace projection with either lbex or sel50p is mutually exclusive');

--- a/ft_prepare_sourcemodel.m
+++ b/ft_prepare_sourcemodel.m
@@ -149,7 +149,7 @@ if isfield(cfg, 'grid')
     cfg.grid.template = ft_checkconfig(cfg.grid.template, 'renamed',  {'pnt' 'pos'});
   end
 end
-cfg = ft_checkconfig(cfg, 'index2logical', 'yes');
+cfg = ft_checkconfig(cfg, 'inside2logical', 'yes');
 
 if ~isfield(cfg, 'headmodel') && nargin>1
   % put it in the configuration structure

--- a/ft_sourceanalysis.m
+++ b/ft_sourceanalysis.m
@@ -182,7 +182,7 @@ cfg = ft_checkconfig(cfg, 'renamedval',  {'method', 'coh_refdip',      'dics'});
 cfg = ft_checkconfig(cfg, 'renamedval',  {'method', 'dics_cohrefchan', 'dics'});
 cfg = ft_checkconfig(cfg, 'renamedval',  {'method', 'dics_cohrefdip',  'dics'});
 cfg = ft_checkconfig(cfg, 'forbidden',   {'parallel', 'trials'});
-cfg = ft_checkconfig(cfg, 'forbidden', {'foi', 'toi'});
+cfg = ft_checkconfig(cfg, 'forbidden',   {'foi', 'toi'});
 cfg = ft_checkconfig(cfg, 'renamed',     {'hdmfile', 'headmodel'});
 cfg = ft_checkconfig(cfg, 'renamed',     {'vol',     'headmodel'});
 

--- a/inverse/README
+++ b/inverse/README
@@ -1,5 +1,5 @@
 This is the FieldTrip INVERSE module. It contains functions for inverse
-modeling and source estimation of EEG and MEG data, based on a choise
+modeling and source estimation of EEG and MEG data, based on a variety
 of volume conduction models, including spherical and realistic models.
 
 For more information please visit http://www.fieldtriptoolbox.org/development/modules

--- a/utilities/ft_checkconfig.m
+++ b/utilities/ft_checkconfig.m
@@ -39,7 +39,7 @@ function [cfg] = ft_checkconfig(cfg, varargin)
 %   unused          = {'opt1', 'opt2', etc.} % list the unused options, these will be removed and a warning is issued
 %   createsubcfg    = {'subname', etc.}      % list the names of the subcfg
 %   dataset2files   = 'yes', 'no'            % converts dataset into headerfile and datafile
-%   index2logical   = 'yes', 'no'            % converts cfg.index or cfg.grid.index into logical representation
+%   inside2logical  = 'yes', 'no'            % converts cfg.inside or cfg.grid.inside into logical representation
 %   checksize       = 'yes', 'no'            % remove large fields from the cfg
 %   trackconfig     = 'on', 'off'            % start/end config tracking
 %
@@ -75,7 +75,7 @@ renamedval      = ft_getopt(varargin, 'renamedval');
 allowedval      = ft_getopt(varargin, 'allowedval');
 createsubcfg    = ft_getopt(varargin, 'createsubcfg');
 checkfilenames  = ft_getopt(varargin, 'dataset2files');
-checkinside     = ft_getopt(varargin, 'index2logical', 'off');
+checkinside     = ft_getopt(varargin, 'inside2logical', 'off');
 checksize       = ft_getopt(varargin, 'checksize', 'off');
 trackconfig     = ft_getopt(varargin, 'trackconfig');
 
@@ -516,7 +516,7 @@ if ~isempty(createsubcfg)
 end
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% checkinside, i.e. index2logical
+% checkinside, i.e. inside2logical
 %
 % Converts indexed cfg.inside/outside into logical representation if neccessary.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -531,6 +531,10 @@ if istrue(checkinside)
     inside(cfg.grid.inside) = true;
     cfg.grid = removefields(cfg.grid, {'inside', 'outside'});
     cfg.grid.inside = inside;
+  elseif isfield(cfg, 'inside') && ~islogical(cfg.inside) && numel(cfg.inside)==size(cfg.pos,1)
+    cfg.inside = logical(cfg.inside);  
+  elseif isfield(cfg, 'grid') && isfield(cfg.grid, 'inside') && ~islogical(cfg.grid.inside) && numel(cfg.grid.inside)==size(cfg.grid.pos,1)
+    cfg.grid.inside = logical(cfg.grid.inside);  
   end
 end % if checkinside
 


### PR DESCRIPTION
@mcvinding reported an issue with a cfg.grid.inside=ones(npos,1), which we tracked down to it not being inside, causing all dipoles to be replaced by dipole position 1. This fixes it by ensuring that the inside field is converted to a logical vector.