### PR TITLE
Leadfield

### DIFF
--- a/forward/ft_average_sens.m
+++ b/forward/ft_average_sens.m
@@ -44,9 +44,8 @@ nsens  = numel(sens);
 
 % ensure the correct representation
 for i=1:nsens
-  newsens(i) = ft_datatype_sens(sens(i));
+  sens(i) = ft_datatype_sens(sens(i));
 end
-sens = newsens; clear newsens
 
 fiducials = fixpos(fiducials);
 
@@ -74,16 +73,16 @@ else
 end
 
 pos = detrend(sens(1).chanpos, 'constant');
-[u s v]= svd(pos'*pos);
+[u, s, v]= svd(pos'*pos);
 
 % starting with the second PC works a little better (e.g. on BTi)
 x1 = pos*u(:, 2);
 x2 = pos*u(:, 1);
 
 % detemine the indices of three reference sensors that are close to the three principal axes
-[m ind1] = min(x1);
-[m ind2] = max(x1);
-[m ind3] = max(abs(x2 - mean(x2([ind1 ind2]))));
+[~, ind1] = min(x1);
+[~, ind2] = max(x1);
+[~, ind3] = max(abs(x2 - mean(x2([ind1 ind2]))));
 
 % compute the mean of the three reference sensors for the principal axes
 mean1 = [0 0 0];
@@ -206,15 +205,15 @@ switch nfid
     switch afiducials.unit
         case 'mm'
             c = 0.1;
-        case 'cm';
+        case 'cm'
             c = 1;
-        case 'dm';
+        case 'dm'
             c = 10;
         case 'm'
             c = 100;
     end
     
-    [upos, ind] = unique(round(c*afiducials.pos/tolerance), 'rows');
+    [~, ind] = unique(round(c*afiducials.pos/tolerance), 'rows');
     
     afiducials.pos = afiducials.pos(ind, :);
     

--- a/forward/ft_compute_leadfield.m
+++ b/forward/ft_compute_leadfield.m
@@ -524,7 +524,7 @@ if reducerank<size(lf,2)
       lf(:, (3*ii-2):(3*ii)) = u * s * v';
     else
       % if not backprojected, the new leadfield has a different dimension
-      if ii==1,
+      if ii==1
         newlf    = zeros(size(lf,1), Ndipoles*reducerank);
         origrank = size(lf,2)./Ndipoles;
       end
@@ -532,7 +532,7 @@ if reducerank<size(lf,2)
     end
   end
   
-  if ~istrue(backproject),
+  if ~istrue(backproject)
     lf = newlf;
   end
   clear newlf;

--- a/forward/private/leadsphere_all.m
+++ b/forward/private/leadsphere_all.m
@@ -2,6 +2,7 @@ function out=leadsphere_all(xloc,sensorloc,sensorori)
 % usage: out=leadsphere_all(xloc,sensorloc,sensorori)
 
 % Copyright (C) 2003, Guido Nolte
+% Copyright (C) 2018, Jan-Mathijs Schoffelen
 %
 % This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
 % for the documentation and details.
@@ -21,36 +22,84 @@ function out=leadsphere_all(xloc,sensorloc,sensorori)
 %
 % $Id$
 
-[n,nsens]=size(sensorloc); %n=3 m=? 
-[n,ndip]=size(xloc);
+% ---Here begins Guido's original implementation
+% [n,nsens]=size(sensorloc); %n=3 m=? 
+% [n,ndip]=size(xloc);
+% 
+% 
+% xlocrep=reshape(repmat(xloc,1,nsens),3,ndip,nsens);
+% sensorlocrep=reshape(repmat(sensorloc,ndip,1),3,ndip,nsens);
+% sensororirep=reshape(repmat(sensorori,ndip,1),3,ndip,nsens);
+% 
+% r2=norms(sensorlocrep);
+% veca=sensorlocrep-xlocrep;
+% a=norms(veca);
+% adotr2=dotproduct(veca,sensorlocrep);
+% 
+% gradf1=scal2vec(1./r2.*(a.^2)+adotr2./a+2*a+2*r2);
+% gradf2=scal2vec(a+2*r2+adotr2./a);
+% gradf=gradf1.*sensorlocrep-gradf2.*xlocrep;
+% 
+% F=a.*(r2.*a+adotr2);
+% 
+% A1=scal2vec(1./F);
+% A2=A1.^2;
+% 
+% A3=crossproduct(xlocrep,sensororirep);
+% A4=scal2vec(dotproduct(gradf,sensororirep));
+% A5=crossproduct(xlocrep,sensorlocrep);
+% 
+% out=1e-7*(A3.*A1-(A4.*A2).*A5); %%GRB change
+% 
+% return;
 
+% Here begins JMS' adjustment to Guido's implementation, which is much more
+% memory friendly with large numbers of dipoles. Essentially, it does not
+% work with massively repmatted sensorloc and xloc matrices
+[~,nsens] = size(sensorloc); %n=3 m=? 
+[~, ndip] = size(xloc);
 
-xlocrep=reshape(repmat(xloc,1,nsens),3,ndip,nsens);
-sensorlocrep=reshape(repmat(sensorloc,ndip,1),3,ndip,nsens);
-sensororirep=reshape(repmat(sensorori,ndip,1),3,ndip,nsens);
+r2   = repmat(sqrt(sum(sensorloc.^2)), ndip, 1);
+veca = reshape(repmat(sensorloc,ndip,1),3,ndip,nsens)-reshape(repmat(xloc,1,nsens),3,ndip,nsens);
+a    = norms(veca);
+adotr2 = dotproduct_light(veca,sensorloc');
 
-r2=norms(sensorlocrep);
-veca=sensorlocrep-xlocrep;
-a=norms(veca);
-adotr2=dotproduct(veca,sensorlocrep);
+gradf1 = (1./r2.*(a.^2)+adotr2./a+2*a+2*r2);
+gradf2 = (a+2*r2+adotr2./a);
 
-gradf1=scal2vec(1./r2.*(a.^2)+adotr2./a+2*a+2*r2);
-gradf2=scal2vec(a+2*r2+adotr2./a);
-gradf=gradf1.*sensorlocrep-gradf2.*xlocrep;
+gradf        = zeros(3,ndip,nsens);
+gradf(1,:,:) = gradf1*spdiags(sensorloc(1,:)',0,nsens,nsens) - spdiags(xloc(1,:)',0,ndip,ndip)*gradf2;
+gradf(2,:,:) = gradf1*spdiags(sensorloc(2,:)',0,nsens,nsens) - spdiags(xloc(2,:)',0,ndip,ndip)*gradf2;
+gradf(3,:,:) = gradf1*spdiags(sensorloc(3,:)',0,nsens,nsens) - spdiags(xloc(3,:)',0,ndip,ndip)*gradf2;
 
-F=a.*(r2.*a+adotr2);
+A1  = shiftdim(1./(a.*(r2.*a+adotr2)),-1);
+A42 = shiftdim(dotproduct_light(gradf,sensorori'),-1).*(A1.^2); % this is the element wise product of A2 and A4 in Guido's original
 
-A1=scal2vec(1./F);
-A2=A1.^2;
+A3 = crossproduct_light(xloc', sensorori');
+A5 = crossproduct_light(xloc',sensorloc');
 
-A3=crossproduct(xlocrep,sensororirep);
-A4=scal2vec(dotproduct(gradf,sensororirep));
-A5=crossproduct(xlocrep,sensorlocrep);
-
-out=1e-7*(A3.*A1-(A4.*A2).*A5); %%GRB change
-
+out        = zeros(size(A3));
+out(1,:,:) = 1e-7*(A3(1,:,:).*A1 - A5(1,:,:).*A42);
+out(2,:,:) = 1e-7*(A3(2,:,:).*A1 - A5(2,:,:).*A42);
+out(3,:,:) = 1e-7*(A3(3,:,:).*A1 - A5(3,:,:).*A42);
 return;
 
+function out=crossproduct_light(x,y)
+% this should work because the original x is always repmatted along the
+% third (original, i.e. sens) dimension, the y along the second (i.e. loc)
+m=size(x,1);
+k=size(y,1);
+out=zeros(3,m,k);
+out(1,:,:)=x(:,2)*y(:,3)'-x(:,3)*y(:,2)';
+out(2,:,:)=x(:,3)*y(:,1)'-x(:,1)*y(:,3)';
+out(3,:,:)=x(:,1)*y(:,2)'-x(:,2)*y(:,1)';
+return;
+
+function out=dotproduct_light(x,y)
+k = size(y,1);
+% this should work because the x is always 3xnlocxnsens, and y is nsensx3
+out=shiftdim(x(1,:,:))*spdiags(y(:,1),0,k,k)+shiftdim(x(2,:,:))*spdiags(y(:,2),0,k,k)+shiftdim(x(3,:,:))*spdiags(y(:,3),0,k,k);
+return;
 
 
 function out=crossproduct(x,y)

--- a/ft_headmovement.m
+++ b/ft_headmovement.m
@@ -131,6 +131,10 @@ tmpcfg.trl          = cfg.trl;
 tmpcfg.channel      = {'HLC0011' 'HLC0012' 'HLC0013' 'HLC0021' 'HLC0022' 'HLC0023' 'HLC0031' 'HLC0032' 'HLC0033'};
 tmpcfg.continuous   = 'yes';
 data                = ft_preprocessing(tmpcfg);
+data                = removefields(data, 'elec'); % this slows down a great
+                        % rendering the persistent variable trick useless.
+                        % we don't need the elec anyway
+
 wdat                = cellfun('size', data.time, 2); % weights for weighted average
 
 trial_index = cell(1,numel(data.trial));
@@ -304,6 +308,9 @@ switch cfg.method
       tmpcfg        = [];
       tmpcfg.trials = find(bin==k);
       tmpdata_clus  = ft_selectdata(tmpcfg, data);
+      %tmpcfg.previous = tmpdata_clus.cfg;
+      
+      %tmpdata_clus.cfg  = tmpcfg;
       tmpdata_clus.grad = grad(k);
       
       varargout{k} = tmpdata_clus;
@@ -313,5 +320,5 @@ end
 ft_postamble debug
 ft_postamble trackconfig
 ft_postamble provenance
-ft_postamble previous data  % this copies the datain.cfg structure into the cfg.previous field. You can also use it for multiple inputs, or for "varargin"
-ft_postamble history varargout  % this adds the local cfg structure to the output data structure, i.e. dataout.cfg = cfg
+ft_postamble previous varargout{:}  % this copies the datain.cfg structure into the cfg.previous field. You can also use it for multiple inputs, or for "varargin"
+ft_postamble history varargout{:}  % this adds the local cfg structure to the output data structure, i.e. dataout.cfg = cfg

--- a/ft_headmovement.m
+++ b/ft_headmovement.m
@@ -1,4 +1,4 @@
-function [grad] = ft_headmovement(cfg)
+function [grad, trialinfo, transform] = ft_headmovement(cfg)
 
 % FT_HEADMOVEMENT creates a representation of the CTF gradiometer definition
 % in which the headmovement in incorporated. The result can be used
@@ -11,6 +11,24 @@ function [grad] = ft_headmovement(cfg)
 %   cfg.trl          = Nx3 matrix with the trial definition, see FT_DEFINETRIAL
 %   cfg.numclusters  = number of segments with constant headposition in which to split the data (default = 12)
 %
+% optional arguments are
+%   cfg.updatesens   = 'yes' (default) or 'no'
+%   cfg.pertrial     = 'no' (default) or 'yes'
+%
+% If cfg.updatesens is specified, the output gradiometer description is
+% defined in dewar coordinates, and the specification of the coils is
+% expanded as per the centroids of the position clusters. The balancing
+% matrix is s a weighted concatenation of the original tra-matrix. If
+% cfg.updatesens is false, the output gradiometer description is the
+% original head coordinate system based grad-array. If cfg.pertrial is
+% specified, the clustering of head positions is done on the average
+% coil-position per trial. Additional output consists of a vector that
+% specifies the cluster-identity of the corresponding trial, and a set of
+% cluster-specific transformation matrices (4x4xcfg.numclusters) that can
+% be applied to the output grad-array, to obtain the sensor-description of
+% the corresponding trial.
+%
+% 
 % This method and related methods are described by Stolk et al., Online and
 % offline tools for head movement compensation in MEG. NeuroImage, 2012.
 %
@@ -58,7 +76,9 @@ cfg = ft_checkconfig(cfg, 'dataset2files', 'yes');
 
 % set the defaults
 cfg.numclusters = ft_getopt(cfg, 'numclusters', 12);
-cfg.feedback    = ft_getopt(cfg, 'feedback', 'yes');
+cfg.feedback    = ft_getopt(cfg, 'feedback',    'yes');
+cfg.updatesens  = ft_getopt(cfg, 'updatesens',  'yes');
+cfg.pertrial    = ft_getopt(cfg, 'pertrial',    'no');
 
 % read the header information
 hdr = ft_read_header(cfg.headerfile);
@@ -87,18 +107,29 @@ tmpcfg.channel      = {'HLC0011' 'HLC0012' 'HLC0013' 'HLC0021' 'HLC0022' 'HLC002
 tmpcfg.continuous   = 'yes';
 data                = ft_preprocessing(tmpcfg);
 
+if istrue(cfg.pertrial)
+  for k = 1:numel(data.trial)
+    data.trial{k} = mean(data.trial{k},2);
+    data.time{k}  = 0;
+  end
+end
 dat = cat(2, data.trial{:});
 dat = dat * ft_scalingfactor('m', grad.unit); % scale in units of the gradiometer definition
 
-[tmpdata, dum, ic] = unique(dat', 'rows');
-dat = tmpdata';
+if ~istrue(cfg.pertrial)
+  [tmpdata, ~, ic] = unique(dat', 'rows');
+  dat = tmpdata';
 
-% counthow often each position occurs
-[wdat, dum] = hist(ic, unique(ic));
+  % count how often each position occurs
+  wdat = hist(ic, unique(ic));
 
-% compute the cluster means
-[bin, cluster] = kmeans(dat', cfg.numclusters);
-
+  % compute the cluster means
+  [bin, cluster] = kmeans(dat', cfg.numclusters);
+else
+  [bin, cluster] = kmeans(dat', cfg.numclusters);
+  wdat           = ones(size(dat,2),1);
+end
+  
 % find the three channels for each fiducial
 selnas = strmatch('HLC001', data.label);
 sellpa = strmatch('HLC002', data.label);
@@ -112,8 +143,8 @@ for k = 1:length(ubin)
   numperbin(k) = sum(wdat(bin==ubin(k)));
 end
 
+hc    = read_ctf_hc([cfg.datafile(1:end-4),'hc']);  
 if istrue(cfg.feedback)
-  hc    = read_ctf_hc([cfg.datafile(1:end-4),'hc']);
   
   % plot some stuff
   figure; hold on;
@@ -136,21 +167,31 @@ for k = 1:size(transform, 3)
   transform(:,:,k) = ft_headcoordinates(nas(k,:), lpa(k,:), rpa(k,:), 'ctf');
 end
 
-npos        = size(transform, 3);
-ncoils      = size(grad.coilpos,  1);
-gradnew     = grad;
-gradnew.coilpos = zeros(size(grad.coilpos,1)*npos, size(grad.coilpos,2));
-gradnew.coilori = zeros(size(grad.coilpos,1)*npos, size(grad.coilpos,2));
-gradnew.tra = repmat(grad.tra, [1 npos]);
-for m = 1:npos
-  tmptransform                                  = transform(:,:,m);
-  gradnew.coilpos((m-1)*ncoils+1:(m*ncoils), :) = ft_warp_apply(tmptransform, grad.coilpos); % back to head coordinates
-  tmptransform(1:3, 4)                          = 0; % keep rotation only
-  gradnew.coilori((m-1)*ncoils+1:(m*ncoils), :) = ft_warp_apply(tmptransform, grad.coilori);
-  gradnew.tra(:, (m-1)*ncoils+1:(m*ncoils))     = grad.tra.*(numperbin(m)./sum(numperbin));
+if istrue(cfg.updatesens)
+  npos        = size(transform, 3);
+  ncoils      = size(grad.coilpos,  1);
+  gradnew     = grad;
+  gradnew.coilpos = zeros(size(grad.coilpos,1)*npos, size(grad.coilpos,2));
+  gradnew.coilori = zeros(size(grad.coilpos,1)*npos, size(grad.coilpos,2));
+  gradnew.tra = repmat(grad.tra, [1 npos]);
+  for m = 1:npos
+    tmptransform                                  = transform(:,:,m);
+    gradnew.coilpos((m-1)*ncoils+1:(m*ncoils), :) = ft_warp_apply(tmptransform, grad.coilpos); % back to head coordinates
+    tmptransform(1:3, 4)                          = 0; % keep rotation only
+    gradnew.coilori((m-1)*ncoils+1:(m*ncoils), :) = ft_warp_apply(tmptransform, grad.coilori);
+    gradnew.tra(:, (m-1)*ncoils+1:(m*ncoils))     = grad.tra.*(numperbin(m)./sum(numperbin));
+  end
+  
+  grad = gradnew;
+  trialinfo = [];
+else
+  M = [reshape(hc.affine,[4 3])';0 0 0 1];
+  for k = 1:size(transform,3)
+    transform(:,:,k) = M\transform(:,:,k);
+  end
+  grad      = grad_head;
+  trialinfo = bin(:)';
 end
-
-grad = gradnew;
 
 % do the general cleanup and bookkeeping at the end of the function
 ft_postamble debug

--- a/ft_prepare_leadfield.m
+++ b/ft_prepare_leadfield.m
@@ -51,14 +51,14 @@ function [grid, cfg] = ft_prepare_leadfield(cfg, data)
 % specified. 
 %
 % For OPENMEEG based headmodels:
-%   cfg.om.batchsize = scalar (default 100e3), number of voxels per DSM batch. 
+%   cfg.openmeeg.batchsize = scalar (default 100e3), number of voxels per DSM batch. 
 %                       Set to e.g. 1000 if not much RAM available
-%   cfg.om.dsm       = 'no'/'yes', reuse existing DSM if provided
-%   cfg.om.keepdsm   = 'no'/'yes', option to retain DSM (no by default)
-%   cfg.om.nonadaptive = 'no'/'yes'
+%   cfg.openmeeg.dsm       = 'no'/'yes', reuse existing DSM if provided
+%   cfg.openmeeg.keepdsm   = 'no'/'yes', option to retain DSM (no by default)
+%   cfg.openmeeg.nonadaptive = 'no'/'yes'
 %  
 % For SINGLESHELL based headmodels:
-%   cfg.om.batchsize = scalar (default 1), but can be 'all'. Number of
+%   cfg.singleshell.batchsize = scalar (default 1), but can be 'all'. Number of
 %                       dipoles for which the leadfield is computed in a 
 %                       single call to the low-level code. Trades off
 %                       memory efficiency for speed.
@@ -131,6 +131,7 @@ end
 % check if the input cfg is valid for this function
 cfg = ft_checkconfig(cfg, 'renamed', {'hdmfile', 'headmodel'});
 cfg = ft_checkconfig(cfg, 'renamed', {'vol',     'headmodel'});
+cfg = ft_checkconfig(cfg, 'renamed', {'om',      'openmeeg'});
 
 % set the defaults
 cfg.normalize      = ft_getopt(cfg, 'normalize',      'no');
@@ -193,13 +194,13 @@ if ft_voltype(headmodel, 'openmeeg')
   % calling it once is much more efficient
   fprintf('calculating leadfield for all positions at once, this may take a while...\n');
   
-  if(~isfield(cfg,'om'))
-    cfg.om = [];
+  if(~isfield(cfg,'openmeeg'))
+    cfg.openmeeg = [];
   end
-  batchsize   = ft_getopt(cfg.om, 'batchsize',100e3); % number of voxels per DSM batch; set to e.g. 1000 if not much RAM available
-  dsm         = ft_getopt(cfg.om, 'dsm'); % reuse existing DSM if provided
-  keepdsm     = ft_getopt(cfg.om, 'keepdsm', 'no'); % option to retain DSM (no by default)
-  nonadaptive = ft_getopt(cfg.om, 'nonadaptive', 'no');
+  batchsize   = ft_getopt(cfg.openmeeg, 'batchsize',100e3); % number of voxels per DSM batch; set to e.g. 1000 if not much RAM available
+  dsm         = ft_getopt(cfg.openmeeg, 'dsm'); % reuse existing DSM if provided
+  keepdsm     = ft_getopt(cfg.openmeeg, 'keepdsm', 'no'); % option to retain DSM (no by default)
+  nonadaptive = ft_getopt(cfg.openmeeg, 'nonadaptive', 'no');
   
   ndip       = length(insideindx);
   numchunks  = ceil(ndip/batchsize);
@@ -235,7 +236,7 @@ if ft_voltype(headmodel, 'openmeeg')
         
         if istrue(keepdsm)
           % retain DSM in cfg if desired
-          cfg.om.dsm = dsm;
+          cfg.openmeeg.dsm = dsm;
         end
         
         dipindx = insideindx(diprange);

--- a/private/topoplot_common.m
+++ b/private/topoplot_common.m
@@ -39,6 +39,8 @@ cfg = ft_checkconfig(cfg, 'unused',     {'cohtargetchannel'});
 cfg = ft_checkconfig(cfg, 'renamed',    {'cohrefchannel' 'refchannel'});
 cfg = ft_checkconfig(cfg, 'renamed',    {'zparam', 'parameter'});
 
+cfg.newfigure = ft_getopt(cfg, 'newfigure', 'yes');
+
 Ndata = numel(varargin);
 if isnumeric(varargin{end})
   % the call with multiple inputs is done by ft_topoplotIC and recursively by ft_topoplotER/TFR itself
@@ -52,12 +54,16 @@ end
 % the call with multiple inputs is done by ft_topoplotIC and recursively by ft_topoplotER/TFR itself
 % the last input argument points to the specific data to be plotted
 if Ndata>1 && ~isnumeric(varargin{end})
+  
   for k=1:Ndata
     
-    if k>1
+    if k>1 && istrue(cfg.newfigure)
       % create a new figure for the additional input arguments
       % ensure that the new figure appears at the same position
       figure('Position', get(gcf, 'Position'), 'Visible', get(gcf, 'Visible'));
+    end
+    if ~istrue(cfg.newfigure)
+      subplot(floor(sqrt(Ndata)), ceil(sqrt(Ndata)), k);
     end
     
     % the indexing is necessary if ft_topoplotER/TFR is called from

--- a/test/test_ft_headmovement.m
+++ b/test/test_ft_headmovement.m
@@ -9,6 +9,7 @@ dataset = dccnpath('/home/common/matlab/fieldtrip/data/SubjectRest.ds');
 
 cfg = [];
 cfg.dataset = dataset;
+cfg.method  = 'updatesens';
 data1 = ft_headmovement(cfg);
 
 cfg = [];
@@ -18,14 +19,18 @@ cfg.numclusters = 10;
 data2 = cell(1,cfg.numclusters);
 [data2{:}] = ft_headmovement(cfg);
 
-cfg = [];
-cfg.length = 10;
-data_chunked = ft_redefinetrial(cfg, data1);
-
-cfg = [];
-cfg.dataset = dataset;
-cfg.trl    = data_chunked.sampleinfo;
+cfg          = [];
+cfg.dataset  = dataset;
+cfg.trl      = [(1:1000:100000)' (1000:1000:100000)'];
 cfg.trl(:,3) = 0;
-cfg.method = 'pertrial';
-data3 = cell(1,numel(data_chunked.trial));
+cfg.method = 'pertrial_cluster';
+cfg.numclusters = 10;
+data3 = cell(1,cfg.numclusters);
 [data3{:}] = ft_headmovement(cfg);
+
+cfg         = [];
+cfg.dataset = dataset;
+cfg.trl      = [(1:1000:100000)' (1000:1000:100000)'];
+cfg.trl(:,3) = 0;
+cfg.method  = 'avgoverrpt';
+data4 = ft_headmovement(cfg);

--- a/test/test_ft_headmovement.m
+++ b/test/test_ft_headmovement.m
@@ -1,0 +1,31 @@
+function test_ft_headmovement
+
+% MEM 3000mb
+% WALLTIME 00:20:00
+
+% TEST ft_headmovement
+
+dataset = dccnpath('/home/common/matlab/fieldtrip/data/SubjectRest.ds');
+
+cfg = [];
+cfg.dataset = dataset;
+data1 = ft_headmovement(cfg);
+
+cfg = [];
+cfg.dataset = dataset;
+cfg.method = 'cluster';
+cfg.numclusters = 10;
+data2 = cell(1,cfg.numclusters);
+[data2{:}] = ft_headmovement(cfg);
+
+cfg = [];
+cfg.length = 10;
+data_chunked = ft_redefinetrial(cfg, data1);
+
+cfg = [];
+cfg.dataset = dataset;
+cfg.trl    = data_chunked.sampleinfo;
+cfg.trl(:,3) = 0;
+cfg.method = 'pertrial';
+data3 = cell(1,numel(data_chunked.trial));
+[data3{:}] = ft_headmovement(cfg);


### PR DESCRIPTION
This PR reflects some work to add functionality to ft_headmovement, and to be able to use this functionality in downstream analysis (requiring the computation of forward models possibly multiple times).

Essentially:
1 ft_headmovement can now also output a struct-array of gradiometer descriptions, based on a kmeans clustering of the HLC reconstructed head position during the measurement. 
2 ft_prepare_leadfield can now compute singleshell headmodel based leadfields much faster (in my specific test case (matlab 2016b, 8196 dipoles) this speeds up the computation with a factor of 6.
3 in order for ft_prepare_leadfield to compute the 'leadfield' in chunks-of-dipoles for the singleshell method, I adjusted also the low-level code contributed by Guido (leadsphere_all), to keep it somewhat memory efficient. The original implementation was extremely greedy, which became apparent when using it on the 8196 dipole example. The function required at some point about 4000mb of memory extra. I have tested the numerical equality between Guido's original and my implementation, and I'm pretty sure that they are equivalent.
4 some small cosmetic changes along the way in functions that I brushed by.
5 (as of yet hidden) option in topoplot_common to plot the topo's in a single figure with subplots, rather than one topo per figure, when multiple inputs are present