### PR TITLE
Fix backward incompatibility in ft_defaults

### DIFF
--- a/ft_defaults.m
+++ b/ft_defaults.m
@@ -344,7 +344,7 @@ end % function checkMultipleToolbox
 function checkIncorrectPath
 p = fileparts(mfilename('fullpath'));
 incorrect = fullfile(p, 'compat', 'incorrect');
-if contains(path, incorrect)
+if ~isempty(strfind(path, incorrect))
   ft_warning('Your path is set up incorrectly. You probably used addpath(genpath(''path_to_fieldtrip'')), this can lead to unexpected behaviour. See http://www.fieldtriptoolbox.org/faq/should_i_add_fieldtrip_with_all_subdirectories_to_my_matlab_path');
 end
 end % function checkIncorrectPath


### PR DESCRIPTION
Commit 1716c92 added (inter alia) a contains()-command to ft_defaults, which does not exist in Matlab versions older than R2016b. This (ugly but working) alternative restores backwards compatibility to older Matlab versions.