### PR TITLE
ENH: ability to warp from pial to inflated surface

### DIFF
--- a/ft_electroderealign.m
+++ b/ft_electroderealign.m
@@ -56,6 +56,8 @@ function [elec_realigned] = ft_electroderealign(cfg, elec_original)
 %                        'nonlin5'         apply a 5th order non-linear warp
 %                        'dykstra2012'     non-linear wrap only for headshape method, useful for projecting ECoG onto cortex hull
 %                        'fsaverage'       surface-based realignment with the freesurfer fsaverage brain
+%                        'fsinflated'      realignment of electrodes to patient's inflated brain
+%                        patients
 %   cfg.channel        = Nx1 cell-array with selection of channels (default = 'all'),
 %                        see  FT_CHANNELSELECTION for details
 %   cfg.keepchannel    = string, 'yes' or 'no' (default = 'no')
@@ -407,6 +409,8 @@ elseif strcmp(cfg.method, 'headshape')
     norm.elecpos = warp_hermes2010(cfg, elec, headshape);
   elseif strcmp(cfg.warp, 'fsaverage')
     norm.elecpos = warp_fsaverage(cfg, elec);
+  elseif strcmp(cfg.warp, 'fsinflated')
+    norm.elecpos = warp_fsinflated(cfg, elec); 
   else
     fprintf('warping electrodes to skin surface... '); % the newline comes later
     [norm.elecpos, norm.m] = ft_warp_optim(elec.elecpos, headshape, cfg.warp);
@@ -616,7 +620,7 @@ end % if method
 % electrode labels by their case-sensitive original values
 switch cfg.method
   case {'template', 'headshape'}
-    if strcmpi(cfg.warp, 'dykstra2012') || strcmpi(cfg.warp, 'hermes2010') || strcmpi(cfg.warp, 'fsaverage')
+    if strcmpi(cfg.warp, 'dykstra2012') || strcmpi(cfg.warp, 'hermes2010') || strcmpi(cfg.warp, 'fsaverage') || strcmpi(cfg.warp, 'fsinflated')
       elec_realigned = norm;
       elec_realigned.label = label_original;
     else

--- a/ft_electroderealign.m
+++ b/ft_electroderealign.m
@@ -55,9 +55,8 @@ function [elec_realigned] = ft_electroderealign(cfg, elec_original)
 %                        'nonlin4'         apply a 4th order non-linear warp
 %                        'nonlin5'         apply a 5th order non-linear warp
 %                        'dykstra2012'     non-linear wrap only for headshape method, useful for projecting ECoG onto cortex hull
-%                        'fsaverage'       surface-based realignment with the freesurfer fsaverage brain
-%                        'fsinflated'      realignment of electrodes to patient's inflated brain
-%                        patients
+%                        'fsaverage'       surface-based realignment with FreeSurfer fsaverage brain
+%                        'fsinflated'      surface-based realignment with FreeSurfer individual subject inflated brain
 %   cfg.channel        = Nx1 cell-array with selection of channels (default = 'all'),
 %                        see  FT_CHANNELSELECTION for details
 %   cfg.keepchannel    = string, 'yes' or 'no' (default = 'no')

--- a/private/warp_fsinflated.m
+++ b/private/warp_fsinflated.m
@@ -1,0 +1,49 @@
+function [coord_inf] = warp_fsinflated(cfg, elec)
+
+% WARP_FSINFLATED maps electrodes from FreeSurfer's pial surface to
+% FreeSurfer's inflated brain.
+%
+% The configuration must contain the following options:
+%   cfg.headshape      = string, filename containing subject headshape
+%                      (e.g. <path to freesurfer/surf/lh.pial>)
+%   cfg.fshome         = string, path to freesurfer
+%
+% See also FT_ELECTRODEREALIGN, FT_PREPARE_MESH
+
+% Copyright (C) 2018, Richard Jimenez & Arjen Stolk
+%
+% This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
+% for the documentation and details.
+%
+%    FieldTrip is free software: you can redistribute it and/or modify
+%    it under the terms of the GNU General Public License as published by
+%    the Free Software Foundation, either version 3 of the License, or
+%    (at your option) any later version.
+%
+%    FieldTrip is distributed in the hope that it will be useful,
+%    but WITHOUT ANY WARRANTY; without even the implied warranty of
+%    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%    GNU General Public License for more details.
+%
+%    You should have received a copy of the GNU General Public License
+%    along with FieldTrip. If not, see <http://www.gnu.org/licenses/>.
+%
+% $Id$
+
+subj_pial = ft_read_headshape(cfg.headshape);
+[PATHSTR, NAME] = fileparts(cfg.headshape); % lh or rh
+if ~exist([PATHSTR filesep NAME '.inflated'],'file');
+  ft_error([PATHSTR filesep NAME filesep 'inflated cannot be found'])
+end
+subj_inflated = ft_read_headshape([PATHSTR filesep NAME '.inflated']);
+
+for e = 1:numel(elec.label)
+  % subject space (3D surface): electrode pos -> pial vertex index
+  dist = sqrt(sum(((subj_pial.pos - repmat(elec.elecpos(e,:), size(subj_pial.pos,1), 1)).^2),2));
+  [~, minidx] = min(dist);
+  
+  % template space (3D surface): pial/inflated vertex index -> inflated brain pos
+  coord_inf(e,:) = subj_inflated.pos(minidx,:);
+  clear minidx
+end
+clear subj_pial subj_inflated


### PR DESCRIPTION
Hi, 

With the help of Arjen, the following changes to 'ft_electroderealign' and the addition of 'warp_fsinflated' allows the electrodes to be projected to the FreeSurfer subject's inflated brain output. In order to warp the electrodes onto the inflated brain, the only change that needs to be made is when calling 'ft_electroderealign', the configuration needs to have 'cfg.warp = 'fsinflated''. The following attachments show how the electrodes are warped from the mesh onto the inflated brain, where the gyri are the lighter regions in which the electrodes are found bordering the darker regions that contain the sulci where no electrodes are found since this is a grid case. 
![ir29_pial_left](https://user-images.githubusercontent.com/26529191/44241068-69eaab80-a176-11e8-9e77-0e36f6a58be2.jpg)
![ir29_inflated_left](https://user-images.githubusercontent.com/26529191/44241067-69521500-a176-11e8-9fe0-e8a5ef28a440.jpg)

Please let me know if you need further clarification or would like to make any changes. 

Thank you, 
Richard and Arjen 



