### PR TITLE
fix: prepare_mesh_cortexhull now sources freesurfer while executing freesurfer commands

### DIFF
--- a/private/prepare_mesh_cortexhull.m
+++ b/private/prepare_mesh_cortexhull.m
@@ -64,12 +64,12 @@ surf_smooth  = [tempname() '_pial_smooth'];
 
 cmd = sprintf('mris_fill -c -r %d %s %s', resolution, headshape, ...
   surf_filled);
-system(cmd);
+system(['source $FREESURFER_HOME/SetUpFreeSurfer.sh; ' cmd]);
 
 make_outer_surface(surf_filled, outer_surface_sphere, surf_outer)
 
 cmd = sprintf('mris_smooth -nw -n %d %s %s', smooth_steps, surf_outer, ...
   surf_smooth);
-system(cmd);
+system(['source $FREESURFER_HOME/SetUpFreeSurfer.sh; ' cmd]);
 
 headshape = ft_read_headshape(surf_smooth);


### PR DESCRIPTION
This issue was raised by Toshiki Okadome on the fieldtrip mailing list. Prepare_mesh_cortexhull would fail with his version 6.0.0 of freesurfer, issuing errors related to faulty library references*. Sourcing freesurfer before executing freesurfer commands fixes the issue for him, and prepare_mesh_cortexhull remains running fine on my personal older copy (v5.3.0).




*[ERROR]

dyld: lazy symbol binding failed: Symbol not found: ___emutls_get_address
  Referenced from: /Applications/freesurfer/bin/../lib/gcc/lib/libgomp.1.dylib
  Expected in: /usr/lib/libSystem.B.dylib

dyld: Symbol not found: ___emutls_get_address
  Referenced from: /Applications/freesurfer/bin/../lib/gcc/lib/libgomp.1.dylib
  Expected in: /usr/lib/libSystem.B.dylib

mris_fill -c -r 1 /Users/okadometoshiki/Desktop/SubjectUCI29/freesurfer/surf/lh.pial /private/var/folders/cc/fv5fk09d3hj5g5kx7dg7pqq80000gn/T/tp0a8d7856_136c_4156_bf73_d23f64bbf687_pial.filled.mgz: Aborted
reading filled volume...
gunzip: can't stat: /private/var/folders/cc/fv5fk09d3hj5g5kx7dg7pqq80000gn/T/tp0a8d7856_136c_4156_bf73_d23f64bbf687_pial.filled.mgz (/private/var/folders/cc/fv5fk09d3hj5g5kx7dg7pqq80000gn/T/tp0a8d7856_136c_4156_bf73_d23f64bbf687_pial.filled.mgz.gz): No such file or directory
ERROR: problem reading fname 
