### PR TITLE
Change in event detection in Yokogawa data

### DIFF
--- a/fileio/ft_read_event.m
+++ b/fileio/ft_read_event.m
@@ -978,7 +978,7 @@ switch eventformat
     for i=1:length(fn)
       event = rmfield(event, fn{i});
     end
-    
+
   case {'egi_mff_v3' 'egi_mff'} % this is the default
     ft_hastoolbox('mffmatlabio', 1);
     event = mff_fileio_read_event(filename);
@@ -2003,7 +2003,7 @@ switch eventformat
   case {'ricoh_ave', 'ricoh_con'}
     % use the Ricoh MEG Reader toolbox for the file reading
     ft_hastoolbox('ricoh_meg_reader', 1);
-    % the user should be able to specify the analog threshold, but the code falls back to '1.0' as default
+    % the user should be able to specify the analog threshold, but the code falls back to '1.6' as default
     % the user should be able to specify the trigger channels
     % the user should be able to specify the flank, but the code falls back to 'up' as default
     if isempty(detectflank)
@@ -2030,21 +2030,24 @@ switch eventformat
     if ~ft_hastoolbox('yokogawa', 0);
       ft_hastoolbox('yokogawa_meg_reader', 1);
     end
-    % the user should be able to specify the analog threshold
+    % the user should be able to specify the analog threshold, but the code falls back to '1.6' as default
     % the user should be able to specify the trigger channels
-    % the user should be able to specify the flank, but the code falls back to 'auto' as default
+    % the user should be able to specify the flank, but the code falls back to 'up' as default
     if isempty(detectflank)
-      detectflank = 'auto';
+      detectflank = 'up';
+    end
+    if isempty(threshold)
+      threshold = 1.6;
     end
     event = read_yokogawa_event(filename, 'detectflank', detectflank, 'trigindx', trigindx, 'threshold', threshold);
-    
+
   case 'artinis_oxy3'
     ft_hastoolbox('artinis', 1);
     if isempty(hdr)
       hdr = read_artinis_oxy3(filename);
     end
     event = read_artinis_oxy3(filename, true);
-    
+
     if isempty(trigindx) % indx gets precedence over labels! numbers before words
       triglabel = ft_getopt(varargin, 'triglabel', 'ADC*');  % this allows subselection of AD channels to be markes as trigger channels (for Artinis *.oxy3 data)
       trigindx = find(ismember(hdr.label, ft_channelselection(triglabel, hdr.label)));

--- a/fileio/private/read_ricoh_event.m
+++ b/fileio/private/read_ricoh_event.m
@@ -96,8 +96,6 @@ else
   ft_error('cannot determine, whether Ricoh toolbox is present');
 end
 
-% the data structure does not contain events, but flank detection on the trigger channel might reveal them
-% this is done below for all formats
 if isempty(event)
   ft_warning('no events were detected');
 end

--- a/fileio/private/read_yokogawa_event.m
+++ b/fileio/private/read_yokogawa_event.m
@@ -40,87 +40,97 @@ detectflank = ft_getopt(varargin, 'detectflank');
 
 % ensure that the required toolbox is on the path
 if ft_hastoolbox('yokogawa_meg_reader');
- 
-    % read the dataset header
-    hdr = read_yokogawa_header_new(filename);
-    ch_info = hdr.orig.channel_info.channel;
-    type = [ch_info.type];
-    
-    % determine the trigger channels (if not specified by the user)
-    if isempty(trigindx)
-      trigindx = find(type==handles.TriggerChannel);
+  % read the dataset header
+  hdr = read_yokogawa_header_new(filename);
+  ch_info = hdr.orig.channel_info.channel;
+  type = [ch_info.type];
+
+  % determine the trigger channels (if not specified by the user)
+  if isempty(trigindx)
+    trigindx = find(type==handles.TriggerChannel);
+  end
+
+  % Use the MEG Reader documentation if more detailed support is required.
+  if hdr.orig.acq_type==handles.AcqTypeEvokedRaw
+    % read the trigger id from all trials
+    event = getYkgwHdrEvent(filename);
+    % use the standard FieldTrip header for trial events
+    % make an event for each trial as defined in the header
+    for i=1:hdr.nTrials
+      event(end+1).type     = 'trial';
+      event(end  ).sample   = (i-1)*hdr.nSamples + 1;
+      event(end  ).offset   = -hdr.nSamplesPre;
+      event(end  ).duration =  hdr.nSamples;
+      if ~isempty(value)
+        event(end  ).value    =  event(i).code;
+      end
     end
- 
-    % Use the MEG Reader documentation if more detailed support is
-    % required.
-    if hdr.orig.acq_type==handles.AcqTypeEvokedRaw
-      % read the trigger id from all trials
-      event = getYkgwHdrEvent(filename);
-      % use the standard FieldTrip header for trial events
-      % make an event for each trial as defined in the header
-      for i=1:hdr.nTrials
-        event(end+1).type     = 'trial';
-        event(end  ).sample   = (i-1)*hdr.nSamples + 1;
-        event(end  ).offset   = -hdr.nSamplesPre;
-        event(end  ).duration =  hdr.nSamples;
- 
-        if ~isempty(value)
-          event(end  ).value    =  event(i).code;
+
+  % Use the MEG Reader documentation if more detailed support is required.
+  elseif hdr.orig.acq_type==handles.AcqTypeEvokedAve
+    % make an event for the average
+    event(1).type     = 'average';
+    event(1).sample   = 1;
+    event(1).offset   = -hdr.nSamplesPre;
+    event(1).duration =  hdr.nSamples;
+
+  elseif hdr.orig.acq_type==handles.AcqTypeContinuousRaw
+    % Events annotated by users during measurements
+    bookmark_tmp = [];
+    bookmark_tmp = getYkgwHdrBookmark(filename);
+    if ~isempty(bookmark_tmp)
+      for i = 1:length(bookmark_tmp)
+        event(end+1).sample = bookmark_tmp(i).sample_no + 1;
+        event(end  ).type   =  'bookmarks';
+        if ~isempty(bookmark_tmp(i).label)
+          event(end  ).value = bookmark_tmp(i).label;
+          %% 0 in default
+        else
+          event(end  ).value = 99;
         end
       end
- 
-    % Use the MEG Reader documentation if more detailed support is required.
-    elseif hdr.orig.acq_type==handles.AcqTypeEvokedAve
-      % make an event for the average
-      event(1).type     = 'average';
-      event(1).sample   = 1;
-      event(1).offset   = -hdr.nSamplesPre;
-      event(1).duration =  hdr.nSamples;
- 
-    elseif hdr.orig.acq_type==handles.AcqTypeContinuousRaw
-      % the data structure does not contain events, but flank detection on the trigger channel might reveal them
-      % this is done below for all formats
     end
- 
+    clear bookmark_tmp;
+  end
+
 elseif ft_hastoolbox('yokogawa');
-    
-    % read the dataset header
-    hdr = read_yokogawa_header(filename);
 
-    % determine the trigger channels (if not specified by the user)
-    if isempty(trigindx)
-      trigindx = find(hdr.orig.channel_info(:,2)==handles.TriggerChannel);
-    end
+  % read the dataset header
+  hdr = read_yokogawa_header(filename);
 
-    if hdr.orig.acq_type==handles.AcqTypeEvokedRaw
-      % read the trigger id from all trials
-      fid   = fopen(filename, 'r');
-      value = GetMeg160TriggerEventM(fid);
-      fclose(fid);
-      % use the standard FieldTrip header for trial events
-      % make an event for each trial as defined in the header
-      for i=1:hdr.nTrials
-	event(end+1).type     = 'trial';
-	event(end  ).sample   = (i-1)*hdr.nSamples + 1;
-	event(end  ).offset   = -hdr.nSamplesPre;
-	event(end  ).duration =  hdr.nSamples;
-	
-	if ~isempty(value)
-	  event(end  ).value    =  value(i);
-	end
+  % determine the trigger channels (if not specified by the user)
+  if isempty(trigindx)
+    trigindx = find(hdr.orig.channel_info(:,2)==handles.TriggerChannel);
+  end
+
+  if hdr.orig.acq_type==handles.AcqTypeEvokedRaw
+    % read the trigger id from all trials
+    fid   = fopen(filename, 'r');
+    value = GetMeg160TriggerEventM(fid);
+    fclose(fid);
+    % use the standard FieldTrip header for trial events
+    % make an event for each trial as defined in the header
+    for i=1:hdr.nTrials
+      event(end+1).type     = 'trial';
+      event(end  ).sample   = (i-1)*hdr.nSamples + 1;
+      event(end  ).offset   = -hdr.nSamplesPre;
+      event(end  ).duration =  hdr.nSamples;
+      if ~isempty(value)
+        event(end  ).value    =  value(i);
       end
-      
-    elseif hdr.orig.acq_type==handles.AcqTypeEvokedAve
-      % make an event for the average
-      event(1).type     = 'average';
-      event(1).sample   = 1;
-      event(1).offset   = -hdr.nSamplesPre;
-      event(1).duration =  hdr.nSamples;
-      
-    elseif hdr.orig.acq_type==handles.AcqTypeContinuousRaw
-      % the data structure does not contain events, but flank detection on the trigger channel might reveal them
-      % this is done below for all formats
     end
+
+  elseif hdr.orig.acq_type==handles.AcqTypeEvokedAve
+    % make an event for the average
+    event(1).type     = 'average';
+    event(1).sample   = 1;
+    event(1).offset   = -hdr.nSamplesPre;
+    event(1).duration =  hdr.nSamples;
+
+  elseif hdr.orig.acq_type==handles.AcqTypeContinuousRaw
+    % the data structure does not contain events, but flank detection on the trigger channel might reveal them
+    % this is done below
+  end
 
 else
     ft_error('cannot determine, whether Yokogawa toolbox is present');


### PR DESCRIPTION
We have modified “ft_read_event.m”, “read_yokogawa_event.m”, and “read_ricoh_event.m”: 

The modified “ft_read_event.m” has a default value of threshold (1.6 volts) to detect trigger events for Yokogawa data (L2039-2041). 

The modified “read_yokogawa_event.m” retrieves the annotation (bookmark) information as events for Yokogawa *.con data (L78-91). Indent in the code has also modified. 

In the modified “read_ricoh_event.m”, needless comments have been removed (L99-100 in the original code). 

