### PR TITLE
fix: potential misordering bug in ft_appensens bug related to matlab's unique operation 

### DIFF
--- a/ft_appendsens.m
+++ b/ft_appendsens.m
@@ -14,7 +14,7 @@ function [sens] = ft_appendsens(cfg, varargin)
 % See also FT_ELECTRODEPLACEMENT, FT_ELECTRODEREALIGN, FT_DATAYPE_SENS,
 % FT_APPENDDATA, FT_APPENDTIMELOCK, FT_APPENDFREQ, FT_APPENDSOURCE
 
-% Copyright (C) 2017, Arjen Stolk
+% Copyright (C) 2017-2018, Arjen Stolk
 %
 % This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
 % for the documentation and details.
@@ -148,16 +148,14 @@ end
 
 % concatenate the main fields and remove duplicates
 sens.label = cat(1,label{:});
-[~, labidx] = unique(sens.label);
-labidx = sort(labidx);
+[~, labidx] = unique(sens.label, 'stable');
 if ~isequal(numel(labidx), numel(sens.label))
   fprintf('removing duplicate labels\n')
   sens.label = sens.label(labidx);
 end
 
 sens.chanpos = cat(1,chanpos{:});
-[~, chanidx] = unique(sens.chanpos, 'rows');
-chanidx = sort(chanidx);
+[~, chanidx] = unique(sens.chanpos, 'rows', 'stable');
 if ~isequal(numel(chanidx), size(sens.chanpos,1))
   fprintf('removing duplicate channels\n')
   sens.chanpos = sens.chanpos(chanidx,:);
@@ -186,8 +184,7 @@ end
 
 if haselecpos
   sens.elecpos = cat(1,elecpos{:});
-  [~, elecidx, elecidx2] = unique(sens.elecpos, 'rows');
-  [elecidx, elecord] = sort(elecidx); % sort and keep track of the order
+  [~, elecidx, elecidx2] = unique(sens.elecpos, 'rows', 'stable');
   if ~isequal(numel(elecidx), size(sens.elecpos,1))
     fprintf('removing duplicate electrodes\n')
     sens.elecpos = sens.elecpos(elecidx,:);
@@ -195,7 +192,7 @@ if haselecpos
   if isfield(sens, 'tra')
     % shape duplicates into a single column, if necessary
     for idx = 1:numel(elecidx)
-      tmp(:, idx) = sum(sens.tra(chanidx, find(elecord(idx)==elecidx2)),2);
+      tmp(:, idx) = sum(sens.tra(chanidx, find(idx==elecidx2)),2); % find and take sum over duplicates
     end
     sens.tra = tmp;
     % check for expected size and non-empty rows or columns
@@ -209,8 +206,7 @@ end
 
 if hasoptopos
   sens.optopos = cat(1,optopos{:});
-  [~, optoidx, optoidx2] = unique(sens.optopos, 'rows');
-  [optoidx, optoord] = sort(optoidx); % sort and keep track of the order
+  [~, optoidx, optoidx2] = unique(sens.optopos, 'rows', 'stable');
   if ~isequal(numel(optoidx), size(sens.optopos,1))
     fprintf('removing duplicate optodes\n')
     sens.optopos = sens.optopos(optoidx,:);
@@ -218,7 +214,7 @@ if hasoptopos
   if isfield(sens, 'tra')
     % shape duplicates into a single column, if necessary
     for idx = 1:numel(optoidx)
-      tmp(:, idx) = sum(sens.tra(chanidx, find(optoord(idx)==optoidx2)),2);
+      tmp(:, idx) = sum(sens.tra(chanidx, find(idx==optoidx2)),2); % find and take sum over duplicates
     end
     sens.tra = tmp;
     % check for expected size and non-empty rows or columns
@@ -232,8 +228,7 @@ end
 
 if hascoilpos
   sens.coilpos = cat(1,coilpos{:});
-  [~, coilidx, coilidx2] = unique(sens.coilpos, 'rows');
-  [coilidx, coilord] = sort(coilidx); % sort and keep track of the order
+  [~, coilidx, coilidx2] = unique(sens.coilpos, 'rows', 'stable');
   if ~isequal(numel(coilidx), size(sens.coilpos,1))
     fprintf('removing duplicate coils\n')
     sens.coilpos = sens.coilpos(coilidx,:);
@@ -241,7 +236,7 @@ if hascoilpos
   if isfield(sens, 'tra')
     % shape duplicates into a single column, if necessary
     for idx = 1:numel(coilidx)
-      tmp(:, idx) = sum(sens.tra(chanidx, find(coilord(idx)==coilidx2)),2);
+      tmp(:, idx) = sum(sens.tra(chanidx, find(idx==coilidx2)),2); % find and take sum over duplicates
     end
     sens.tra = tmp;
     % check for expected size and non-empty rows or columns

--- a/test/test_ft_appendsens.m
+++ b/test/test_ft_appendsens.m
@@ -1,0 +1,75 @@
+function test_ft_appendsens
+
+% MEM 1500mb
+% WALLTIME 00:10:00
+
+
+% regular
+elec1.elecpos = [1 1 1; 2 2 2; 3 3 3];
+elec1.chanpos = elec1.elecpos;
+elec1.label = {'1';'2';'3'};
+elec1.unit  = 'mm';
+elec1.coordsys  = 'acpc';
+
+elec2.elecpos = [4 4 4; 5 5 5];
+elec2.chanpos = elec2.elecpos;
+elec2.label = {'4';'5'};
+elec2.unit  = 'mm';
+elec2.coordsys  = 'acpc';
+
+elec = ft_appendsens([], elec1, elec2);
+
+% duplicate chanpos, elecpos, and channel
+elec1.elecpos = [1 1 1; 2 2 2; 3 3 3];
+elec1.chanpos = elec1.elecpos;
+elec1.label = {'1';'2';'3'};
+elec1.unit  = 'mm';
+elec1.coordsys  = 'acpc';
+elec1.tra  = [1 0 0; 0 1 0; 0 0 1];
+elec2.elecpos = [2 2 2; 0 0 0]; % 2 2 2 is a duplicate
+elec2.chanpos = elec2.elecpos;
+elec2.label = {'2';'7'}; % 2 is a duplicate
+elec2.unit  = 'mm';
+elec2.coordsys  = 'acpc';
+elec2.tra  = [1 0; 0 1];
+elec = ft_appendsens([], elec1, elec2);
+
+% duplicate elecpos (eg same elec used for two bipolar derivations)
+elec1.elecpos = [1 1 1; 2 2 2];
+elec1.chanpos = [1.5 1.5 1.5];
+elec1.label = {'1-2'};
+elec1.unit  = 'mm';
+elec1.coordsys  = 'acpc';
+elec1.tra  = [1 -1];
+elec2.elecpos = [2 2 2; 3 3 3]; % 2 2 2 is a duplicate
+elec2.chanpos = [2.5 2.5 2.5];
+elec2.label = {'2-3'}; % 2 is a duplicate
+elec2.unit  = 'mm';
+elec2.coordsys  = 'acpc';
+elec2.tra  = [1 -1];
+
+elec = ft_appendsens([], elec1, elec2);
+
+% duplicate chanpos and elecpos, but no duplicate label (eg two electrodes
+% localized to the same location)
+elec1.elecpos = [1 1 1; 2 2 2; 3 3 3];
+elec1.chanpos = elec1.elecpos;
+elec1.label = {'1';'2';'3'};
+elec1.unit  = 'mm';
+elec1.coordsys  = 'acpc';
+elec1.tra  = [1 0 0; 0 1 0; 0 0 1];
+elec2.elecpos = [2 2 2; 0 0 0]; % 2 2 2 is a duplicate
+elec2.chanpos = elec2.elecpos;
+elec2.label = {'8';'7'}; % no duplicate label
+elec2.unit  = 'mm';
+elec2.coordsys  = 'acpc';
+elec2.tra  = [1 0; 0 1];
+
+try
+  elec = ft_appendsens([], elec1, elec2);
+  % this SHOULD throw an error because two labels for the same chanpos are not allowed
+  error('an error was expected but not thrown')
+catch
+  fprintf('ft_appendsens threw an error as expected\n')
+end
+


### PR DESCRIPTION
Matlab's unique operation automatically sorts the output. However, it does this on the basis of lowest value in the case of digits, and alphabetically in the case of strings. 

ft_appendsens uses the unique operation to find duplicate channels. When those are found, the unique outputs, i.e. channel labels and positions, are at risk of being misordered relative to each other because the chance of them being alphabetically and numerically in agreement is obviously slim.

This fix adds the 'stable' option when calling the unique operation, enforcing the unsorted return of the unique labels and channelpos.