### PR TITLE
ENH - added empty directory to detect incorrect path setup

### DIFF
--- a/compat/incorrect/README
+++ b/compat/incorrect/README
@@ -1,0 +1,4 @@
+This is a directory that should never be added to your MATLAB path.
+It only serves to check whether your path is setup incorrectly.
+
+See also http://www.fieldtriptoolbox.org/faq/should_i_add_fieldtrip_with_all_subdirectories_to_my_matlab_path

--- a/compat/matlablt2010b/README
+++ b/compat/matlablt2010b/README
@@ -1,0 +1,12 @@
+This directory contains some functions that allow FieldTrip to run
+on older MATLAB versions. These functions emulate the functionality
+that is present in the latest MATLAB version.
+
+Each of these directories is called matlabltXXXXX, where "lt" stands
+for "less than" and XXXXX is the MATLAB release. If you are using
+MATLAB release N, then you should only add the directories N+1,
+N+2, ... to your path. In general this will be done automatically
+by the ft_defaults function.
+
+See also http://www.fieldtriptoolbox.org/faq/should_i_add_fieldtrip_with_all_subdirectories_to_my_matlab_path
+

--- a/compat/matlablt2011b/README
+++ b/compat/matlablt2011b/README
@@ -1,0 +1,11 @@
+This directory contains some functions that allow FieldTrip to run
+on older MATLAB versions. These functions emulate the functionality
+that is present in the latest MATLAB version.
+
+Each of these directories is called matlabltXXXXX, where "lt" stands
+for "less than" and XXXXX is the MATLAB release. If you are using
+MATLAB release N, then you should only add the directories N+1,
+N+2, ... to your path. In general this will be done automatically
+by the ft_defaults function.
+
+See also http://www.fieldtriptoolbox.org/faq/should_i_add_fieldtrip_with_all_subdirectories_to_my_matlab_path

--- a/compat/matlablt2012a/README
+++ b/compat/matlablt2012a/README
@@ -1,0 +1,11 @@
+This directory contains some functions that allow FieldTrip to run
+on older MATLAB versions. These functions emulate the functionality
+that is present in the latest MATLAB version.
+
+Each of these directories is called matlabltXXXXX, where "lt" stands
+for "less than" and XXXXX is the MATLAB release. If you are using
+MATLAB release N, then you should only add the directories N+1,
+N+2, ... to your path. In general this will be done automatically
+by the ft_defaults function.
+
+See also http://www.fieldtriptoolbox.org/faq/should_i_add_fieldtrip_with_all_subdirectories_to_my_matlab_path

--- a/compat/matlablt2013b/README
+++ b/compat/matlablt2013b/README
@@ -1,0 +1,11 @@
+This directory contains some functions that allow FieldTrip to run
+on older MATLAB versions. These functions emulate the functionality
+that is present in the latest MATLAB version.
+
+Each of these directories is called matlabltXXXXX, where "lt" stands
+for "less than" and XXXXX is the MATLAB release. If you are using
+MATLAB release N, then you should only add the directories N+1,
+N+2, ... to your path. In general this will be done automatically
+by the ft_defaults function.
+
+See also http://www.fieldtriptoolbox.org/faq/should_i_add_fieldtrip_with_all_subdirectories_to_my_matlab_path

--- a/compat/matlablt2014b/README
+++ b/compat/matlablt2014b/README
@@ -1,0 +1,11 @@
+This directory contains some functions that allow FieldTrip to run
+on older MATLAB versions. These functions emulate the functionality
+that is present in the latest MATLAB version.
+
+Each of these directories is called matlabltXXXXX, where "lt" stands
+for "less than" and XXXXX is the MATLAB release. If you are using
+MATLAB release N, then you should only add the directories N+1,
+N+2, ... to your path. In general this will be done automatically
+by the ft_defaults function.
+
+See also http://www.fieldtriptoolbox.org/faq/should_i_add_fieldtrip_with_all_subdirectories_to_my_matlab_path

--- a/compat/matlablt2015a/README
+++ b/compat/matlablt2015a/README
@@ -1,0 +1,11 @@
+This directory contains some functions that allow FieldTrip to run
+on older MATLAB versions. These functions emulate the functionality
+that is present in the latest MATLAB version.
+
+Each of these directories is called matlabltXXXXX, where "lt" stands
+for "less than" and XXXXX is the MATLAB release. If you are using
+MATLAB release N, then you should only add the directories N+1,
+N+2, ... to your path. In general this will be done automatically
+by the ft_defaults function.
+
+See also http://www.fieldtriptoolbox.org/faq/should_i_add_fieldtrip_with_all_subdirectories_to_my_matlab_path

--- a/compat/matlablt2016b/README
+++ b/compat/matlablt2016b/README
@@ -1,0 +1,11 @@
+This directory contains some functions that allow FieldTrip to run
+on older MATLAB versions. These functions emulate the functionality
+that is present in the latest MATLAB version.
+
+Each of these directories is called matlabltXXXXX, where "lt" stands
+for "less than" and XXXXX is the MATLAB release. If you are using
+MATLAB release N, then you should only add the directories N+1,
+N+2, ... to your path. In general this will be done automatically
+by the ft_defaults function.
+
+See also http://www.fieldtriptoolbox.org/faq/should_i_add_fieldtrip_with_all_subdirectories_to_my_matlab_path

--- a/compat/matlablt2017b/README
+++ b/compat/matlablt2017b/README
@@ -1,0 +1,11 @@
+This directory contains some functions that allow FieldTrip to run
+on older MATLAB versions. These functions emulate the functionality
+that is present in the latest MATLAB version.
+
+Each of these directories is called matlabltXXXXX, where "lt" stands
+for "less than" and XXXXX is the MATLAB release. If you are using
+MATLAB release N, then you should only add the directories N+1,
+N+2, ... to your path. In general this will be done automatically
+by the ft_defaults function.
+
+See also http://www.fieldtriptoolbox.org/faq/should_i_add_fieldtrip_with_all_subdirectories_to_my_matlab_path

--- a/ft_defaults.m
+++ b/ft_defaults.m
@@ -94,6 +94,11 @@ if ~isfield(ft_default.toolbox, 'images'), ft_default.toolbox.images  = 'compat'
 if ~isfield(ft_default.toolbox, 'stats') , ft_default.toolbox.stats   = 'compat'; end % matlab or compat
 if ~isfield(ft_default.toolbox, 'signal'), ft_default.toolbox.signal  = 'compat'; end % matlab or compat
 
+% Some people mess up their path settings and then have
+% stuff on the path that should not be there.
+% The following will issue a warning
+checkIncorrectPath();
+
 % Check whether this ft_defaults function has already been executed. Note that we
 % should not use ft_default itself directly, because the user might have set stuff
 % in that struct already prior to ft_defaults being called for the first time.
@@ -316,3 +321,18 @@ if length(list)>1
 end
 end % function checkMultipleToolbox
 
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% SUBFUNCTION
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+function checkIncorrectPath
+
+persistent v p
+if isempty(v) || isempty(p)
+  [v, p] = ft_version;
+end
+
+incorrect = fullfile(p, 'compat', 'incorrect');
+if contains(path, incorrect)
+  ft_warning('Your path is set up incorrectly.\nYou probably used addpath(genpath(''path_to_fieldtrip'')).\nThis can lead to unexpected behaviour.\nSee http://www.fieldtriptoolbox.org/faq/should_i_add_fieldtrip_with_all_subdirectories_to_my_matlab_path');
+end
+end % function checkPath

--- a/ft_defaults.m
+++ b/ft_defaults.m
@@ -11,9 +11,10 @@ function ft_defaults
 % the FieldTrip function that you are calling.
 %
 % The global options and their default values are
-%   ft_default.showcallinfo      = string, can be 'yes' or 'no' (default = 'yes')
 %   ft_default.checkconfig       = string, can be 'pedantic', 'loose', 'silent' (default = 'loose')
+%   ft_default.checkpath         = string, can be 'pedantic', 'once', 'no' (default = 'pedantic')
 %   ft_default.checksize         = number in bytes, can be inf (default = 1e5)
+%   ft_default.showcallinfo      = string, can be 'yes' or 'no' (default = 'yes')
 %   ft_default.trackconfig       = string, can be 'cleanup', 'report', 'off' (default = 'off')
 %   ft_default.trackusage        = false, or string with salt for one-way encryption of identifying information (by default this is enabled and an automatic salt is created)
 %   ft_default.trackdatainfo     = string, can be 'yes' or 'no' (default = 'no')
@@ -34,7 +35,7 @@ function ft_defaults
 % undocumented options
 %   ft_default.siunits        = 'yes' or 'no'
 
-% Copyright (C) 2009-2016, Robert Oostenveld
+% Copyright (C) 2009-2018, Robert Oostenveld
 %
 % This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
 % for the documentation and details.
@@ -56,9 +57,14 @@ function ft_defaults
 
 global ft_default
 persistent initialized
+persistent checkpath
 
 if isempty(initialized)
   initialized = false;
+end
+
+if isempty(checkpath)
+  checkpath = false;
 end
 
 % ft_warning is located in fieldtrip/utilities, which may not be on the path yet
@@ -77,11 +83,12 @@ end
 % NOTE ft_getopt might not be available on the path at this moment and can therefore not yet be used.
 % NOTE all options here should be explicitly listed as allowed in ft_checkconfig
 
-if ~isfield(ft_default, 'trackconfig'),       ft_default.trackconfig    = 'off';    end % cleanup, report, off
-if ~isfield(ft_default, 'checkconfig'),       ft_default.checkconfig    = 'loose';  end % pedantic, loose, silent
-if ~isfield(ft_default, 'checksize'),         ft_default.checksize      = 1e5;      end % number in bytes, can be inf
-if ~isfield(ft_default, 'showcallinfo'),      ft_default.showcallinfo   = 'yes';    end % yes or no, this is used in ft_pre/postamble_provenance
-if ~isfield(ft_default, 'debug'),             ft_default.debug          = 'no';     end % no, save, saveonerror, display, displayonerror, this is used in ft_pre/postamble_debug
+if ~isfield(ft_default, 'trackconfig'),       ft_default.trackconfig    = 'off';      end % cleanup, report, off
+if ~isfield(ft_default, 'checkconfig'),       ft_default.checkconfig    = 'loose';    end % pedantic, loose, silent
+if ~isfield(ft_default, 'checkpath'),         ft_default.checkpath      = 'pedantic'; end % pedantic, once, no
+if ~isfield(ft_default, 'checksize'),         ft_default.checksize      = 1e5;        end % number in bytes, can be inf
+if ~isfield(ft_default, 'showcallinfo'),      ft_default.showcallinfo   = 'yes';      end % yes or no, this is used in ft_pre/postamble_provenance
+if ~isfield(ft_default, 'debug'),             ft_default.debug          = 'no';       end % no, save, saveonerror, display, displayonerror, this is used in ft_pre/postamble_debug
 if ~isfield(ft_default, 'outputfilepresent'), ft_default.outputfilepresent = 'overwrite'; end % can be keep, overwrite, error
 
 % These options allow to disable parts of the provenance
@@ -94,10 +101,21 @@ if ~isfield(ft_default.toolbox, 'images'), ft_default.toolbox.images  = 'compat'
 if ~isfield(ft_default.toolbox, 'stats') , ft_default.toolbox.stats   = 'compat'; end % matlab or compat
 if ~isfield(ft_default.toolbox, 'signal'), ft_default.toolbox.signal  = 'compat'; end % matlab or compat
 
-% Some people mess up their path settings and then have
-% stuff on the path that should not be there.
+% Some people mess up their path settings and then have stuff on the path that should not be there.
 % The following will issue a warning
-checkIncorrectPath();
+switch ft_default.checkpath
+  case 'pedantic'
+    % check every time
+    checkIncorrectPath();
+  case 'once'
+    % check only once
+    if ~checkpath
+      checkIncorrectPath();
+      checkpath = true;
+    end
+  case 'no'
+    % do not check
+end % case
 
 % Check whether this ft_defaults function has already been executed. Note that we
 % should not use ft_default itself directly, because the user might have set stuff
@@ -123,8 +141,7 @@ if ~isdeployed
     addpath(fullfile(fileparts(which('ft_defaults')), 'utilities'));
   end
   
-  % Some people mess up their path settings and then have
-  % different versions of certain toolboxes on the path.
+  % Some people mess up their path settings and then have different versions of certain toolboxes on the path.
   % The following will issue a warning
   checkMultipleToolbox('FieldTrip',           'ft_defaults.m');
   checkMultipleToolbox('spm',                 'spm.m');
@@ -325,14 +342,9 @@ end % function checkMultipleToolbox
 % SUBFUNCTION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 function checkIncorrectPath
-
-persistent v p
-if isempty(v) || isempty(p)
-  [v, p] = ft_version;
-end
-
+p = fileparts(mfilename('fullpath'));
 incorrect = fullfile(p, 'compat', 'incorrect');
 if contains(path, incorrect)
-  ft_warning('Your path is set up incorrectly.\nYou probably used addpath(genpath(''path_to_fieldtrip'')).\nThis can lead to unexpected behaviour.\nSee http://www.fieldtriptoolbox.org/faq/should_i_add_fieldtrip_with_all_subdirectories_to_my_matlab_path');
+  ft_warning('Your path is set up incorrectly. You probably used addpath(genpath(''path_to_fieldtrip'')), this can lead to unexpected behaviour. See http://www.fieldtriptoolbox.org/faq/should_i_add_fieldtrip_with_all_subdirectories_to_my_matlab_path');
 end
-end % function checkPath
+end % function checkIncorrectPath


### PR DESCRIPTION
give warning in ft_defaults if this incorrect directory is on the path.

I also updated http://www.fieldtriptoolbox.org/faq/should_i_add_fieldtrip_with_all_subdirectories_to_my_matlab_path#should_i_add_fieldtrip_with_all_subdirectories_to_my_matlab_path

See http://bugzilla.fieldtriptoolbox.org/show_bug.cgi?id=3436