### PR TITLE
enh: improved testing of tra matrix consistency

### DIFF
--- a/ft_appendsens.m
+++ b/ft_appendsens.m
@@ -195,9 +195,9 @@ if haselecpos
       tmp(:, idx) = sum(sens.tra(chanidx, find(idx==elecidx2)),2); % find and take sum over duplicates
     end
     sens.tra = tmp;
-    % check for expected size and non-empty rows or columns
+    % check for expected size and non-empty rows
     if ~isequal(size(sens.tra,1), size(sens.chanpos,1)) || ~isequal(size(sens.tra,2), size(sens.elecpos,1)) ...
-        || any(any(sens.tra,1)==0) || any(any(sens.tra,2)==0)
+        || any(any(sens.tra,2)==0) % all channels need to be linked to their origins
       fprintf('removing inconsistent tra matrix\n')
       sens = rmfield(sens, 'tra');
     end
@@ -217,9 +217,9 @@ if hasoptopos
       tmp(:, idx) = sum(sens.tra(chanidx, find(idx==optoidx2)),2); % find and take sum over duplicates
     end
     sens.tra = tmp;
-    % check for expected size and non-empty rows or columns
+    % check for expected size and non-empty rows
     if ~isequal(size(sens.tra,1), size(sens.chanpos,1)) || ~isequal(size(sens.tra,2), size(sens.optopos,1)) ...
-        || any(any(sens.tra,1)==0) || any(any(sens.tra,2)==0)
+        || any(any(sens.tra,2)==0) % all channels need to be linked to their origins
       fprintf('removing inconsistent tra matrix\n')
       sens = rmfield(sens, 'tra');
     end
@@ -239,9 +239,9 @@ if hascoilpos
       tmp(:, idx) = sum(sens.tra(chanidx, find(idx==coilidx2)),2); % find and take sum over duplicates
     end
     sens.tra = tmp;
-    % check for expected size and non-empty rows or columns
+    % check for expected size and non-empty rows
     if ~isequal(size(sens.tra,1), size(sens.chanpos,1)) || ~isequal(size(sens.tra,2), size(sens.coilpos,1)) ...
-        || any(any(sens.tra,1)==0) || any(any(sens.tra,2)==0)
+        || any(any(sens.tra,2)==0) % all channels need to be linked to their origins
       fprintf('removing inconsistent tra matrix\n')
       sens = rmfield(sens, 'tra');
     end


### PR DESCRIPTION
ft_append would discard the tra matrix when an electrode could not be linked to a channel. For instance, if there are 80 (bipolar) channels originating from say 100 electrodes, out of a 101 unique recording electrodes, then the tra matrix would be 80 x 101 with one empty column. The empty column was a reason for ft_appendsens to remove the tra matrix from the output. The current implementation makes this test less stringent by allowing 80 x 101, provided that there are 101 electrodes in the elecpos field of course. That way each channel can still be traced back to its original electrode (using the tra matrix).