### PR TITLE
bugzilla 3325  - determine orientation by fitting a sphere

### DIFF
--- a/bin/synchronize-private.sh
+++ b/bin/synchronize-private.sh
@@ -458,6 +458,7 @@ sync ${ARRAY[*]}
 
 ARRAY=()
 ARRAY+=(forward/private/fitsphere.m)
+ARRAY+=(plotting/private/fitsphere.m)
 ARRAY+=(private/fitsphere.m)
 sync ${ARRAY[*]}
 

--- a/plotting/ft_plot_sens.m
+++ b/plotting/ft_plot_sens.m
@@ -24,10 +24,12 @@ function hs = ft_plot_sens(sens, varargin)
 %   'coilsize'        = diameter or edge length of the coils (default is automatic)
 % The following options apply to EEG electrodes
 %   'elec'            = true/false, plot each individual electrode (default = false)
+%   'orientation'     = true/false, plot a line for the orientation of each electrode (default = false)
 %   'elecshape'       = 'point', 'circle', 'square', or 'sphere' (default is automatic)
 %   'elecsize'        = diameter of the electrodes (default is automatic)
 % The following options apply to NIRS optodes
 %   'opto'            = true/false, plot each individual optode (default = false)
+%   'orientation'     = true/false, plot a line for the orientation of each optode (default = false)
 %   'optoshape'       = 'point', 'circle', 'square', or 'sphere' (default is automatic)
 %   'optosize'        = diameter of the optodes (default is automatic)
 %
@@ -254,47 +256,21 @@ if ~holdflag
   hold on
 end
 
-if istrue(orientation)
-  if istrue(individual)
-    if isfield(sens, 'coilori')
-      pos = sens.coilpos;
-      ori = sens.coilori;
-    elseif isfield(sens, 'elecori')
-      pos = sens.elecpos;
-      ori = sens.elecori;
-    else
-      pos = [];
-      ori = [];
-    end
-  else
-    if isfield(sens, 'chanori')
-      pos = sens.chanpos;
-      ori = sens.chanori;
-    else
-      pos = [];
-      ori = [];
-    end
-  end
-  scale = ft_scalingfactor('mm', sens.unit)*20; % draw a line segment of 20 mm
-  for i=1:size(pos,1)
-    x = [pos(i,1) pos(i,1)+ori(i,1)*scale];
-    y = [pos(i,2) pos(i,2)+ori(i,2)*scale];
-    z = [pos(i,3) pos(i,3)+ori(i,3)*scale];
-    line(x, y, z)
-  end
-end
-
 if istrue(individual)
-  % simply get the position of all individual coils or electrodes
+  % get the position of all individual coils, electrodes or optodes
   if isfield(sens, 'coilpos')
     pos = sens.coilpos;
   elseif isfield(sens, 'elecpos')
     pos = sens.elecpos;
+  elseif isfield(sens, 'optopos')
+    pos = sens.optopos;
   end
   if isfield(sens, 'coilori')
     ori = sens.coilori;
   elseif isfield(sens, 'elecori')
     ori = sens.elecori;
+  elseif isfield(sens, 'optoori')
+    ori = sens.optoori;
   else
     ori = [];
   end
@@ -315,6 +291,26 @@ else
   end
   
 end % if istrue(individual)
+
+if isempty(ori)
+  % determine the orientation by fitting a sphere to the positions
+  % this should be reasonable for scalp electrodes or optodes with complete coverage
+  center = fitsphere(pos);
+  for i=1:size(pos,1)
+    ori(i,:) = pos(i,:) - center;
+    ori(i,:) = ori(i,:)/norm(ori(i,:));
+  end
+end
+
+if istrue(orientation)
+  scale = ft_scalingfactor('mm', sens.unit)*20; % draw a line segment of 20 mm
+  for i=1:size(pos,1)
+    x = [pos(i,1) pos(i,1)+ori(i,1)*scale];
+    y = [pos(i,2) pos(i,2)+ori(i,2)*scale];
+    z = [pos(i,3) pos(i,3)+ori(i,3)*scale];
+    line(x, y, z)
+  end
+end
 
 switch sensshape
   case 'point'

--- a/plotting/private/channelposition.m
+++ b/plotting/private/channelposition.m
@@ -5,11 +5,11 @@ function [pnt, ori, lab] = channelposition(sens)
 %
 % Use as
 %   [pos, ori, lab] = channelposition(sens)
-% where sens is an electrode or gradiometer array.
+% where sens is an electrode,  gradiometer or optode array.
 %
 % See also FT_DATATYPE_SENS
 
-% Copyright (C) 2009-2012, Robert Oostenveld & Vladimir Litvak
+% Copyright (C) 2009-2018, Robert Oostenveld & Vladimir Litvak
 %
 % This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
 % for the documentation and details.
@@ -313,7 +313,7 @@ switch ft_senstype(sens)
     
 end % switch senstype
 
-n   = size(lab,2);
+n = size(lab,2);
 % this is to fix the planar layouts, which cannot be plotted anyway
 if n>1 && size(lab, 1)>1 % this is to prevent confusion when lab happens to be a row array
   pnt = repmat(pnt, n, 1);

--- a/plotting/private/fitsphere.m
+++ b/plotting/private/fitsphere.m
@@ -1,0 +1,93 @@
+function [C,R] = fitsphere(pnt)
+
+% FITSPHERE fits the centre and radius of a sphere to a set of points
+% using Taubin's method.
+%
+% Use as
+%       [center,radius] = fitsphere(pnt)
+% where
+%   pnt     = Nx3 matrix with the Carthesian coordinates of the surface points
+% and
+%   center  = the center of the fitted sphere
+%   radius  = the radius of the fitted sphere
+
+% Copyright (C) 2009, Jean Daunizeau (for SPM)
+%
+% This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
+% for the documentation and details.
+%
+%    FieldTrip is free software: you can redistribute it and/or modify
+%    it under the terms of the GNU General Public License as published by
+%    the Free Software Foundation, either version 3 of the License, or
+%    (at your option) any later version.
+%
+%    FieldTrip is distributed in the hope that it will be useful,
+%    but WITHOUT ANY WARRANTY; without even the implied warranty of
+%    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%    GNU General Public License for more details.
+%
+%    You should have received a copy of the GNU General Public License
+%    along with FieldTrip. If not, see <http://www.gnu.org/licenses/>.
+%
+% $Id$
+
+x = pnt(:,1);
+y = pnt(:,2);
+z = pnt(:,3);
+
+% Make sugary one and zero vectors
+l = ones(length(x),1);
+O = zeros(length(x),1);
+
+% Make design mx
+D = [(x.*x + y.*y + z.*z) x y z l];
+
+Dx = [2*x l O O O];
+Dy = [2*y O l O O];
+Dz = [2*z O O l O];
+
+% Create scatter matrices
+M = D'*D;
+N = Dx'*Dx + Dy'*Dy + Dz'*Dz;
+
+% Extract eigensystem
+[v, evalues] = eig(M);
+evalues = diag(evalues);
+Mrank = sum(evalues > eps*5*norm(M));
+
+if (Mrank == 5)
+  % Full rank -- min ev corresponds to solution
+  % Minverse = v'*diag(1./evalues)*v;
+  [v,evalues] = eig(inv(M)*N);
+  [dmin,dminindex] = max(diag(evalues));
+  pvec = v(:,dminindex(1))';
+else
+  % Rank deficient -- just extract nullspace of M
+  % pvec = null(M)';  % this does not work reliably because of inconsistent rank definition
+  pvec = v(:,evalues <= eps*5*norm(M))';
+  [m,n] = size(pvec);
+  if m > 1
+    pvec = pvec(1,:);
+  end
+end
+
+if isempty(pvec)
+  ft_warning('was not able to fit a sphere to the surface points');
+   C = [NaN NaN NaN];
+   R = Inf;
+else
+   % Convert to (R,C)
+   C = -0.5*pvec(2:4) / pvec(1);
+   R = sqrt(sum(C*C') - pvec(5)/pvec(1));
+end
+
+
+% if nargout == 1,
+%   if pvec(1) < 0
+%     pvec = -pvec;
+%   end
+%   C = pvec;
+% else
+%   C = -0.5*pvec(2:4) / pvec(1);
+%   R = sqrt(sum(C*C') - pvec(5)/pvec(1));
+% end

--- a/plotting/test/test_ft_plot_sens.m
+++ b/plotting/test/test_ft_plot_sens.m
@@ -6,10 +6,33 @@ function test_ft_plot_sens
 % TEST test_ft_plot_sens
 % TEST ft_plot_sens
 
-elec.pnt = randn(10,3);
-for i=1:10
+elec.pnt = randn(32,3);
+for i=1:32
+  elec.pnt(i,:) = elec.pnt(i,:) / norm(elec.pnt(i,:));
   elec.label{i} = num2str(i);
 end
 
-figure
-ft_plot_sens(elec);
+figure; ft_plot_sens(elec);
+figure; ft_plot_sens(elec, 'elec', false);
+figure; ft_plot_sens(elec, 'elec', true);
+
+figure; ft_plot_sens(elec, 'elec', true, 'elecshape', 'point');
+figure; ft_plot_sens(elec, 'elec', true, 'elecshape', 'circle');
+figure; ft_plot_sens(elec, 'elec', true, 'elecshape', 'square');
+figure; ft_plot_sens(elec, 'elec', true, 'elecshape', 'sphere');
+
+figure; ft_plot_sens(elec, 'elec', true, 'individual', true, 'elecshape', 'point');
+figure; ft_plot_sens(elec, 'elec', true, 'individual', true, 'elecshape', 'circle');
+figure; ft_plot_sens(elec, 'elec', true, 'individual', true, 'elecshape', 'square');
+figure; ft_plot_sens(elec, 'elec', true, 'individual', true, 'elecshape', 'sphere');
+
+figure; ft_plot_sens(elec, 'elec', true, 'individual', false, 'elecshape', 'point');
+figure; ft_plot_sens(elec, 'elec', true, 'individual', false, 'elecshape', 'circle');
+figure; ft_plot_sens(elec, 'elec', true, 'individual', false, 'elecshape', 'square');
+figure; ft_plot_sens(elec, 'elec', true, 'individual', false, 'elecshape', 'sphere');
+
+figure; ft_plot_sens(elec, 'elec', true, 'individual', false, 'orientation', true, 'elecshape', 'point');
+figure; ft_plot_sens(elec, 'elec', true, 'individual', false, 'orientation', true, 'elecshape', 'circle');
+figure; ft_plot_sens(elec, 'elec', true, 'individual', false, 'orientation', true, 'elecshape', 'square');
+figure; ft_plot_sens(elec, 'elec', true, 'individual', false, 'orientation', true, 'elecshape', 'sphere');
+


### PR DESCRIPTION
added support for circle and square for all sensor types. See http://bugzilla.fieldtriptoolbox.org/show_bug.cgi?id=3325

This PR also includes plotting the orientation with a stick for all cases.