### PR TITLE
Computing time of ft_freqanalysis reduced

### DIFF
--- a/ft_freqanalysis.m
+++ b/ft_freqanalysis.m
@@ -627,14 +627,17 @@ for itrial = 1:ntrials
   %%% Create output
   if keeprpt~=4
     
+    % mtmconvol is a special case and needs special processing
+    if strcmp(cfg.method, 'mtmconvol')
+      foiind = ones(1,nfoi);
+    else
+      % by using this vector below for indexing, the below code does not need to be duplicated for mtmconvol
+      foiind = 1:nfoi;
+    end
+
     for ifoi = 1:nfoi
-      
-      % mtmconvol is a special case and needs special processing
       if strcmp(cfg.method, 'mtmconvol')
         spectrum = reshape(permute(spectrum_mtmconvol(:,:,freqtapind{ifoi}),[3 1 2]),[ntaper(ifoi) nchan 1 ntoi]);
-        foiind = ones(1,nfoi);
-      else
-        foiind = 1:nfoi; % by using this vector below for indexing, the below code does not need to be duplicated for mtmconvol
       end
       
       % set ingredients for below


### PR DESCRIPTION
Function  ft_freqanalysis – Creation of output reorganized → this change results in a tremendous saving of time when this function is called with a dataset of very long trials

I was wondering why ft_freqanalysis was so munch slower in estimating the power activity of a huge matrix with 25x2130000 sample compared to MATLABs periodogram function.

I found out that the initialization of the 'foiind' variable was the main problem and that this problem can be easily fixed. The variable foiind has in every loop cycle the same value. Accordingly, it can be set before entering the for loop. In my case the computing time was reduced by this fix from 1h 8 minutes to 40 seconds in total.