### PR TITLE
FIX - the default in ft_fetch_data iwith regard to allowing overlap was

### DIFF
--- a/utilities/ft_fetch_data.m
+++ b/utilities/ft_fetch_data.m
@@ -43,7 +43,7 @@ if true
   addOptional(p, 'begsample', []);
   addOptional(p, 'endsample', []);
   addOptional(p, 'chanindx', []);
-  addOptional(p, 'allowoverlap', []);
+  addOptional(p, 'allowoverlap', false);
   parse(p,varargin{:});
   hdr           = p.Results.header;
   begsample     = p.Results.begsample;


### PR DESCRIPTION
not set correctly, causing a regression error in test_bug2269

This was already broken for some time, probably 2 weeks or so.