### PR TITLE
make the order for the forward computation configurable

### DIFF
--- a/forward/ft_headmodel_concentricspheres.m
+++ b/forward/ft_headmodel_concentricspheres.m
@@ -22,10 +22,11 @@ function headmodel = ft_headmodel_concentricspheres(mesh, varargin)
 % include
 %   conductivity = vector with the conductivity of each compartment
 %   fitind       = vector with indices of the surfaces to use in fitting the center of the spheres
+%   order        = number of iterations in series expansion (default = 60);
 %
 % See also FT_PREPARE_VOL_SENS, FT_COMPUTE_LEADFIELD
 
-% Copyright (C) 2012-2013, Donders Centre for Cognitive Neuroimaging, Nijmegen, NL
+% Copyright (C) 2012-2018, Donders Centre for Cognitive Neuroimaging, Nijmegen, NL
 %
 % This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
 % for the documentation and details.
@@ -48,6 +49,7 @@ function headmodel = ft_headmodel_concentricspheres(mesh, varargin)
 % get the optional input arguments
 conductivity = ft_getopt(varargin, 'conductivity'); % default is determined below
 fitind       = ft_getopt(varargin, 'fitind', 'all');
+order        = ft_getopt(varargin, 'order', 60);
 
 if any(strcmp(varargin(1:2:end), 'unit')) || any(strcmp(varargin(1:2:end), 'units'))
   % the geometrical units should be specified in the input mesh
@@ -58,7 +60,7 @@ if isnumeric(mesh) && size(mesh,2)==3
   % assume that it is a Nx3 array with vertices
   % convert it to a structure, this is needed to determine the units further down
   mesh = struct('pos', mesh);
-elseif isstruct(mesh) && isfield(mesh,'bnd')
+elseif isstruct(mesh) && isfield(mesh, 'bnd')
   % take the triangulated surfaces from the input structure
   mesh = mesh.bnd;
 end
@@ -129,5 +131,26 @@ else
 end
 
 for i=1:numel(mesh)
-  fprintf('concentric sphere %d: radius = %.1f, conductivity = %f\n', i, headmodel.r(i), headmodel.cond(i));
+  fprintf('concentric sphere %d: radius = %f, conductivity = %f\n', i, headmodel.r(i), headmodel.cond(i));
 end
+
+% replicate the spheres if there are fewer than four
+switch numel(mesh)
+  case 1
+    headmodel.r    = [headmodel.r(1)    headmodel.r(1)    headmodel.r(1)    headmodel.r(1)];
+    headmodel.cond = [headmodel.cond(1) headmodel.cond(1) headmodel.cond(1) headmodel.cond(1)];
+  case 2
+    headmodel.r    = [headmodel.r(1)    headmodel.r(2)    headmodel.r(2)    headmodel.r(2)];
+    headmodel.cond = [headmodel.cond(1) headmodel.cond(2) headmodel.cond(2) headmodel.cond(2)];
+  case 3
+    headmodel.r    = [headmodel.r(1)    headmodel.r(2)    headmodel.r(3)    headmodel.r(3)];
+    headmodel.cond = [headmodel.cond(1) headmodel.cond(2) headmodel.cond(3) headmodel.cond(3)];
+  case 4
+    headmodel.r    = [headmodel.r(1)    headmodel.r(2)    headmodel.r(3)    headmodel.r(4)];
+    headmodel.cond = [headmodel.cond(1) headmodel.cond(2) headmodel.cond(3) headmodel.cond(4)];
+  otherwise
+    error('not more than 4 spheres are supported');
+end
+
+% precompute the parameters for the series expansion
+headmodel.t = eeg_leadfield4_prepare(headmodel, order);

--- a/forward/ft_headmodel_concentricspheres.m
+++ b/forward/ft_headmodel_concentricspheres.m
@@ -18,11 +18,10 @@ function headmodel = ft_headmodel_concentricspheres(mesh, varargin)
 % Use as
 %   headmodel = ft_headmodel_concentricspheres(mesh, ...)
 %
-% Optional input arguments should be specified in key-value pairs and can
-% include
+% Optional input arguments should be specified in key-value pairs and can include
 %   conductivity = vector with the conductivity of each compartment
 %   fitind       = vector with indices of the surfaces to use in fitting the center of the spheres
-%   order        = number of iterations in series expansion (default = 60);
+%   order        = number of iterations in series expansion (default = 60)
 %
 % See also FT_PREPARE_VOL_SENS, FT_COMPUTE_LEADFIELD
 

--- a/forward/ft_headmodel_singleshell.m
+++ b/forward/ft_headmodel_singleshell.m
@@ -18,9 +18,12 @@ function headmodel = ft_headmodel_singleshell(mesh, varargin)
 % Use as
 %   headmodel = ft_headmodel_singleshell(mesh, ...)
 %
+% Optional input arguments should be specified in key-value pairs and can include
+%   order        = number of iterations in series expansion (default = 10)
+%
 % See also FT_PREPARE_VOL_SENS, FT_COMPUTE_LEADFIELD
 
-% Copyright (C) 2012, Donders Centre for Cognitive Neuroimaging, Nijmegen, NL
+% Copyright (C) 2012-2018, Donders Centre for Cognitive Neuroimaging, Nijmegen, NL
 %
 % This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
 % for the documentation and details.
@@ -41,7 +44,7 @@ function headmodel = ft_headmodel_singleshell(mesh, varargin)
 % $Id$
 
 % order of spherical spherical harmonics
-order = ft_getopt(varargin, 'order');
+order = ft_getopt(varargin, 'order', 10);
 
 if isnumeric(mesh) && size(mesh,2)==3
   % assume that it is a Nx3 array with vertices

--- a/forward/ft_headmodel_singleshell.m
+++ b/forward/ft_headmodel_singleshell.m
@@ -3,18 +3,18 @@ function headmodel = ft_headmodel_singleshell(mesh, varargin)
 % FT_HEADMODEL_SINGLESHELL creates a volume conduction model of the
 % head for MEG based on a realistic shaped surface of the inside of
 % the skull.
-% 
+%
 % The method implemented in this function allows for a simple and
 % fast method for the MEG forward calculation for one shell of arbitrary
 % shape, based on a correction of the lead field for a spherical
 % volume conductor by a superposition of basis functions, gradients
 % of harmonic functions constructed from spherical harmonics.
-% 
+%
 % This function implements
 %   G. Nolte, "The magnetic lead field theorem in the quasi-static
 %   approximation and its use for magnetoencephalography forward calculation
 %   in realistic volume conductors", Phys Med Biol. 2003 Nov 21;48(22):3637-52.
-% 
+%
 % Use as
 %   headmodel = ft_headmodel_singleshell(mesh, ...)
 %
@@ -40,6 +40,9 @@ function headmodel = ft_headmodel_singleshell(mesh, varargin)
 %
 % $Id$
 
+% order of spherical spherical harmonics
+order = ft_getopt(varargin, 'order');
+
 if isnumeric(mesh) && size(mesh,2)==3
   % assume that it is a Nx3 array with vertices
   % convert it to a structure, this is needed to determine the units further down
@@ -58,8 +61,9 @@ end
 
 % represent the mesh in a headmodel strucure
 % the computational parameters will be added later on by ft_prepare_vol_sens
-headmodel      = [];
-headmodel.bnd  = mesh;
-headmodel.type = 'singleshell';
-headmodel = ft_determine_units(headmodel);
+headmodel       = [];
+headmodel.bnd   = mesh;
+headmodel.type  = 'singleshell';
+headmodel.order = order;
+headmodel       = ft_determine_units(headmodel);
 

--- a/forward/ft_headmodel_singlesphere.m
+++ b/forward/ft_headmodel_singlesphere.m
@@ -16,7 +16,7 @@ function headmodel = ft_headmodel_singlesphere(mesh, varargin)
 %
 % See also FT_PREPARE_VOL_SENS, FT_COMPUTE_LEADFIELD
 
-% FIXME document the EEG case
+% FIXME document both EEG and MEG case
 
 % Copyright (C) 2012-2013, Donders Centre for Cognitive Neuroimaging, Nijmegen, NL
 %

--- a/forward/ft_prepare_vol_sens.m
+++ b/forward/ft_prepare_vol_sens.m
@@ -17,7 +17,6 @@ function [headmodel, sens] = ft_prepare_vol_sens(headmodel, sens, varargin)
 %
 % Additional options should be specified in key-value pairs and can be
 %   'channel'    cell-array with strings (default = 'all')
-%   'order'      number, for single shell "Nolte" model (default = 10)
 %
 % The detailed behaviour of this function depends on whether the input
 % consists of EEG or MEG and furthermoree depends on the type of volume
@@ -69,7 +68,6 @@ end
 % get the optional input arguments
 % fileformat = ft_getopt(varargin, 'fileformat');
 channel = ft_getopt(varargin, 'channel', sens.label);   % cell-array with channel labels, default is all
-order   = ft_getopt(varargin, 'order', 10);             % order of expansion for Nolte method; 10 should be enough for real applications; in simulations it makes sense to go higher
 
 % ensure that the sensor description is up-to-date (Aug 2011)
 sens = ft_datatype_sens(sens);
@@ -285,7 +283,14 @@ elseif ismeg
       end
       
       % estimate center and radius
-      [center,radius] = fitsphere(headmodel.bnd.pos);
+      [center, radius] = fitsphere(headmodel.bnd.pos);
+
+      % order of spherical spherical harmonics, for 'real' realistic volume conductors order=10 is o.k
+      if isfield(headmodel, 'order')
+        order = headmodel.order;
+      else
+        order = 10;
+      end
       
       % initialize the forward calculation (only if  coils are available)
       if size(sens.coilpos,1)>0 && ~isfield(headmodel, 'forwpar')

--- a/forward/private/eeg_leadfield4_prepare.m
+++ b/forward/private/eeg_leadfield4_prepare.m
@@ -1,4 +1,4 @@
-function [lut_t, cuf_t] = eeg_leadfield4_prepare(vol, Nmax)
+function [lut_t, cuf_t] = eeg_leadfield4_prepare(vol, order)
 
 % EEG_LEADFIELD4_PREPARE computes constant factors for series expansion
 % for the 4 concentric sphere electric leadfield computation. Calling
@@ -6,7 +6,7 @@ function [lut_t, cuf_t] = eeg_leadfield4_prepare(vol, Nmax)
 % factors "t" do not have to be computed each time in eeg_leadfield4.
 %
 % Use as
-%   vol.t = eeg_leadfield4_prepare(vol, N);
+%   vol.t = eeg_leadfield4_prepare(vol, order);
 % where
 %   vol.r      radius of the 4 spheres 
 %   vol.cond   conductivity of the 4 spheres
@@ -50,8 +50,8 @@ r2 = vol.r(2); c2 = vol.cond(2);
 r3 = vol.r(3); c3 = vol.cond(3);
 r4 = vol.r(4); c4 = vol.cond(4);
 
-if nargin==1
-  Nmax = 60;
+if nargin==1 || isempty(order)
+  order = 60;
 end
 
 % these are the constants of cuffin1979
@@ -59,7 +59,7 @@ k1 = c1/c2;
 k2 = c2/c3;
 k3 = c3/c4;
 
-for n=1:Nmax
+for n=1:order
   % according to lutkenhoner1992 the constant C is
   % lut_t(n) = ((n*c1/c2+n+1)*(n*c2/c3+n+1)+n*(n+1)*(c1/c2-1)*(c2/c3-1)*(r1/r2)^(2*n+1)) * ...
   %        ((n*c3/c4+n+1)+(n+1)*(c3/c4-1)*(r3/r4)^(2*n+1)) + ...
@@ -82,7 +82,7 @@ if nargout>1
 
   % according to cuffin1979 the constant Tau is (re-entered on 25 sept 2002)
   % but this requires also slightly other constants in the eeg_leadfield4 function
-  for n=1:Nmax
+  for n=1:order
     cuf_t(n) = d^(2*n+1) * (b^(2*n+1)*n*(k1-1)*(k2-1)*(n+1)...
            + c^(2*n+1)*(k1*n+n+1)*(k2*n+n+1))...
            *((k3*n+n+1)+(n+1)*(k3-1)*d^(2*n+1))...

--- a/forward/private/meg_ini.m
+++ b/forward/private/meg_ini.m
@@ -49,22 +49,22 @@ function forwpar=meg_ini(vc,center,order,sens,refs,gradlocs,weights)
 % $Id$
 
 if nargin==4
-  if order>0;
+  if order>0
     coeff_sens=getcoeffs(sens,vc,center,order);
     forwpar=struct('device_sens',sens,'coeff_sens',coeff_sens,'center',center,'order',order);
   else
     forwpar=struct('device_sens',sens,'center',center,'order',order);
   end
 elseif nargin==5
-  if order>0;
+  if order>0
     coeff_sens=getcoeffs(sens,vc,center,order);
     coeff_refs=getcoeffs(refs,vc,center,order);
     forwpar=struct('device_sens',sens,'device_ref',refs,'coeff_sens',coeff_sens,'coeff_ref',coeff_refs,'center',center,'order',order);
   else
     forwpar=struct('device_sens',sens,'device_ref',refs,'center',center,'order',order);
   end
-elseif nargin==7;
-  if order>0;
+elseif nargin==7
+  if order>0
     coeff_sens=getcoeffs(sens,vc,center,order);
     coeff_refs=getcoeffs(refs,vc,center,order);
     coeff_weights=getcoeffs(gradlocs,vc,center,order);

--- a/ft_prepare_headmodel.m
+++ b/ft_prepare_headmodel.m
@@ -64,6 +64,7 @@ function [headmodel, cfg] = ft_prepare_headmodel(cfg, data)
 %
 % CONCENTRICSPHERES
 %   cfg.tissue            see above; in combination with 'seg' input
+%   cfg.order             (optional)
 %   cfg.fitind            (optional)
 %
 % LOCALSPHERES
@@ -79,6 +80,7 @@ function [headmodel, cfg] = ft_prepare_headmodel(cfg, data)
 %
 % SINGLESHELL
 %   cfg.tissue            see above; in combination with 'seg' input; default options are 'brain' or 'scalp'
+%   cfg.order             (optional)
 %
 % SINGLESPHERE
 %   cfg.tissue            see above; in combination with 'seg' input; default options are 'brain' or 'scalp'; must be only 1 value
@@ -117,7 +119,7 @@ function [headmodel, cfg] = ft_prepare_headmodel(cfg, data)
 
 % Copyright (C) 2011, Cristiano Micheli
 % Copyright (C) 2011-2012, Jan-Mathijs Schoffelen, Robert Oostenveld
-% Copyright (C) 2013, Robert Oostenveld, Johanna Zumer
+% Copyright (C) 2013-2018, Robert Oostenveld, Johanna Zumer
 %
 % This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
 % for the documentation and details.
@@ -177,7 +179,6 @@ cfg.threshold       = ft_getopt(cfg, 'threshold');
 % other options
 cfg.numvertices     = ft_getopt(cfg, 'numvertices', 3000);
 cfg.isolatedsource  = ft_getopt(cfg, 'isolatedsource'); % used for dipoli and openmeeg
-cfg.fitind          = ft_getopt(cfg, 'fitind');         % used for concentricspheres
 cfg.point           = ft_getopt(cfg, 'point');          % used for halfspace
 cfg.submethod       = ft_getopt(cfg, 'submethod');      % used for halfspace
 cfg.feedback        = ft_getopt(cfg, 'feedback');
@@ -283,6 +284,9 @@ switch cfg.method
     end
     
   case 'concentricspheres'
+    cfg.fitind = ft_getopt(cfg, 'fitind');
+    cfg.order  = ft_getopt(cfg, 'order');
+
     % the low-level functions needs surface points, triangles are not needed
     if input_mesh || input_pos
       geometry = data;
@@ -304,7 +308,7 @@ switch cfg.method
       ft_error('You must give a mesh, segmented MRI, sensor data type, or cfg.headshape');
     end
     
-    headmodel = ft_headmodel_concentricspheres(geometry, 'conductivity', cfg.conductivity, 'fitind', cfg.fitind);
+    headmodel = ft_headmodel_concentricspheres(geometry, 'conductivity', cfg.conductivity, 'fitind', cfg.fitind, 'order', cfg.order);
     
   case 'halfspace'
     if input_mesh || input_pos
@@ -387,6 +391,7 @@ switch cfg.method
           % construct the volume conduction model
           headmodel = ft_headmodel_singlesphere(geometry, 'conductivity', cfg.conductivity);
         end % headmodel
+        
       case 'localspheres'
         if ~isempty(cfg.headmodel)
           % read the volume conduction model from a CTF *.hdm file
@@ -408,14 +413,19 @@ switch cfg.method
           end
           headmodel = ft_headmodel_localspheres(geometry, cfg.grad, 'feedback', cfg.feedback, 'radius', cfg.radius, 'maxradius', cfg.maxradius, 'baseline', cfg.baseline, 'singlesphere', cfg.singlesphere);
         end % headmodel
+        
       case 'singleshell'
+        cfg.order  = ft_getopt(cfg, 'order');
         if ~isfield(geometry, 'tri')
           tmpcfg = [];
           tmpcfg.headshape = geometry;
           geometry = ft_prepare_mesh(tmpcfg);
         end
-        headmodel = ft_headmodel_singleshell(geometry);
-    end
+        headmodel = ft_headmodel_singleshell(geometry, 'order', cfg.order);
+        
+      otherwise
+        ft_error('unsupported method %s', cfg.method);
+    end % switch method
     
   case {'simbio'}
     if input_elec || isfield(data, 'pos') || input_mesh

--- a/private/prepare_headmodel.m
+++ b/private/prepare_headmodel.m
@@ -38,9 +38,10 @@ function [headmodel, sens, cfg] = prepare_headmodel(cfg, data)
 %
 % $Id$
 
+cfg = ft_checkconfig(cfg, 'forbidden', 'order');
+
 % set the defaults
 cfg.channel  = ft_getopt(cfg, 'channel', 'all');
-cfg.order    = ft_getopt(cfg, 'order', 10);       % order of expansion for Nolte method; 10 should be enough for real applications; in simulations it makes sense to go higher
 cfg.siunits  = ft_getopt(cfg, 'siunits', 'no');   % yes/no, ensure that SI units are used consistently
 
 hasdata = (nargin>1);
@@ -109,7 +110,7 @@ end
 % sens      = struct(sens);
 
 % the prepare_vol_sens function from the forwinv module does most of the actual work
-[headmodel, sens] = ft_prepare_vol_sens(headmodel, sens, 'channel', cfg.channel, 'order', cfg.order);
+[headmodel, sens] = ft_prepare_vol_sens(headmodel, sens, 'channel', cfg.channel);
 
 % update the selected channels in the configuration
 if iscell(sens)

--- a/test/test_bug131.m
+++ b/test/test_bug131.m
@@ -40,14 +40,14 @@ grid.outside = [];
 
 % create leadfield with single sphere
 cfg = [];
-cfg.vol = vol;
+cfg.headmodel = vol;
 cfg.grid = grid;
 cfg.grad = grad;
 grid1 = ft_prepare_leadfield(cfg);
 
 % create leadfield with singleshell
 cfg = [];
-cfg.vol = vol2;
+cfg.headmodel = vol2;
 cfg.grid = grid;
 cfg.grad = grad;
 grid2 = ft_prepare_leadfield(cfg);

--- a/test/test_bug3453.m
+++ b/test/test_bug3453.m
@@ -1,0 +1,59 @@
+function test_bug3453
+
+% WALLTIME 00:10:00
+% MEM 2gb
+
+%%
+
+% unit radius, scaling is done further down
+pos = randn(100,3);
+for i=1:100
+  pos(i,:) = pos(i,:)/norm(pos(i,:));
+end
+% brain, csf, skull, skin
+headshape = [];
+headshape.bnd(1).unit = 'm';
+headshape.bnd(2).unit = 'm';
+headshape.bnd(3).unit = 'm';
+headshape.bnd(4).unit = 'm';
+headshape.bnd(1).pos = pos*0.087;
+headshape.bnd(2).pos = pos*0.088;
+headshape.bnd(3).pos = pos*0.092;
+headshape.bnd(4).pos = pos*0.100;
+
+elec = [];
+elec.unit = 'm';
+elec.elecpos = randn(40,3);
+for i=1:40
+  elec.label{i} = num2str(i);
+  elec.elecpos(i,:) = 0.1*elec.elecpos(i,:)/norm(elec.elecpos(i,:));
+end
+elec.chanpos = elec.elecpos;
+elec.tra = eye(40);
+
+%%
+
+cfg = [];
+cfg.method = 'concentricspheres';
+cfg.headshape = headshape;
+cfg.conductivity = [0.3300 1 0.0042 0.3300]; % brain, csf, skull, skin
+vol1 = ft_prepare_headmodel(cfg);
+
+cfg.order = 60;
+vol2 = ft_prepare_headmodel(cfg); % should be same as default
+
+cfg.order = 5;
+vol3 = ft_prepare_headmodel(cfg); % very inaccurate
+
+%%
+
+dippos = [0 0 0.08];
+
+lf1 = ft_compute_leadfield(dippos, elec, vol1);
+lf2 = ft_compute_leadfield(dippos, elec, vol2);
+lf3 = ft_compute_leadfield(dippos, elec, vol3); % should be inaccurate
+
+assert( isequal(lf1, lf2));
+assert(~isequal(lf1, lf3));
+
+

--- a/test/test_bug3453.m
+++ b/test/test_bug3453.m
@@ -31,6 +31,8 @@ end
 elec.chanpos = elec.elecpos;
 elec.tra = eye(40);
 
+dippos = [0 0 0.08];
+
 %%
 
 cfg = [];
@@ -45,15 +47,25 @@ vol2 = ft_prepare_headmodel(cfg); % should be same as default
 cfg.order = 5;
 vol3 = ft_prepare_headmodel(cfg); % very inaccurate
 
-%%
+%% using high-level code
 
-dippos = [0 0 0.08];
+cfg = [];
+cfg.grid.pos = dippos;
+cfg.grid.unit = 'm';
+cfg.elec = elec;
+cfg.headmodel = vol1;
+lf1 = ft_prepare_leadfield(cfg);
+cfg.headmodel = vol2;
+lf2 = ft_prepare_leadfield(cfg);
+cfg.headmodel = vol3;
+lf3 = ft_prepare_leadfield(cfg);
 
+%% slightly lower level code
+
+% note that I am skipping ft_prepare_vol_sens, which would not make a difference here
 lf1 = ft_compute_leadfield(dippos, elec, vol1);
 lf2 = ft_compute_leadfield(dippos, elec, vol2);
 lf3 = ft_compute_leadfield(dippos, elec, vol3); % should be inaccurate
 
 assert( isequal(lf1, lf2));
 assert(~isequal(lf1, lf3));
-
-


### PR DESCRIPTION
Both for concentricspheres and for single shell there is an "order" that determines the accuracy. This PR makes it configurable in ft_prepare_leadfield. 

See also http://bugzilla.fieldtriptoolbox.org/show_bug.cgi?id=3453