### PR TITLE
Remove tilde when used to ignore function outputs

### DIFF
--- a/connectivity/ft_connectivity_csd2transfer.m
+++ b/connectivity/ft_connectivity_csd2transfer.m
@@ -121,11 +121,11 @@ elseif strcmp(sfmethod, 'trivariate')
   end
   
   % create an Ntriplet x 3 index matrix, to be used below
-  [~,i2] = match_str(channeltriplet(:,1),freq.label);
+  [dum,i2] = match_str(channeltriplet(:,1),freq.label);
   cmbindx(:,1) = i2;
-  [~,i2] = match_str(channeltriplet(:,2),freq.label);
+  [dum,i2] = match_str(channeltriplet(:,2),freq.label);
   cmbindx(:,2) = i2;
-  [~,i2] = match_str(channeltriplet(:,3),freq.label);
+  [dum,i2] = match_str(channeltriplet(:,3),freq.label);
   cmbindx(:,3) = i2;
   
 elseif strcmp(sfmethod, 'bivariate_conditional')
@@ -159,7 +159,7 @@ elseif strcmp(sfmethod, 'bivariate_conditional')
   ok      = true(size(tmp,1),1);
   tmpindx = zeros(size(tmp));
   for k = 1:size(tmpindx,1)
-    [~, tmpindx(k,:)] = match_str(tmp(k,:)', utmp);
+    [dum, tmpindx(k,:)] = match_str(tmp(k,:)', utmp);
     tmptmpindx = tmpindx(k,:);
     tmptmpindx = tmptmpindx([1 2 3;1 3 2;2 1 3;2 3 1;3 1 2;3 2 1]);
     if ~isempty(intersect(tmpindx(1:(k-1),:), tmptmpindx, 'rows'))
@@ -433,7 +433,7 @@ elseif strcmp(sfmethod, 'bivariate')
     cmbindx     = zeros(size(channelcmb));
     ok          = true(size(cmbindx,1), 1);
     for k = 1:size(cmbindx,1)
-      [~, cmbindx(k,:)] = match_str(channelcmb(k,:)', freq.label);
+      [dum, cmbindx(k,:)] = match_str(channelcmb(k,:)', freq.label);
       if ~isempty(intersect(cmbindx(1:(k-1),:), cmbindx(k,:), 'rows'))
         ok(k) = false;
       elseif cmbindx(k,1)==cmbindx(k,2)
@@ -533,7 +533,7 @@ elseif strcmp(sfmethod, 'bivariate_conditional')
   ok      = true(size(tmp,1),1);
   tmpindx = zeros(size(tmp));
   for k = 1:size(tmpindx,1)
-    [~, tmpindx(k,:)] = match_str(tmp(k,:)', utmp);
+    [dum, tmpindx(k,:)] = match_str(tmp(k,:)', utmp);
     if ~isempty(intersect(tmpindx(1:(k-1),:), [tmpindx(k,:);tmpindx(k,[2 1])], 'rows'))
       ok(k) = false;
     elseif tmpindx(k,1)==tmpindx(k,2)

--- a/external/fns/fns_leadfield.m
+++ b/external/fns/fns_leadfield.m
@@ -28,7 +28,7 @@ ROW = modelSizes(1) + 1;
 COL = modelSizes(2) + 1;
 
 [M, N] = size(forwardSolutions);
-[numberOfDipoles, ~] = size(dipoles); 
+[numberOfDipoles, dum] = size(dipoles);
 
 % Allocate memory for lead field matrix
 L = zeros(M, numberOfDipoles * 3);

--- a/fileio/ft_read_data.m
+++ b/fileio/ft_read_data.m
@@ -442,7 +442,7 @@ switch dataformat
     ft_hastoolbox('NPMK', 1);
     % ensure that the filename contains a full path specification,
     % otherwise the low-level function fails
-    [p,~,~] = fileparts(filename);
+    p = fileparts(filename);
     if isempty(p)
       filename = which(filename);
     end

--- a/fileio/ft_read_header.m
+++ b/fileio/ft_read_header.m
@@ -441,10 +441,10 @@ switch headerformat
     ft_hastoolbox('NPMK', 1);
     % ensure that the filename contains a full path specification,
     % otherwise the low-level function fails
-    [p,n,~] = fileparts(filename);
+    [p,n] = fileparts(filename);
     if isempty(p)
       filename = which(filename);
-      [p,n,~] = fileparts(filename);
+      [p,n] = fileparts(filename);
     end
     
     NEV = openNEV(filename,'noread','nosave');
@@ -472,7 +472,7 @@ switch headerformat
     ft_hastoolbox('NPMK', 1);
     % ensure that the filename contains a full path specification,
     % otherwise the low-level function fails
-    [p, ~, ~] = fileparts(filename);
+    p = fileparts(filename);
     if isempty(p)
       filename = which(filename);
     end

--- a/fileio/private/read_besa_besa.m
+++ b/fileio/private/read_besa_besa.m
@@ -246,7 +246,7 @@ if(fseek(fid,double(bdat_offset),'bof') == -1) % double() because Windows can't 
 end
 
 % Read BDAT tag and offset
-[~,ofst_BDAT] = read_tag_offset_pair(fid,'BDAT');
+[dum,ofst_BDAT] = read_tag_offset_pair(fid,'BDAT');
 
 % Check that file is not shorter than expected
 if(file_length < (ftell(fid)+ofst_BDAT))
@@ -274,7 +274,7 @@ read_tag_offset_pair(fid,'DATS');
 n_samples = fread(fid,1,'*uint32');
 
 % Read DATA tag and offset
-[~,data_block_length] = read_tag_offset_pair(fid,'DATA');
+[dum,data_block_length] = read_tag_offset_pair(fid,'DATA');
 data_block_offset = double(ftell(fid));
 
 % Read data
@@ -858,7 +858,7 @@ file_length = ftell(fid);
 fseek(fid,0,'bof');
 
 %% Header Block
-[~,ofst_BCF1] = read_tag_offset_pair(fid,'BCF1');
+[dum,ofst_BCF1] = read_tag_offset_pair(fid,'BCF1');
 
 % Read data in header block
 while ~feof(fid) && ftell(fid) < (8+ofst_BCF1) % 8 for header tag ('BCF1') and header offset (uint32)
@@ -1061,7 +1061,7 @@ end
 tags.offsets(end+1) = tags.next_BTAG_ofst;
 
 % Read BTAG tag and offset
-[~,tag_block_length] = read_tag_offset_pair(fid,'BTAG');
+[dum,tag_block_length] = read_tag_offset_pair(fid,'BTAG');
 
 % Untagged offset to next BTAG section
 tags.next_BTAG_ofst = fread(fid,1,'*int64');
@@ -1115,7 +1115,7 @@ end
 file_info.offsets(end+1) = file_info.next_BFMI_ofst;
 
 % Read BFMI tag and offset
-[~,fileinfo_block_length] = read_tag_offset_pair(fid,'BFMI');
+[dum,fileinfo_block_length] = read_tag_offset_pair(fid,'BFMI');
 
 % Untagged offset to next BFMI section
 file_info.next_BFMI_ofst = fread(fid,1,'*int64');
@@ -1382,7 +1382,7 @@ end
 channel_info.offsets(end+1) = channel_info.next_BCAL_ofst;
 
 % Read BCAL tag and offset
-[~,channel_block_length] = read_tag_offset_pair(fid,'BCAL');
+[dum,channel_block_length] = read_tag_offset_pair(fid,'BCAL');
 
 % Untagged offset to next BCAL section
 channel_info.next_BCAL_ofst = fread(fid,1,'*int64');
@@ -1596,14 +1596,14 @@ if(fseek(fid,BEVT_offset,'bof') == -1)
 end
 
 % Read BEVT tag and offset
-[~,event_block_length] = read_tag_offset_pair(fid,'BEVT');
+[dum,event_block_length] = read_tag_offset_pair(fid,'BEVT');
 
 % Read LIST tag and offset but don't save anything
 read_tag_offset_pair(fid,'LIST');
 
 % Now inside of LIST block
 % Read HEAD tag - Assuming that it is first tag in LIST block
-[~,head_length] = read_tag_offset_pair(fid,'HEAD');
+[dum,head_length] = read_tag_offset_pair(fid,'HEAD');
 head_offset = ftell(fid);
 % Read data in header block
 while ~feof(fid) && ftell(fid) < (head_offset+head_length)

--- a/forward/ft_average_sens.m
+++ b/forward/ft_average_sens.m
@@ -82,9 +82,9 @@ x1 = pos*u(:, 2);
 x2 = pos*u(:, 1);
 
 % detemine the indices of three reference sensors that are close to the three principal axes
-[~, ind1] = min(x1);
-[~, ind2] = max(x1);
-[~, ind3] = max(abs(x2 - mean(x2([ind1 ind2]))));
+[dum, ind1] = min(x1);
+[dum, ind2] = max(x1);
+[dum, ind3] = max(abs(x2 - mean(x2([ind1 ind2]))));
 
 % compute the mean of the three reference sensors for the principal axes
 mean1 = [0 0 0];
@@ -215,7 +215,7 @@ switch nfid
             c = 100;
     end
     
-    [~, ind] = unique(round(c*afiducials.pos/tolerance), 'rows');
+    [dum, ind] = unique(round(c*afiducials.pos/tolerance), 'rows');
     
     afiducials.pos = afiducials.pos(ind, :);
     

--- a/forward/ft_headmodel_openmeeg.m
+++ b/forward/ft_headmodel_openmeeg.m
@@ -160,8 +160,8 @@ try
     
     % write conductivity and mesh files
     bndlabel = {};
-    for i=1:length(bnd);
-        [~,bndlabel{i}] = fileparts(bndfile{i});
+    for i=1:length(bnd)
+        [dum,bndlabel{i}] = fileparts(bndfile{i});
     end
 
     om_write_geom(geomfile,bndfile,bndlabel);

--- a/forward/ft_sensinterp_openmeeg.m
+++ b/forward/ft_sensinterp_openmeeg.m
@@ -73,8 +73,8 @@ try
     
     % write conductivity and mesh files
     bndlabel = {};
-    for i=1:length(bndom);
-        [~,bndlabel{i}] = fileparts(bndfile{i});
+    for i=1:length(bndom)
+        [dum,bndlabel{i}] = fileparts(bndfile{i});
     end
     
     om_write_geom(geomfile,bndfile,bndlabel);

--- a/forward/ft_sysmat_openmeeg.m
+++ b/forward/ft_sysmat_openmeeg.m
@@ -67,8 +67,8 @@ try
     
     % write conductivity and mesh files
     bndlabel = {};
-    for i=1:length(bndom);
-        [~,bndlabel{i}] = fileparts(bndfile{i});
+    for i=1:length(bndom)
+        [dum,bndlabel{i}] = fileparts(bndfile{i});
     end
     
     om_write_geom(geomfile,bndfile,bndlabel);

--- a/forward/private/leadsphere_all.m
+++ b/forward/private/leadsphere_all.m
@@ -56,8 +56,8 @@ function out=leadsphere_all(xloc,sensorloc,sensorori)
 % Here begins JMS' adjustment to Guido's implementation, which is much more
 % memory friendly with large numbers of dipoles. Essentially, it does not
 % work with massively repmatted sensorloc and xloc matrices
-[~,nsens] = size(sensorloc); %n=3 m=? 
-[~, ndip] = size(xloc);
+[dum,nsens] = size(sensorloc); %n=3 m=?
+[dum, ndip] = size(xloc);
 
 r2   = repmat(sqrt(sum(sensorloc.^2)), ndip, 1);
 veca = reshape(repmat(sensorloc,ndip,1),3,ndip,nsens)-reshape(repmat(xloc,1,nsens),3,ndip,nsens);

--- a/ft_appendsens.m
+++ b/ft_appendsens.m
@@ -148,14 +148,14 @@ end
 
 % concatenate the main fields and remove duplicates
 sens.label = cat(1,label{:});
-[~, labidx] = unique(sens.label, 'stable');
+[dum, labidx] = unique(sens.label, 'stable');
 if ~isequal(numel(labidx), numel(sens.label))
   fprintf('removing duplicate labels\n')
   sens.label = sens.label(labidx);
 end
 
 sens.chanpos = cat(1,chanpos{:});
-[~, chanidx] = unique(sens.chanpos, 'rows', 'stable');
+[dum, chanidx] = unique(sens.chanpos, 'rows', 'stable');
 if ~isequal(numel(chanidx), size(sens.chanpos,1))
   fprintf('removing duplicate channels\n')
   sens.chanpos = sens.chanpos(chanidx,:);
@@ -184,7 +184,7 @@ end
 
 if haselecpos
   sens.elecpos = cat(1,elecpos{:});
-  [~, elecidx, elecidx2] = unique(sens.elecpos, 'rows', 'stable');
+  [dum, elecidx, elecidx2] = unique(sens.elecpos, 'rows', 'stable');
   if ~isequal(numel(elecidx), size(sens.elecpos,1))
     fprintf('removing duplicate electrodes\n')
     sens.elecpos = sens.elecpos(elecidx,:);
@@ -206,7 +206,7 @@ end
 
 if hasoptopos
   sens.optopos = cat(1,optopos{:});
-  [~, optoidx, optoidx2] = unique(sens.optopos, 'rows', 'stable');
+  [dum, optoidx, optoidx2] = unique(sens.optopos, 'rows', 'stable');
   if ~isequal(numel(optoidx), size(sens.optopos,1))
     fprintf('removing duplicate optodes\n')
     sens.optopos = sens.optopos(optoidx,:);
@@ -228,7 +228,7 @@ end
 
 if hascoilpos
   sens.coilpos = cat(1,coilpos{:});
-  [~, coilidx, coilidx2] = unique(sens.coilpos, 'rows', 'stable');
+  [dum, coilidx, coilidx2] = unique(sens.coilpos, 'rows', 'stable');
   if ~isequal(numel(coilidx), size(sens.coilpos,1))
     fprintf('removing duplicate coils\n')
     sens.coilpos = sens.coilpos(coilidx,:);

--- a/ft_artifact_threshold.m
+++ b/ft_artifact_threshold.m
@@ -255,11 +255,11 @@ for trlop = 1:numtrl
       for i=1:numel(begsample)
         seg = dat(begsample(i):endsample(i)); % get the segment of data
         if all(seg>=artfctdef.max) || strcmp(direction, 'up')
-          [~, indx] = max(seg);
-          offset(i) = 1 - indx; % relative to the start of the segment, 0 is the first sample, -1 is the 2nd, etc.
+          [dum, indx] = max(seg);
+          offset(i)   = 1 - indx; % relative to the start of the segment, 0 is the first sample, -1 is the 2nd, etc.
         elseif all(seg<=artfctdef.min) || strcmp(direction, 'down')
-          [~, indx] = min(seg);
-          offset(i) = 1 - indx; % relative to the start of the segment, 0 is the first sample, -1 is the 2nd, etc.
+          [dum, indx] = min(seg);
+          offset(i)   = 1 - indx; % relative to the start of the segment, 0 is the first sample, -1 is the 2nd, etc.
         end % if up or down
       end % for each artifact in this trial
     end % if single channel

--- a/ft_combineplanar.m
+++ b/ft_combineplanar.m
@@ -180,7 +180,7 @@ if isfreq
             dum = permute(dum, [2 3 1]);
             dum = reshape(dum, [2 Ntim*Nrpt]);
             timbin = ~isnan(dum(1,:));
-            [loading, ~,  ori, sin_val] = svdfft(dum(:,timbin),2,data.cumtapcnt);
+            [loading, dum,  ori, sin_val] = svdfft(dum(:,timbin),2,data.cumtapcnt);
             dum2   = loading(1,:);
             dum(1,timbin) = dum2;
             dum = reshape(dum(1,:),[Ntim Nrpt]);
@@ -246,7 +246,7 @@ elseif (israw || istimelock)
           tmpdat(:, (Csmp(m)+1):Csmp(m+1)) = data.trial{m}([sel_dH(k) sel_dV(k)],:);
         end
         if strcmp(cfg.method, 'abssvd')||strcmp(cfg.method, 'svd')
-          [loading, ~,  ori, sin_val] = svdfft(tmpdat,2);
+          [loading, dum,  ori, sin_val] = svdfft(tmpdat,2);
           data.ori{k} = ori; % to change into a cell
           data.eta{k} = sin_val(1)/sum(sin_val(2:end)); % to change into a cell
           if strcmp(cfg.method, 'abssvd')

--- a/ft_componentanalysis.m
+++ b/ft_componentanalysis.m
@@ -438,7 +438,7 @@ switch cfg.method
     % do the rest of the icasso related processing
     sR = icassoCluster(sR, 'strategy', 'AL', 'simfcn', 'abscorr', 's2d', 'sim2dis', 'L',cfg.numcomponent);
     sR = icassoProjection(sR, 'cca', 's2d', 'sqrtsim2dis', 'epochs', 75);
-    [Iq, mixing, unmixing, ~, index2centrotypes] = icassoResult(sR,cfg.numcomponent);
+    [Iq, mixing, unmixing, dum, index2centrotypes] = icassoResult(sR,cfg.numcomponent);
     
     % this step is done, because in icassoResult mixing is determined to be
     % pinv(unmixing), which yields strange results. Better take it from the

--- a/ft_connectivitysimulation.m
+++ b/ft_connectivitysimulation.m
@@ -620,11 +620,11 @@ function z = firws_filter(N, Fs, Fbp)
 
 switch numel(Fbp)
   case 1
-    [~, B, ~] = ft_preproc_lowpassfilter(randn(1,N), Fs, Fbp, [], 'firws', 'onepass-minphase');
+    [dum, B] = ft_preproc_lowpassfilter(randn(1,N), Fs, Fbp, [], 'firws', 'onepass-minphase');
     z  = fft(B, N);
 
   case 2
-    [~, B, ~] = ft_preproc_bandpassfilter(randn(1,N), Fs, Fbp, [], 'firws', 'onepass-minphase');
+    [dum, B] = ft_preproc_bandpassfilter(randn(1,N), Fs, Fbp, [], 'firws', 'onepass-minphase');
     z  = fft(B, N);
   
 end

--- a/ft_crossfrequencyanalysis.m
+++ b/ft_crossfrequencyanalysis.m
@@ -352,7 +352,7 @@ pacdata = zeros(size(LFsigtemp,1),size(HFsigtemp,1),nbin);
 
 Ang  = angle(LFsigtemp);
 Amp  = abs(HFsigtemp);
-[~,bin] = histc(Ang, linspace(-pi,pi,nbin));  % binned low frequency phase
+[dum,bin] = histc(Ang, linspace(-pi,pi,nbin));  % binned low frequency phase
 binamp = zeros (size(HFsigtemp,1),nbin);      % binned amplitude
 
 for i = 1:size(Ang,1)

--- a/ft_denoise_dssp.m
+++ b/ft_denoise_dssp.m
@@ -256,9 +256,9 @@ fprintf('Using %d spatial dimensions for the inside field\n', Nin);
 Qout = Vout(:,1:Nout);
 Qin  = Vin(:, 1:Nin);
 
-C       = Qin'*Qout;
-[U,S,~] = svd(C);
-S       = diag(S);
+C     = Qin'*Qout;
+[U,S] = svd(C);
+S     = diag(S);
 if (ischar(Nee) && strcmp(Nee, 'auto'))
   ft_error('automatic determination of intersection dimension is not supported');
 elseif ischar(Nee) && strcmp(Nee, 'interactive')

--- a/ft_denoise_dssp.m
+++ b/ft_denoise_dssp.m
@@ -98,7 +98,7 @@ lf = cat(2, grid.leadfield{:});
 G  = lf*lf';
 
 dat     = cat(2,datain.trial{:});
-[~, Ae, N, Nspace, Sout, Sin, Sspace, S] = dssp(dat, G, cfg.dssp.n_in, cfg.dssp.n_out, cfg.dssp.n_space, cfg.dssp.n_intersect);
+[dum, Ae, N, Nspace, Sout, Sin, Sspace, S] = dssp(dat, G, cfg.dssp.n_in, cfg.dssp.n_out, cfg.dssp.n_space, cfg.dssp.n_intersect);
 datAe   = dat*Ae; % the projection is a right multiplication
 % with a matrix (eye(size(Ae,1))-Ae*Ae'), since Ae*Ae' can become quite 
 % sizeable, it's computed slightly differently here.
@@ -226,8 +226,8 @@ function [Ae, Nee, Sout, Sin, S] = CSP01(Bin, Bout, Nin, Nout, Nee)
 % -------------------------------------------------------------
 %
 
-[~,Sout,Vout] = svd(Bout,'econ');
-[~,Sin, Vin]  = svd(Bin, 'econ');
+[dum,Sout,Vout] = svd(Bout,'econ');
+[dum,Sin, Vin]  = svd(Bin, 'econ');
 Sout = diag(Sout);
 Sin  = diag(Sin);
 

--- a/ft_denoise_tsr.m
+++ b/ft_denoise_tsr.m
@@ -222,7 +222,7 @@ else
   fprintf('selecting reference channel data from the first data input argument\n');
   refdata = ft_selectdata(tmpcfg, varargin{1});
 end
-[~, refdata] = rollback_provenance(cfg, refdata);  
+[dum, refdata] = rollback_provenance(cfg, refdata);  
 
 % keep the requested channels from the data
 tmpcfg  = keepfields(cfg, {'trials', 'showcallinfo' 'channel'});
@@ -313,7 +313,7 @@ tmpcfg.trials = find(cellfun('size',data.trial,2)>0);
 data          = ft_selectdata(tmpcfg, data);
 [cfg, data]   = rollback_provenance(cfg, data);
 refdata       = ft_selectdata(tmpcfg, refdata);
-[~,refdata]   = rollback_provenance(cfg, refdata);
+[dum,refdata] = rollback_provenance(cfg, refdata);
 
 % demean again, just to be sure
 if istrue(cfg.demeanrefdata)
@@ -405,9 +405,9 @@ if usetestdata
   tmpcfg = [];
   tmpcfg.trials = find(cellfun('size',testdata.trial,2)>0);
   testdata     = ft_selectdata(tmpcfg, testdata);
-  [~, testdata] = rollback_provenance(cfg, testdata);
+  [dum,testdata] = rollback_provenance(cfg, testdata);
   testrefdata = ft_selectdata(tmpcfg, testrefdata);
-  [~,testrefdata] = rollback_provenance(cfg, testrefdata);
+  [dum,testrefdata] = rollback_provenance(cfg, testrefdata);
 
   predicted = beta_ref*testrefdata.trial;
   observed  = testdata.trial;

--- a/ft_electroderealign.m
+++ b/ft_electroderealign.m
@@ -694,7 +694,7 @@ end
 
 if istrue(cfg.keepchannel)
   % append the channels that are not realigned
-  [~, idx] = setdiff(elec_original.label, elec_realigned.label);
+  [dum, idx] = setdiff(elec_original.label, elec_realigned.label);
   idx = sort(idx);
   elec_realigned.label = [elec_realigned.label; elec_original.label(idx)];
   elec_realigned.elecpos = [elec_realigned.elecpos; elec_original.elecpos(idx,:)];

--- a/ft_headmovement.m
+++ b/ft_headmovement.m
@@ -175,7 +175,7 @@ end
 
 % remove duplicates if clustering is to be performed
 if dokmeans && ~isequal(cfg.method, 'pertrial_cluster')
-  [tmpdata, ~, ic] = unique(dat', 'rows');
+  [tmpdata, dum, ic] = unique(dat', 'rows');
   dat = tmpdata';
 
   % count how often each position occurs

--- a/ft_resampledata.m
+++ b/ft_resampledata.m
@@ -204,9 +204,9 @@ if usefsample
     if ~strcmp(cfg.baselinewindow, 'all')
       begsample   = ceil(data.fsample*cfg.baselinewindow(1))+find(data.time{itr}==0);
       endsample   = floor(data.fsample*cfg.baselinewindow(2))-1+find(data.time{itr}==0);
-      [~,bsl]     = ft_preproc_baselinecorrect(data.trial{itr}, begsample, endsample);
+      [dum,bsl]   = ft_preproc_baselinecorrect(data.trial{itr}, begsample, endsample);
     else
-      [~,bsl]     = ft_preproc_baselinecorrect(data.trial{itr});
+      [dum,bsl]   = ft_preproc_baselinecorrect(data.trial{itr});
     end
     % always remove the mean to avoid edge effects when there's a strong
     % offset, the cfg.demean option is dealt with below

--- a/ft_volumenormalise.m
+++ b/ft_volumenormalise.m
@@ -178,7 +178,7 @@ sel = strcmp(cfg.parameter, 'anatomy');
 if ~any(sel)
   cfg.parameter = [{'anatomy'} cfg.parameter];
 else
-  [~, indx] = sort(sel);
+  [dum, indx] = sort(sel);
   cfg.parameter = cfg.parameter(fliplr(indx));
 end
 

--- a/ft_volumenormalise.m
+++ b/ft_volumenormalise.m
@@ -272,7 +272,7 @@ if ~isfield(cfg, 'spmparams')
     
     % this writes the 'deformation field'
     fprintf('writing the deformation field to file\n');
-    [bb, ~] = spm_get_bbox(opts.tpm.V(1));
+    bb        = spm_get_bbox(opts.tpm.V(1));
     spm_preproc_write8(params, zeros(6,4), [0 0], [0 1], 1, 1, bb, cfg.downsample);
     
     oldparams = false;
@@ -292,7 +292,7 @@ else
     
     % this writes the 'deformation field'
     fprintf('writing the deformation field to file\n');
-    [bb, ~] = spm_get_bbox(params.tpm(1));
+    bb = spm_get_bbox(params.tpm(1));
     spm_preproc_write8(params, zeros(6,4), [0 0], [0 1], 1, 1, bb, cfg.downsample);
   end
 end
@@ -362,9 +362,9 @@ end
 if strcmp(cfg.keepintermediate, 'no')
   % remove the intermediate files
   for k = 1:length(Vout)
-    [p, f, ~] = fileparts(VF(k).fname);
+    [p, f] = fileparts(VF(k).fname);
     delete(fullfile(p, [f, '.*']));
-    [p, f, ~] = fileparts(Vout(k).fname);
+    [p, f] = fileparts(Vout(k).fname);
     delete(fullfile(p, [f, '.*']));
   end
 end

--- a/ft_volumesegment.m
+++ b/ft_volumesegment.m
@@ -238,7 +238,7 @@ if ~isfield(cfg, 'name')
     ft_error('you must specify the output filename in cfg.name');
   end
 end
-[pathstr, name, ~] = fileparts(cfg.name);
+[pathstr, name] = fileparts(cfg.name);
 cfg.name = fullfile(pathstr, name); % remove any possible file extension, to be added later
 
 if ~iscell(cfg.output)
@@ -362,8 +362,8 @@ if dotpm
       VF = ft_write_mri([cfg.name, '.img'], mri.anatomy, 'transform', mri.transform, 'spmversion', cfg.spmversion, 'dataformat', 'nifti_spm');
 
       fprintf('performing the segmentation on the specified volume\n');
-      p       = spm_preproc(VF, px);
-      [po, ~] = spm_prep2sn(p);
+      p         = spm_preproc(VF, px);
+      [po, dum] = spm_prep2sn(p);
       
       % this writes a mat file, may be needed for Dartel, not sure yet
       save([cfg.name '_sn.mat'],'-struct','po');
@@ -380,7 +380,7 @@ if dotpm
       spm_preproc_write(po, opts);
 
       % generate the list of filenames that contains the segmented volumes
-      [pathstr, name, ~] = fileparts(cfg.name);
+      [pathstr, name] = fileparts(cfg.name);
       filenames = {fullfile(pathstr,['c1', name, '.img']);...
                    fullfile(pathstr,['c2', name, '.img']);...
                    fullfile(pathstr,['c3', name, '.img'])};
@@ -400,8 +400,8 @@ if dotpm
         VF = ft_write_mri([cfg.name, '.nii'], mri.anatomy, 'transform', mri.transform, 'spmversion', cfg.spmversion, 'dataformat', 'nifti_spm');
         
         fprintf('performing the segmentation on the specified volume, using the old-style segmentation\n');
-        p       = spm_preproc(VF, px);
-        [po, ~] = spm_prep2sn(p);
+        p         = spm_preproc(VF, px);
+        [po, dum] = spm_prep2sn(p);
       
         % this write a mat file, may be needed for Dartel, not sure yet
         save([cfg.name '_sn.mat'],'-struct','po');
@@ -418,7 +418,7 @@ if dotpm
         spm_preproc_write(po, opts);
         
         % generate the list of filenames that contains the segmented volumes
-        [pathstr, name, ~] = fileparts(cfg.name);
+        [pathstr, name] = fileparts(cfg.name);
         filenames = {fullfile(pathstr,['c1', name, '.nii']);...
                      fullfile(pathstr,['c2', name, '.nii']);...
                      fullfile(pathstr,['c3', name, '.nii'])};
@@ -469,7 +469,7 @@ if dotpm
         save([cfg.name '_seg8.mat'],'-struct','p');
         
        
-        [pathstr, name, ~] = fileparts(cfg.name);
+        [pathstr, name] = fileparts(cfg.name);
         filenames = {fullfile(pathstr,['c1', name, '.nii']);...
                      fullfile(pathstr,['c2', name, '.nii']);...
                      fullfile(pathstr,['c3', name, '.nii']);...
@@ -494,7 +494,7 @@ if dotpm
   end
   
   if strcmp(cfg.write, 'no')
-    [pathstr, name, ~] = fileparts(cfg.name);
+    [pathstr, name] = fileparts(cfg.name);
     prefix = {'c1';'c2';'c3';'c3';'c4';'c5';'c6';'m';'y_';''};
     suffix = {'_seg1.hdr';'_seg2.hdr';'_seg3.hdr';'_seg1.img';'_seg2.img';'_seg3.img';'_seg1.mat';'_seg2.mat';'_seg3.mat';'.hdr';'.img';'.nii'};
     for k = 1:numel(prefix)

--- a/ft_volumesegment.m
+++ b/ft_volumesegment.m
@@ -685,7 +685,7 @@ elseif  ~isempty(intersect(outp, {'white' 'gray' 'csf' 'brain' 'skull' 'scalp' '
 
       % output: gray, white, csf
     elseif any(strcmp(outp, 'gray')) || any(strcmp(outp, 'white')) || any(strcmp(outp, 'csf'))
-      [~, tissuetype] = max(cat(4, segmented.csf, segmented.gray, segmented.white), [], 4);
+      [dum, tissuetype] = max(cat(4, segmented.csf, segmented.gray, segmented.white), [], 4);
       clear dummy
       if any(strcmp(outp, 'white'))
         segmented.white = (tissuetype == 3) & brainmask;

--- a/imotions2fieldtrip.m
+++ b/imotions2fieldtrip.m
@@ -248,28 +248,28 @@ switch interpolate
         cfgint = [];
         cfgint.channel = isinteger;
         raw_int = ft_selectdata(cfgint, raw);
-        [~, raw_int] = rollback_provenance([], raw_int);
+        [dum, raw_int] = rollback_provenance([], raw_int);
         tmpcfg.method = 'nearest';
         raw_int = ft_resampledata(tmpcfg, raw_int);
-        [~, raw_int] = rollback_provenance([], raw_int);
+        [dum, raw_int] = rollback_provenance([], raw_int);
         
         % interpolating other channels using 'pchip', see INTERP1, shape-preserving piecewise cubic interpolation
         cfgint = [];
         cfgint.channel = setdiff(raw.label,isinteger);
         raw_nonint = ft_selectdata(cfgint, raw);
-        [~, raw_nonint] = rollback_provenance([], raw_nonint);
+        [dum, raw_nonint] = rollback_provenance([], raw_nonint);
         tmpcfg.method = 'pchip';
         raw_nonint = ft_resampledata(tmpcfg, raw_nonint);
-        [~, raw_nonint] = rollback_provenance([], raw_nonint);
+        [dum, raw_nonint] = rollback_provenance([], raw_nonint);
         
         % append
         raw = ft_appenddata([],raw_int, raw_nonint);
-        [~, raw] = rollback_provenance([], raw);
+        [dum, raw] = rollback_provenance([], raw);
       else
         % interpolating all channels using 'pchip', see INTERP1, shape-preserving piecewise cubic interpolation
         tmpcfg.method = 'pchip';
         raw = ft_resampledata(tmpcfg, raw);
-        [~, raw] = rollback_provenance([], raw);
+        [dum, raw] = rollback_provenance([], raw);
       end
     end
     

--- a/inverse/beamformer_lcmv.m
+++ b/inverse/beamformer_lcmv.m
@@ -254,11 +254,11 @@ for i=1:size(dip.pos,1)
   
   if fixedori
     switch(weightnorm)
-      case {'unitnoisegain','nai'};
+      case {'unitnoisegain','nai'}
         % optimal orientation calculation for unit-noise gain beamformer,
         % (also applies to similar NAI), based on equation 4.47 from Sekihara & Nagarajan (2008)
         [vv, dd] = eig(pinv(lf' * invCy_squared *lf)*(lf' * invCy *lf));
-        [~,maxeig]=max(diag(dd));
+        [dum,maxeig]=max(diag(dd));
         eta = vv(:,maxeig);
         lf  = lf * eta;
         if ~isempty(subspace), lforig = lforig * eta; end

--- a/inverse/ft_sloreta.m
+++ b/inverse/ft_sloreta.m
@@ -237,7 +237,7 @@ for i=1:size(dip.pos,1)
 
   if fixedori
       [vv, dd] = eig(pinv(lf' * invG * lf) * lf' * invG * Cy * invG * lf); % eqn 13.22 from Sekihara & Nagarajan 2008 for sLORETA
-      [~,maxeig]=max(diag(dd));
+      [dum,maxeig]=max(diag(dd));
       eta = vv(:,maxeig);
       lf  = lf * eta;
       if ~isempty(subspace), lforig = lforig * eta; end

--- a/inverse/harmony.m
+++ b/inverse/harmony.m
@@ -167,7 +167,7 @@ lc           = ft_getopt(varargin, 'filter_bs');
 %% Create brain harmonics matrix
 
 % Mesh harmonics
-[~,H,d] = ct_mesh_spectrum(dip,num_harm,num_comp);
+[dum,H,d] = ct_mesh_spectrum(dip,num_harm,num_comp);
 
 % Elimination of pathological zeroth frequencies and concatenating
 % harmonics numbers

--- a/inverse/private/mesh_spectrum.m
+++ b/inverse/private/mesh_spectrum.m
@@ -34,7 +34,7 @@ for j = 1:length(pnt)
     elseif length(pnt)==2&&j == 2
         disp('Computing the spectrum of the the second hemisphere')
     end
-    [L{j},~] = mesh_laplacian(pnt{j},tri{j});
+    L{j} = mesh_laplacian(pnt{j},tri{j});
     L{j} = (L{j} + L{j}')/2;
     disp('Computing the spectrum of the negative Laplacian matrix')
     [H{j},D] = eigs(L{j},n,'sm');

--- a/private/blockindx2cmbindx.m
+++ b/private/blockindx2cmbindx.m
@@ -69,8 +69,8 @@ for k = 1:numel(uz)
   
   z_label{k} = tok(:); % the label of the channels that participate in a block
   
-  [~,i2x] = match_str(y(tmp,1), z_label{k});
-  [~,i2y] = match_str(y(tmp,2), z_label{k});
+  [dum,i2x] = match_str(y(tmp,1), z_label{k});
+  [dum,i2y] = match_str(y(tmp,2), z_label{k});
   
   if sqrt(sum(tmp))~=numel(tok)
     error('incomplete data');
@@ -115,7 +115,7 @@ for k = 1:numel(block)
       break;
     end
   end
-  [~, i2]    = match_str(b_label{k}, z_label{indx});
+  [dum, i2]    = match_str(b_label{k}, z_label{indx});
   cmbindx{k} = reshape(z_block{indx}(i2,i2),[],1);
   n{k}       = b_n{k};%(i2);
 end

--- a/private/mesh_spectrum.m
+++ b/private/mesh_spectrum.m
@@ -34,7 +34,7 @@ for j = 1:length(pnt)
     elseif length(pnt)==2&&j == 2
         disp('Computing the spectrum of the the second hemisphere')
     end
-    [L{j},~] = mesh_laplacian(pnt{j},tri{j});
+    L{j} = mesh_laplacian(pnt{j},tri{j});
     L{j} = (L{j} + L{j}')/2;
     disp('Computing the spectrum of the negative Laplacian matrix')
     [H{j},D] = eigs(L{j},n,'sm');

--- a/private/multivariate_decomp.m
+++ b/private/multivariate_decomp.m
@@ -78,8 +78,8 @@ end
 
 % perform the decomposition in a svd-based subspace
 if ~isempty(strfind(method, 'svd'))
-  [ux,sx,~] = svd(B(x,x));
-  [uy,sy,~] = svd(B(y,y));
+  [ux,sx] = svd(B(x,x));
+  [uy,sy] = svd(B(y,y));
   
   if thr(1)<1
     keepx = cumsum(diag(sx))./sum(diag(sx))<=thr(1); keepx(1) = true;

--- a/private/warp_fsaverage.m
+++ b/private/warp_fsaverage.m
@@ -46,11 +46,11 @@ fsavg_reg = ft_read_headshape([cfg.fshome filesep 'subjects' filesep 'fsaverage'
 for e = 1:numel(elec.label)
   % subject space (3D surface): electrode pos -> vertex index
   dist = sqrt(sum(((subj_pial.pos - repmat(elec.elecpos(e,:), size(subj_pial.pos,1), 1)).^2),2));
-  [~, minidx] = min(dist);
+  [dum, minidx] = min(dist);
   
   % intersubject space (2D sphere): vertex index -> vertex pos -> template vertex index
   dist2 = sqrt(sum(((fsavg_reg.pos - repmat(subj_reg.pos(minidx,:), size(fsavg_reg.pos,1), 1)).^2),2));
-  [~, minidx2] = min(dist2);
+  [dum, minidx2] = min(dist2);
   clear minidx
   
   % template space (3D surface): template vertex index -> template electrode pos

--- a/private/warp_fsinflated.m
+++ b/private/warp_fsinflated.m
@@ -32,7 +32,7 @@ function [coord_inf] = warp_fsinflated(cfg, elec)
 
 subj_pial = ft_read_headshape(cfg.headshape);
 [PATHSTR, NAME] = fileparts(cfg.headshape); % lh or rh
-if ~exist([PATHSTR filesep NAME '.inflated'],'file');
+if ~exist([PATHSTR filesep NAME '.inflated'],'file')
   ft_error([PATHSTR filesep NAME filesep 'inflated cannot be found'])
 end
 subj_inflated = ft_read_headshape([PATHSTR filesep NAME '.inflated']);
@@ -40,7 +40,7 @@ subj_inflated = ft_read_headshape([PATHSTR filesep NAME '.inflated']);
 for e = 1:numel(elec.label)
   % subject space (3D surface): electrode pos -> pial vertex index
   dist = sqrt(sum(((subj_pial.pos - repmat(elec.elecpos(e,:), size(subj_pial.pos,1), 1)).^2),2));
-  [~, minidx] = min(dist);
+  [dum, minidx] = min(dist);
   
   % template space (3D surface): pial/inflated vertex index -> inflated brain pos
   coord_inf(e,:) = subj_inflated.pos(minidx,:);

--- a/utilities/private/individual2sn.m
+++ b/utilities/private/individual2sn.m
@@ -65,7 +65,7 @@ else
   ft_hastoolbox('spm12', 1);
 
   fprintf('creating the deformation field and writing it to a temporary file\n');
-  [bb, ~] = spm_get_bbox(P.image(1));
+  bb = spm_get_bbox(P.image(1));
   
   fname  = [tempname,'.nii'];
   V      = nifti;


### PR DESCRIPTION
As discussed in https://github.com/fieldtrip/fieldtrip/issues/831 for backward compatibility with older MATLAB versions.
`~` is replaced by `dum` or removed when used for last argument of a function (as long as it doesn't affect behaviour for remaining arguments as in `size`, `spm_prep2sn` or `svd`).