### PR TITLE
FIX - fix to apply rotation only to the coil orientations

### DIFF
--- a/fileio/private/mne2grad.m
+++ b/fileio/private/mne2grad.m
@@ -133,7 +133,7 @@ if ~isempty(coilaccuracy)
     R = H;
     T(1:3,1:3) = 0; % remove the rotation, keep the translation
     R(1:3,4)   = 0; % remove the translation, keep the rotation
-    ori = ft_warp_apply(H, ori);
+    ori = ft_warp_apply(R, ori);
     for j=1:thisdef.num_points
       grad.coilpos(k,:) = pos(j,:);
       grad.coilori(k,:) = ori(j,:);


### PR DESCRIPTION
This was reported already a long time ago, and I think the reporter is right (see bugzilla bug 3263)
@robertoostenveld can you quickly review this and merge if agreed?