### PR TITLE
ENH: added support to ft_read_spike for wave_clus output (sorted spikes)

### DIFF
--- a/fileio/ft_filetype.m
+++ b/fileio/ft_filetype.m
@@ -677,7 +677,11 @@ elseif isfolder(filename) && most(filetype_check_extension({ls.name}, '.ntt'))
   type = 'neuralynx_ds';
   manufacturer = 'Neuralynx';
   content = 'tetrode recordings ';
-
+  
+elseif filetype_check_extension(filename, '.mat') && contains(filename, 'times_')
+  type = 'wave_clus';
+  manufacturer = 'Department of Engineering, University of Leicester, UK';
+  content = 'sorted spikes';  
 elseif isfolder(p) && exist(fullfile(p, 'header'), 'file') && exist(fullfile(p, 'samples'), 'file') && exist(fullfile(p, 'events'), 'file')
   type = 'fcdc_buffer_offline';
   manufacturer = 'Donders Centre for Cognitive Neuroimaging';

--- a/fileio/ft_read_spike.m
+++ b/fileio/ft_read_spike.m
@@ -90,8 +90,8 @@ switch spikeformat
   
   case 'wave_clus'
     load(filename); % load the mat file
-    clusters = sort(unique(cluster_class(:,1))); % detected clusters (0 constitutes the rejected cluster)
-    clusters(clusters==0) = []; % remove rejected cluster
+    clusters = sort(unique(cluster_class(:,1))); % detected clusters
+    clusters(clusters==0) = []; % remove rejected cluster (indexed by zeros)
     nclust = numel(clusters);
     t = tokenize(filename, ['_', '.']); % extract channel name
     spike.label     = cell(1,nclust);

--- a/fileio/ft_read_spike.m
+++ b/fileio/ft_read_spike.m
@@ -87,6 +87,25 @@ switch spikeformat
     spike.waveform  = {};   % this is unknown
     spike.unit      = {};   % this is unknown
     spike.hdr       = H;
+  
+  case 'wave_clus'
+    load(filename); % load the mat file
+    clusters = sort(unique(cluster_class(:,1))); % detected clusters (0 constitutes the rejected cluster)
+    clusters(clusters==0) = []; % remove rejected cluster
+    nclust = numel(clusters);
+    t = tokenize(filename, ['_', '.']); % extract channel name
+    spike.label     = cell(1,nclust);
+    spike.unit      = cell(1,nclust);
+    spike.waveform  = cell(1,nclust);
+    spike.timestamp = cell(1,nclust);
+    spike.hdr       = par;
+    for cl = 1:nclust
+      unit_idx                  = cluster_class(:,1)==cl;
+      spike.label{cl}           = [t{2} '-' num2str(cl)];
+      spike.timestamp{cl}       = cluster_class(unit_idx,2)';
+      spike.waveform{cl}(1,:,:) = spikes(unit_idx,:)';
+      spike.unit{cl}            = cluster_class(unit_idx,1)';
+    end
     
   case 'neuralynx_nse'
     % single channel file, read all records

--- a/fileio/ft_read_spike.m
+++ b/fileio/ft_read_spike.m
@@ -21,6 +21,7 @@ function [spike] = ft_read_spike(filename, varargin)
 %   'plexon_plx'
 %   'neuroshare'
 %   'neurosim_spikes'
+%   'wave_clus'
 %
 % The output spike structure usually contains
 %   spike.label     = 1xNchans cell-array, with channel labels
@@ -32,7 +33,7 @@ function [spike] = ft_read_spike(filename, varargin)
 %
 % See also FT_DATATYPE_SPIKE, FT_READ_HEADER, FT_READ_DATA, FT_READ_EVENT
 
-% Copyright (C) 2007-2011 Robert Oostenveld
+% Copyright (C) 2007-2018 Robert Oostenveld, Arjen Stolk
 %
 % This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
 % for the documentation and details.
@@ -106,6 +107,7 @@ switch spikeformat
       spike.waveform{cl}(1,:,:) = spikes(unit_idx,:)';
       spike.unit{cl}            = cluster_class(unit_idx,1)';
     end
+    fprintf('note that wave_clus timestamps are typically expressed in millisec and not in samples\n')
     
   case 'neuralynx_nse'
     % single channel file, read all records


### PR DESCRIPTION
This addition supports reading in wave_clus output (.mat files with filenames beginning with "times_"), which can then be processed with ft_spike_maketrials. I will make a test script at a future point in time, for which I first need to select and upload a suitable data set.