### PR TITLE
import event info for mne -epo.fif

### DIFF
--- a/fileio/ft_read_event.m
+++ b/fileio/ft_read_event.m
@@ -1543,12 +1543,12 @@ switch eventformat
     elseif isepoched
         begsample = cumsum([1 repmat(615, 29, 1)']);
         events_id = split(split(hdr.orig.epochs.event_id, ';'), ':');
-        events_label = cell2mat(events_id(:,1));
-        events_code = str2num(cell2mat(events_id(:,2)));
+        events_label = cell2mat(events_id(:, 1));
+        events_code = str2num(cell2mat(events_id(:, 2)));
         for i=1:hdr.nTrials 
-            event(end+1).type      = events_label(events_code == hdr.orig.epochs.events(i, 3), :);
+            event(end+1).type      = 'trial';
             event(end  ).sample    = begsample(i);
-            event(end  ).value     = hdr.orig.epochs.events(i, 3);
+            event(end  ).value     = events_label(events_code == hdr.orig.epochs.events(i, 3), :);
             event(end  ).offset    = -hdr.nSamplesPre;
             event(end  ).duration  = hdr.nSamples;
         end

--- a/fileio/ft_read_event.m
+++ b/fileio/ft_read_event.m
@@ -1541,7 +1541,19 @@ switch eventformat
       end
 
     elseif isepoched
-      ft_error('Support for epoched *.fif data is not yet implemented.')
+        begsample = cumsum([1 repmat(615, 29, 1)']);
+        events_id = split(split(hdr.orig.epochs.event_id, ';'), ':');
+        events_label = cell2mat(events_id(:,1));
+        events_code = str2num(cell2mat(events_id(:,2)));
+        for i=1:hdr.nTrials 
+            event(end+1).type      = events_label(events_code == hdr.orig.epochs.events(i, 3), :);
+            event(end  ).sample    = begsample(i);
+            event(end  ).value     = hdr.orig.epochs.events(i, 3);
+            event(end  ).offset    = -hdr.nSamplesPre;
+            event(end  ).duration  = hdr.nSamples;
+        end
+        
+%       ft_error('Support for epoched *.fif data is not yet implemented.')
     end
 
     % check whether the *.fif file is accompanied by an *.eve file

--- a/fileio/ft_read_event.m
+++ b/fileio/ft_read_event.m
@@ -1541,7 +1541,7 @@ switch eventformat
       end
 
     elseif isepoched
-        begsample = cumsum([1 repmat(615, 29, 1)']);
+        begsample = cumsum([1 repmat(hdr.nSamples, hdr.nTrials-1, 1)']);
         events_id = split(split(hdr.orig.epochs.event_id, ';'), ':');
         events_label = cell2mat(events_id(:, 1));
         events_code = str2num(cell2mat(events_id(:, 2)));
@@ -1552,8 +1552,6 @@ switch eventformat
             event(end  ).offset    = -hdr.nSamplesPre;
             event(end  ).duration  = hdr.nSamples;
         end
-        
-%       ft_error('Support for epoched *.fif data is not yet implemented.')
     end
 
     % check whether the *.fif file is accompanied by an *.eve file

--- a/ft_definetrial.m
+++ b/ft_definetrial.m
@@ -34,7 +34,7 @@ function [cfg] = ft_definetrial(cfg)
 % a negative offset indicates that the trial begins before the trigger.
 %
 % The trial definition "trl" can contain additional columns besides the
-% required three that represend begin, end and offset. These additional
+% required three that represent begin, end and offset. These additional
 % columns can be used by a custom trialfun to provide numeric information
 % about each trial such as trigger codes, response latencies, trial
 % type and response correctness. The additional columns of the "trl"


### PR DESCRIPTION
I am trying to complement the mne-fieltrip integration offering import functionality for Epochs.

It mostly works, but there still is a bug somewhere. In cfg.event every trial appears a second time being labelled as 'trial'. Maybe someone could have a look?