### PR TITLE
FIX #813 - improve the detection and feedback of incorrect SPM8 mex files on macOS

### DIFF
--- a/forward/ft_headmodel_localspheres.m
+++ b/forward/ft_headmodel_localspheres.m
@@ -67,7 +67,7 @@ end
 % replace pnt with pos
 mesh = fixpos(mesh);
 
-if ~isstruct(mesh) || ~isfield(mesh, 'pos')
+if ~isstruct(mesh) || numel(mesh)>1 || ~isfield(mesh, 'pos')
   ft_error('the input mesh should be a set of points or a single triangulated surface')
 end
 

--- a/forward/ft_headmodel_singleshell.m
+++ b/forward/ft_headmodel_singleshell.m
@@ -58,7 +58,7 @@ end
 % replace pnt with pos
 mesh = fixpos(mesh);
 
-if ~isstruct(mesh) || ~isfield(mesh, 'pos')
+if ~isstruct(mesh) || numel(mesh)>1 || ~isfield(mesh, 'pos')
   ft_error('the input mesh should be a set of points or a single triangulated surface')
 end
 

--- a/forward/ft_headmodel_singlesphere.m
+++ b/forward/ft_headmodel_singlesphere.m
@@ -58,7 +58,7 @@ end
 % replace pnt with pos
 mesh = fixpos(mesh);
 
-if ~isstruct(mesh) || ~isfield(mesh, 'pos')
+if ~isstruct(mesh) || numel(mesh)>1 || ~isfield(mesh, 'pos')
   ft_error('the input mesh should be a set of points or a single triangulated surface')
 end
 

--- a/ft_defaults.m
+++ b/ft_defaults.m
@@ -7,7 +7,7 @@ function ft_defaults
 %
 % The global configuration defaults are stored in the global "ft_default" structure.
 % The ft_checkconfig function that is called by many FieldTrip functions will merge
-% these global configuration defaults with the cfg ctructure that you pass to 
+% these global configuration defaults with the cfg ctructure that you pass to
 % the FieldTrip function that you are calling.
 %
 % The global options and their default values are
@@ -26,7 +26,7 @@ function ft_defaults
 %   ft_default.toolbox.images    = string, can be 'compat' or 'matlab' (default = 'compat')
 %
 % If you want to overrule these default settings, you can add something like this in your startup.m script
-%   ft_defaults 
+%   ft_defaults
 %   global ft_default
 %   ft_default.option1 = value1
 %   ft_default.option2 = value2
@@ -328,6 +328,7 @@ ft_trackusage('startup');
 initialized = true;
 
 end % function ft_default
+
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % SUBFUNCTION

--- a/ft_prepare_headmodel.m
+++ b/ft_prepare_headmodel.m
@@ -286,7 +286,7 @@ switch cfg.method
   case 'concentricspheres'
     cfg.fitind = ft_getopt(cfg, 'fitind');
     cfg.order  = ft_getopt(cfg, 'order');
-
+    
     % the low-level functions needs surface points, triangles are not needed
     if input_mesh || input_pos
       geometry = data;
@@ -329,7 +329,7 @@ switch cfg.method
   case {'localspheres' 'singlesphere' 'singleshell'}
     cfg.grad = ft_getopt(cfg, 'grad');           % used for localspheres
     
-    % these three methods all require a set of surface points
+    % these three methods all require a single set of surface points
     if input_mesh || input_pos
       geometry = data;
     elseif input_seg
@@ -346,12 +346,24 @@ switch cfg.method
           try
             tmpcfg.tissue = 'brain';
             geometry = ft_prepare_mesh(tmpcfg, data);
+          catch
+            me = lasterror;
+            if isequal(me.identifier, 'MATLAB:mex:ErrInvalidMEXFile')
+              % SPM8 mex file issues are common on macOS, these should not remain invisible
+              rethrow(me);
+            end
           end
         end
         if isempty(geometry)
           try
             tmpcfg.tissue = 'scalp';
             geometry = ft_prepare_mesh(tmpcfg, data);
+          catch
+            me = lasterror;
+            if isequal(me.identifier, 'MATLAB:mex:ErrInvalidMEXFile')
+              % SPM8 mex file issues are common on macOS, these should not remain invisible
+              rethrow(me);
+            end
           end
         end
         if isempty(geometry)


### PR DESCRIPTION
There is now a check in ft_hastoolbox. Furthermore ft_prepare_headmodel will show problems with mex files, and ft_headmodel_singleshell, singlesphere and localspheres are now all checking that they receive a single surface.  