### PR TITLE
Updated hdr-read functions of Ricoh & Yokogawa data for reading EEG labels

### DIFF
--- a/fileio/private/read_ricoh_header.m
+++ b/fileio/private/read_ricoh_header.m
@@ -134,6 +134,14 @@ for i=1:hdr.nChans
     prefix = 'ETC';
   end
   hdr.label{i} = sprintf('%s%03d', prefix, i);
+
+  % overwrite EEG-channel labels
+  if hdr.orig.channel_info.channel(i).type == handles.EegChannel
+    if ~isempty(hdr.orig.channel_info.channel(i).data.name)
+      hdr.label{i} = strcat(prefix, '_', hdr.orig.channel_info.channel(i).data.name);
+    end
+  end
+
 end
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/fileio/private/read_yokogawa_header_new.m
+++ b/fileio/private/read_yokogawa_header_new.m
@@ -18,7 +18,7 @@ function hdr = read_yokogawa_header_new(filename)
 %
 % See also READ_YOKOGAWA_DATA_NEW, READ_YOKOGAWA_EVENT
 
-% ** 
+% **
 % Copyright (C) 2005, Robert Oostenveld and 2010, Tilmann Sander-Thoemmes
 %
 % This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
@@ -85,12 +85,12 @@ switch acq_type
     sample_rate = acq_cond.sample_rate;
     sample_count = acq_cond.frame_length;
     pretrigger_length = acq_cond.pretrigger_length;
-    averaged_count = acq_cond.average_count; 
+    averaged_count = acq_cond.average_count;
     if isempty(sample_rate) || isempty(sample_count) || isempty(pretrigger_length) || isempty(averaged_count)
       ft_error('invalid sample rate or sample count or pretrigger length or average count in ', filename);
       return;
     end
-    if acq_cond.multi_trigger.enable 
+    if acq_cond.multi_trigger.enable
       ft_error('multi trigger mode not supported for ', filename);
       return;
     end
@@ -98,12 +98,12 @@ switch acq_type
     sample_rate = acq_cond.sample_rate;
     sample_count = acq_cond.frame_length;
     pretrigger_length = acq_cond.pretrigger_length;
-    actual_epoch_count = acq_cond.average_count; 
+    actual_epoch_count = acq_cond.average_count;
     if isempty(sample_rate) || isempty(sample_count) || isempty(pretrigger_length) || isempty(actual_epoch_count)
       ft_error('invalid sample rate or sample count or pretrigger length or epoch count in ', filename);
       return;
     end
-    if acq_cond.multi_trigger.enable 
+    if acq_cond.multi_trigger.enable
       ft_error('multi trigger mode not supported for ', filename);
       return;
     end
@@ -180,6 +180,14 @@ for i=1:hdr.nChans
     prefix = 'ETC';
   end
   hdr.label{i} = sprintf('%s%03d', prefix, i);
+
+  % overwrite EEG-channel labels
+  if hdr.orig.channel_info.channel(i).type == handles.EegChannel
+    if ~isempty(hdr.orig.channel_info.channel(i).data.name)
+      hdr.label{i} = strcat(prefix, '_', hdr.orig.channel_info.channel(i).data.name);
+    end
+  end
+
 end
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/utilities/ft_channelselection.m
+++ b/utilities/ft_channelselection.m
@@ -174,12 +174,12 @@ for i=1:length(channel)
   if length(channel{i}) < 1
     continue;
   end
-  
+
   if strcmp((channel{i}(1)), '-')
     % skip channels to be excluded
     continue;
   end
-  
+
   rexp = sprintf('%s%s%s', '^', regexptranslate('wildcard',channel{i}), '$');
   lreg = ~cellfun(@isempty, regexp(datachannel, rexp));
   if any(lreg)
@@ -202,7 +202,7 @@ labelmegplanar = [];
 labeleeg       = [];
 
 switch senstype
-  
+
   case {'yokogawa', 'yokogawa160', 'yokogawa160_planar', 'yokogawa64', 'yokogawa64_planar', 'yokogawa440', 'yokogawa440_planar'}
     % Yokogawa axial gradiometers channels start with AG, hardware planar gradiometer
     % channels start with PG, magnetometers start with M
@@ -213,7 +213,8 @@ switch senstype
     labelmeg      = datachannel(megind);
     labelmegmag   = datachannel(megmag);
     labelmeggrad  = datachannel(megax | megpl);
-    
+    labeleeg  = datachannel(strncmp('EEG', datachannel, length('EEG')));
+
   case {'ctf64'}
     labelml     = datachannel(~cellfun(@isempty, regexp(datachannel, '^SL')));    % left    MEG channels
     labelmr     = datachannel(~cellfun(@isempty, regexp(datachannel, '^SR')));    % right   MEG channels
@@ -223,7 +224,7 @@ switch senstype
       datachannel(strncmp('P'  , datachannel, 1));
       datachannel(strncmp('Q'  , datachannel, 1));
       datachannel(strncmp('R'  , datachannel, length('G'  )))];
-    
+
   case {'ctf', 'ctf275', 'ctf151', 'ctf275_planar', 'ctf151_planar'}
     % all CTF MEG channels start with "M"
     % all CTF reference channels start with B, G, P, Q or R
@@ -235,7 +236,7 @@ switch senstype
       datachannel(strncmp('Q'  , datachannel, 1));
       datachannel(strncmp('R'  , datachannel, length('G'  )))];
     labeleeg  = datachannel(strncmp('EEG', datachannel, length('EEG')));
-    
+
     % Not sure whether this should be here or outside the switch or
     % whether these specifications should be supported for systems
     % other than CTF.
@@ -256,11 +257,11 @@ switch senstype
     labelmzf  = datachannel(strncmp('MZF', datachannel, length('MZF')));
     labelmzo  = datachannel(strncmp('MZO', datachannel, length('MZO')));
     labelmzp  = datachannel(strncmp('MZP', datachannel, length('MZP')));
-    
+
   case {'bti', 'bti248', 'bti248grad', 'bti148', 'bti248_planar', 'bti148_planar'}
     % all 4D-BTi MEG channels start with "A"
     % all 4D-BTi reference channels start with M or G
-    
+
     labelmeg     = datachannel(myregexp('^A[0-9]+$', datachannel));
     labelmegref  = [datachannel(myregexp('^M[CLR][xyz][aA]*$', datachannel)); datachannel(myregexp('^G[xyz][xyz]A$', datachannel)); datachannel(myregexp('^M[xyz][aA]*$', datachannel))];
     labelmegrefa = datachannel(~cellfun(@isempty,strfind(datachannel, 'a')));
@@ -269,13 +270,13 @@ switch senstype
     labelmegrefl = datachannel(strncmp('ML', datachannel, 2));
     labelmegrefr = datachannel(strncmp('MR', datachannel, 2));
     labelmegrefm = datachannel(myregexp('^M[xyz][aA]*$', datachannel));
-    
+
   case {'neuromag122' 'neuromag122alt', 'neuromag122_combined'}
     % all neuromag MEG channels start with MEG
     % all neuromag EEG channels start with EEG
     labelmeg = datachannel(strncmp('MEG', datachannel, length('MEG')));
     labeleeg = datachannel(strncmp('EEG', datachannel, length('EEG')));
-    
+
   case {'neuromag306' 'neuromag306alt', 'neuromag306_combined'}
     % all neuromag MEG channels start with MEG
     % all neuromag EEG channels start with EEG
@@ -283,27 +284,27 @@ switch senstype
     % all neuromag306 magnetometers follow pattern MEG*1
     labelmeg = datachannel(strncmp('MEG', datachannel, length('MEG')));
     labeleeg = datachannel(strncmp('EEG', datachannel, length('EEG')));
-    
+
     labelmeggrad   = labelmeg(~cellfun(@isempty, regexp(labelmeg, '^MEG.*[23]$')));
     labelmegmag    = labelmeg(~cellfun(@isempty, regexp(labelmeg, '^MEG.*1$')));
     labelmegplanar = labelmeggrad;
-    
+
   case {'ant128', 'biosemi64', 'biosemi128', 'biosemi256', 'egi32', 'egi64', 'egi128', 'egi256', 'eeg1020', 'eeg1010', 'eeg1005', 'ext1020'}
     if ~ft_senstype(datachannel, 'unknown')
       % use an external helper function to define the list with EEG channel names
       labeleeg = ft_senslabel(ft_senstype(datachannel));
     end
-    
+
   case {'itab153' 'itab28' 'itab28_old'}
     % all itab MEG channels start with MAG
     labelmeg = datachannel(strncmp('MAG', datachannel, length('MAG')));
-    
+
   otherwise
     if ~isempty(datachantype)
       labelmeg = datachannel(strncmp('meg', datachantype, 3));
       labeleeg = datachannel(strncmp('eeg', datachantype, 3));
     end
-    
+
 end % switch ft_senstype
 
 % figure out if there are bad channels or channel groups that should be excluded


### PR DESCRIPTION
We have updated 
- read_yokogawa_header_new.m
- read_ricoh_header.m
- ft_channelselection.m

In read_yokogawa_header_new.m and read_ricoh_header.m, we have modified part of defining EEG labels. 
All the defined labels have a common string "EEG_*". 
In ft_channelselection.m, we have added 'labeleeg'. 