### PR TITLE
adding mmfmatlabio code

### DIFF
--- a/fileio/ft_read_data.m
+++ b/fileio/ft_read_data.m
@@ -696,6 +696,10 @@ switch dataformat
     % pass the header along to speed it up, it will be read on the fly in case it is empty
     dat = read_mff_data(filename, 'sample', begsample, endsample, chanindx, hdr);
 
+  case 'egi_mff_v3'
+    ft_hastoolbox('mffmatlabio', 1);
+    dat = mff_fileio_read_data(filename, 'header', hdr, 'begtrial', begtrial, 'endtrial', endtrial, 'chanindx', chanindx);      
+    
   case 'edf'
     % this reader is largely similar to the one for bdf
     % it uses a mex file for reading the 16 bit data

--- a/fileio/ft_read_event.m
+++ b/fileio/ft_read_event.m
@@ -973,6 +973,10 @@ switch eventformat
     for i=1:length(fn)
       event = rmfield(event, fn{i});
     end
+    
+  case 'egi_mff_v3'
+    ft_hastoolbox('mffmatlabio', 1);
+    event = mff_fileio_read_event(filename);
 
   case 'smi_txt'
     if isempty(hdr)

--- a/fileio/ft_read_header.m
+++ b/fileio/ft_read_header.m
@@ -1206,6 +1206,10 @@ switch headerformat
     end
     hdr = read_mff_header(filename);
 
+  case 'egi_mff_v3'
+    ft_hastoolbox('mffmatlabio', 1);
+    hdr = mff_fileio_read_header(filename);
+
   case 'fcdc_buffer'
     % read from a networked buffer for realtime analysis
     [host, port] = filetype_check_uri(filename);

--- a/fileio/ft_write_data.m
+++ b/fileio/ft_write_data.m
@@ -412,6 +412,13 @@ switch dataformat
       % file does not yet exist, which is not a problem
     end
     save(filename, 'dat', 'hdr');
+  
+  case 'mff'  
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    % MFF files using Phillips plugin
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    ft_hastoolbox('mffmatlabio', 1);
+    mff_fileio_write(filename, hdr, dat, evt);
     
   case 'neuralynx_sdma'
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
1. The MFFMATLABIO code is available at https://drive.google.com/open?id=1PHXdEFmVqDRy04vtOKI9aXn54BHoPcqy
I have it in a private repo, and I am in the process of transferring it to github and version it. It will be GNU GPL3.
I have not added it yet to the Fileio/Fieldtrip repo because it is not 100% ready. However, this will not prevent the code to run if you get the zip file.

2. It is an EEGLAB plugin but it also works as standalone in Fieldtrip. I wanted to have a single code that would work in Matlab, Fieldtrip and EEGLAB to avoid having people branching the code.

3. The file testallfiles will test 27 different MFF files all available. I am attaching the report on all files when using the standalone Fieldtrip/File-io importer/exporter (a couple of files still have problem).
When using Fieldtrip, there is still a problem with importing different sensor types so they can be decoded properly. I will fix it.

https://drive.google.com/drive/folders/13PeOVr67g4tu-svKerrsBCg5fMKlRsBF?usp=sharing
