### PR TITLE
Consider NaNs with identical sample number as equal values

### DIFF
--- a/utilities/ft_fetch_data.m
+++ b/utilities/ft_fetch_data.m
@@ -154,7 +154,8 @@ if trlnum>1
         selsmp = smplop - trl(seltrl,1) + begsample; % which sample in each of the trials, requires the adjustment with begsample, rather than 1
         for i=2:length(seltrl)
           % compare all occurences to the first one
-          if ~all(data.trial{seltrl(i)}(:,selsmp(i)) == data.trial{seltrl(1)}(:,selsmp(1)))
+          % consider also mutual occurring NaNs as equal values
+          if ~all(isequaln(data.trial{seltrl(i)}(:,selsmp(i)), data.trial{seltrl(1)}(:,selsmp(1))))
             ft_error('some of the requested samples occur twice in the data and have conflicting values');
           end
         end


### PR DESCRIPTION
Function ft_fetch_data – within the test for sample duplicates mutual occurring NaNs will now be considered as equal values. ( == with isequaln() replaced.)