### PR TITLE
adding new functions to transform md website format t pure matlab

### DIFF
--- a/utilities/markdown2matlab.m
+++ b/utilities/markdown2matlab.m
@@ -1,0 +1,111 @@
+function markdown2matlab(infile,outfile,varargin)
+
+%This function converts a markdown file to a matlab file, commenting out
+%all text, only leaving the code uncommented. As input it takes the name of
+%the file to be converted. Best is to provide the full filepath, otherwise
+%it will look for the file within the current path
+%In addition to the code in the current markdown file it will also add
+%any external markdown files that are connected via the include syntax.
+%The outputfile can be converted back to the original input file using the
+%matlab2markdown function.
+
+
+md_list = '^\*\s|^-\s|^[1-9]*\.\s'; %regex for finding md list syntax
+md_indent = '^\s{4}|^\t';
+
+include = ft_getopt(varargin,'include',0);
+
+%check input
+[inpath, inname, inext]   = fileparts(infile);
+if isempty(inpath), [inpath, inname, inext]   = fileparts(which([inname inext])); end
+if ~strcmp(inext,'.md')
+    error('please specify a markdown file')
+end
+
+if nargin < 2
+    outfile = infile;
+end
+
+%check output
+[outpath, outname,outext] = fileparts(outfile);
+if isempty(outpath), outpath = inpath; end
+if ~strcmp(outext,'.m')
+    outext = '.m';
+end
+
+%avoid overwriting files
+if include
+    perm = 'a';
+else
+    perm = 'w';
+    suffix = 1;
+    newname = outname;
+    while exist([newname,outext],'file') == 2
+        newname = [outname sprintf('%0d',suffix)];
+        suffix = suffix+1;
+    end
+    outname = newname;
+end
+
+
+infile = fullfile(inpath,[inname,inext]);
+outfile = fullfile(outpath,[outname,outext]);
+sprintf('writing converted file to %s',outfile)
+%read & convert file line by line
+infid = fopen(infile,'r');
+outfid = fopen(outfile,perm);
+
+while 1 %convert each line in inputfile % write to output file
+    tline = fgetl(infid);
+    if ~ischar(tline), break, end
+    
+    %if include shared code
+    if ~isempty(strfind(tline,'include')) && ~isempty(strfind(tline,'.md'))
+        pathend = strfind(tline,'.md');
+        pathbeg = strfind(tline,' /');
+        [~,name,ext]= fileparts(tline(pathbeg+1:pathend+2));
+        fprintf(outfid,'%s\n',['%' tline]);
+        fprintf(outfid,'%s\n','%include');
+        fclose(outfid);
+        markdown2matlab(which([name,ext]),outfile,'include',1);
+        outfid = fopen(outfile,'a');
+        fprintf(outfid,'%s\n','%include_end');
+        continue
+    end
+    
+    %leave blank lines as is
+    if ~strcmp(tline,'')
+        %%
+        %convert headings
+        if startsWith(tline,'#')
+            indx = strfind(tline,'#');
+            while length(indx) > indx(end)
+                indx = indx(1:end-1);
+            end
+            tline(indx) = strrep(tline(indx),'#','%');
+        end
+        
+        %convert code blocks
+        if any(regexp(tline,md_indent)) && ~any(regexp(strtrim(tline),md_list))
+            
+            %deal with struct output
+            if endsWith(tline,'=')
+                fprintf(outfid,'%s\n','%output');
+                while ~strcmp(tline,'')
+                    tline = ['%' tline];
+                    fprintf(outfid,'%s\n',tline);
+                    tline = fgetl(infid);
+                end
+            end
+            
+        else      
+            %comment out anything else;
+            tline = ['%' tline];
+        end
+    end
+    
+    fprintf(outfid,'%s\n',tline);
+end
+
+fclose(infid);
+fclose(outfid);

--- a/utilities/matlab2markdown.m
+++ b/utilities/matlab2markdown.m
@@ -1,0 +1,99 @@
+function matlab2markdown(infile,outfile,varargin)
+
+%This function converts a matlab file to a markdown file, uncommenting all comments,
+%assuming they are in correct markdown syntax, plus transforming headings as marked by
+%additional % to the markdown # syntax. The script also makes sure code will be highlighted as such.
+%As input it takes the name of the file to be converted.
+%Best is to provide the full filepath, otherwise it will look for the file within the current path
+%The outputfile can be converted back to the original input file using the
+%markdown2matlab function.
+
+md_list = '^\*\s|^-\s|^[1-9]*\.\s'; %regex for finding md list syntax
+md_indent = '^\s{4}|^\t';
+
+%check input
+[inpath, inname, inext]   = fileparts(infile);
+if isempty(inpath), [inpath, inname, inext]   = fileparts(which([inname inext])); end
+if ~strcmp(inext,'.m')
+    error('please specify a matlab file')
+end
+
+if nargin < 2
+    outfile = infile;
+end
+
+%check output
+[outpath, outname,outext] = fileparts(outfile);
+if isempty(outpath), outpath = inpath; end
+if ~strcmp(outext,'.md')
+    outext = '.md';
+end
+
+%avoid overwriting files
+suffix = 1;
+newname = outname;
+while exist(fullfile(outpath,[newname,outext]),'file') == 2
+    newname = [outname sprintf('%0d',suffix)];
+    suffix = suffix+1;
+end
+outname = newname;
+
+infile = fullfile(inpath,[inname,inext]);
+outfile = fullfile(outpath,[outname,outext]);
+
+%read & convert file line by line
+infid = fopen(infile,'r');
+outfid = fopen(outfile,'w');
+
+prevline = '.';
+while 1
+    tline = fgetl(infid);
+    if ~ischar(tline), break, end
+    
+     %delete included code
+        if strcmp(tline,'%include')
+            while ~strcmp(tline,'%include_end')
+                tline = fgetl(infid);
+            end 
+            tline = fgetl(infid);
+        end
+        
+        if strcmp(tline,'%output')
+            tline = fgetl(infid);
+            while ~strcmp(tline,'')
+                tline = tline(2:end); %uncomment & indent as if code
+                fprintf(outfid,'%s\n',tline);
+                tline = fgetl(infid);
+            end
+        end
+    if ~strcmp(tline,'') %ignore blank lines
+               
+        %each line is either commented out, blank or code
+        if any(regexp(tline,md_indent)) && ~any(regexp(strtrim(tline),md_list))
+            %ensure that code blocks are lead by a blank line
+            if ~any(regexp(prevline,md_indent)) && ~strcmp(prevline,'')
+                fprintf(outfid,'%s\n','');
+            end
+        elseif startsWith(tline,'%')
+            %ensure that code blocks are followed by a blank line
+            if any(regexp(prevline,md_indent)) && ~any(regexp(strtrim(prevline),md_list))
+                fprintf(outfid,'%s\n','');end
+            
+            tline = tline (2:end);
+            %convert headings
+            if startsWith(tline,'%')
+                indx = strfind(tline,'%');
+                while length(indx) > indx(end)
+                    indx = indx(1:end-1);
+                end
+                tline(indx) = strrep(tline(indx),'%','#');
+            end
+        end
+    end
+    %%
+    fprintf(outfid,'%s\n',tline);
+    prevline = tline;
+end
+fclose(infid);
+fclose(outfid);
+end


### PR DESCRIPTION
see also fieldtrip/website issue # 14.

The new function markdown2matlab takes a .md file (ie a tutorial from the new website) and transforms it into a .m file commenting out all markdown syntax and preserving only the matlab code. 
matlab2markdown is the reverse.

Mainly it transforms heading syntax into Matlabs Publish MarkUp syntax and takes care of empty lines around code, as well as structure examples which are also marked as code on the website and the %include functionality.

This is just a first go at this. To have this connect to ft_documentreference and other utilities, we probably should discuss exactly how this conversion will be used and how much it needs to generalize. for now I just implemented it with what I thought was most necessary and tested it on a couple of the already existing tutorial files from the website.

At the moment it is completely disregarding the website specific structures such as header, footer etc. But this should be easy to add.
I'm Happy to hear any feedback of how this needs to be changed & improved to fit the intended purpose.