### PR TITLE
fix: this fixes a too many open files error

### DIFF
--- a/fileio/private/read_brainstorm_data.m
+++ b/fileio/private/read_brainstorm_data.m
@@ -59,8 +59,10 @@ num = [];
 dat = [];
 for e = 1:hdr.nTrials
   for c = 1:numel(chanrange)
-    tmp = in_fread_nk(sFile, fopen(filename), e, [begsample-1 endsample-1], chanrange{c}); % NK1200 samples starts at 0
+    sfid = fopen(filename);
+    tmp = in_fread_nk(sFile, sfid, e, [begsample-1 endsample-1], chanrange{c}); % NK1200 samples starts at 0
     num = [num; tmp]; clear tmp % stack channels
+    fclose(sfid);
   end
   dat = [dat num]; clear num % append epochs/trials
 end


### PR DESCRIPTION
Which would make matlab crash. With the below fix, each opened file is closed after use.