### PR TITLE
enables plotting electrodes using multiple colors

### DIFF
--- a/plotting/ft_plot_sens.m
+++ b/plotting/ft_plot_sens.m
@@ -335,7 +335,7 @@ switch sensshape
       end
     else
       % the style is not specified, use facecolor for the marker
-      hs = plot3(pos(:,1), pos(:,2), pos(:,3), 'Marker', marker, 'MarkerSize', sensize, 'Color', facecolor, 'Linestyle', 'none');
+      hs = scatter3(pos(:,1), pos(:,2), pos(:,3), sensize.^2, facecolor, marker);
     end
     
   case 'circle'


### PR DESCRIPTION
Hi there,

Here's a simple fix to enable plotting electrodes using multiple colors.

I wanted to plot electrodes on a pial surface, using a color code to represent a specific metric. To do this, I originally coded a loop over all electrodes to specify their color individually. Indeed, providing a Nx3 matrix to ft_plot_sens didn't work (N being the number of electrodes), as plot3 only takes a 1x3 array as facecolor.
Replacing plot3 by scatter3 did the trick, and besides simplifying the code a lot (only one call to ft_plot_sens, instead of N), time to generate the full figure is drastically reduced.

Best,
Ludovic