### PR TITLE
improved the conversion between matlab and markdown

### DIFF
--- a/ft_channelnormalise.m
+++ b/ft_channelnormalise.m
@@ -77,24 +77,19 @@ cfg.method    = ft_getopt(cfg, 'method', 'perchannel'); % or acrosschannel
 dodemean      = istrue(cfg.demean);
 doperchannel  = strcmp(cfg.method, 'perchannel');
 
-% select channels and trials of interest, by default this will select all channels and trials
-tmpcfg = keepfields(cfg, {'trials', 'channel', 'showcallinfo'});
-data = ft_selectdata(tmpcfg, data);
-% restore the provenance information
-[cfg, data] = rollback_provenance(cfg, data);
-
 % store original datatype
 dtype = ft_datatype(data);
 
 % check if the input data is valid for this function
 data = ft_checkdata(data, 'datatype', 'raw', 'feedback', 'yes');
 
-% select trials of interest
-tmpcfg = keepfields(cfg, {'trials', 'showcallinfo'});
-data   = ft_selectdata(tmpcfg, data);
-% restore the provenance information
-[cfg, data] = rollback_provenance(cfg, data);
-
+if ~strcmp(cfg.channel, 'all') || ~strcmp(cfg.trials, 'all')
+  % select channels and trials of interest
+  tmpcfg = keepfields(cfg, {'channel', 'trials', 'showcallinfo'});
+  data   = ft_selectdata(tmpcfg, data);
+  % restore the provenance information
+  [cfg, data] = rollback_provenance(cfg, data);
+end
 % initialise some variables
 nchan  = numel(data.label);
 ntrl   = numel(data.trial);

--- a/utilities/markdown2matlab.m
+++ b/utilities/markdown2matlab.m
@@ -1,111 +1,188 @@
 function markdown2matlab(infile,outfile,varargin)
 
-%This function converts a markdown file to a matlab file, commenting out
-%all text, only leaving the code uncommented. As input it takes the name of
-%the file to be converted. Best is to provide the full filepath, otherwise
-%it will look for the file within the current path
-%In addition to the code in the current markdown file it will also add
-%any external markdown files that are connected via the include syntax.
-%The outputfile can be converted back to the original input file using the
-%matlab2markdown function.
+% MARKDOWN2MATLAB converts a MarkDown file to a MATLAB script or function. All text
+% is converted to comments, headings are converted to comment lines starting with %%
+% sections with code are properly formatted, and words that appear in bold, italic or
+% monospace are converted.
+%
+% Use as
+%   markdown2matlab(infile, outfile)
+%
+% If no outfile is specified, it will write it to a .m file with the same name as
+% the infile. In case the file exists, it will be written with a numeric suffix.
+%
+% The best is to provide the full filepath, otherwise it will look for the file within
+% the current path.
+%
+% See also MATLAB2MARKDOWN
 
+% Copyright (C) 2018 Sophie Arana and Robert Oostenveld
+%
+% This file is part of FieldTrip.
+%
+% megconnectome is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% megconnectome is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with megconnectome.  If not, see <http://www.gnu.org/licenses/>.
 
-md_list = '^\*\s|^-\s|^[1-9]*\.\s'; %regex for finding md list syntax
-md_indent = '^\s{4}|^\t';
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% You can use https://regexr.com to test/debug regular expressions
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-include = ft_getopt(varargin,'include',0);
-
-%check input
-[inpath, inname, inext]   = fileparts(infile);
-if isempty(inpath), [inpath, inname, inext]   = fileparts(which([inname inext])); end
+% check input
+[inpath, inname, inext] = fileparts(infile);
+if isempty(inpath), [inpath, inname, inext] = fileparts(which([inname inext])); end
 if ~strcmp(inext,'.md')
-    error('please specify a markdown file')
+  error('please specify a MarkDown file')
 end
 
 if nargin < 2
-    outfile = infile;
+  outfile = infile;
 end
 
-%check output
+% check output
 [outpath, outname,outext] = fileparts(outfile);
 if isempty(outpath), outpath = inpath; end
 if ~strcmp(outext,'.m')
-    outext = '.m';
+  outext = '.m';
 end
 
-%avoid overwriting files
-if include
-    perm = 'a';
-else
-    perm = 'w';
-    suffix = 1;
-    newname = outname;
-    while exist([newname,outext],'file') == 2
-        newname = [outname sprintf('%0d',suffix)];
-        suffix = suffix+1;
-    end
-    outname = newname;
+% add a suffix to avoid overwriting files
+suffix = 1;
+newname = outname;
+while exist(fullfile(outpath,[newname,outext]),'file') == 2
+  newname = [outname sprintf('-%0d',suffix)];
+  suffix = suffix+1;
 end
-
+outname = newname;
 
 infile = fullfile(inpath,[inname,inext]);
 outfile = fullfile(outpath,[outname,outext]);
-sprintf('writing converted file to %s',outfile)
-%read & convert file line by line
-infid = fopen(infile,'r');
-outfid = fopen(outfile,perm);
 
-while 1 %convert each line in inputfile % write to output file
-    tline = fgetl(infid);
-    if ~ischar(tline), break, end
+% read & convert file line by line
+infid = fopen(infile,'r');
+outfid = fopen(outfile,'w');
+
+format = 'comment';
+
+while ~feof(infid)
+  
+  % the format will be reset unless otherwise specified
+  reset_format = true;
+  
+  line = fgetl(infid);
+  if ~ischar(line), break, end
+  
+  if match(line, '^ *[-+*] ')
+    % unordered list
+    [~,endIndex] = regexp(line, '^ *[-+*] ');
     
-    %if include shared code
-    if ~isempty(strfind(tline,'include')) && ~isempty(strfind(tline,'.md'))
-        pathend = strfind(tline,'.md');
-        pathbeg = strfind(tline,' /');
-        [~,name,ext]= fileparts(tline(pathbeg+1:pathend+2));
-        fprintf(outfid,'%s\n',['%' tline]);
-        fprintf(outfid,'%s\n','%include');
-        fclose(outfid);
-        markdown2matlab(which([name,ext]),outfile,'include',1);
-        outfid = fopen(outfile,'a');
-        fprintf(outfid,'%s\n','%include_end');
-        continue
+    [~,level] = regexp(line, '^ *');
+    if isempty(level)
+      level = 0;
+    end
+    level = repmat(' ', 1, level);
+    remainder = reformat(line((endIndex+1):end));
+    fprintf(outfid, '%%%s* %s\n', level, remainder);
+    
+  elseif match(line, '^    ')
+    % normal code
+    [~,endIndex] = regexp(line, '^    ');
+    remainder = line((endIndex+1):end);
+    fprintf(outfid, '%s\n', remainder);
+    format = 'code';
+    % assume that the next line will be in the same format
+    reset_format = false;
+    
+  elseif match(line, '^[A-Za-z]')
+    % normal text
+    remainder = reformat(line);
+    fprintf(outfid, '%% %s\n', remainder);
+    
+  elseif match(line, '^ *[0-9]*\.')
+    % ordered list
+    [~,endIndex] = regexp(line, '^ *[0-9]*\. ');
+    remainder = reformat(line((endIndex+1):end));
+    fprintf(outfid, '%% # %s\n', remainder);
+    
+  elseif match(line, '^#')
+    % heading
+    [~,endIndex] = regexp(line, '^# *');
+    remainder = reformat(line((endIndex+1):end));
+    fprintf(outfid, '%%%% %s\n', remainder);
+    
+  elseif isempty(line)
+    % keep the complete line as it is
+    if strcmp(format, 'comment')
+      fprintf(outfid, '%%\n');
+    else
+      fprintf(outfid, '\n');
     end
     
-    %leave blank lines as is
-    if ~strcmp(tline,'')
-        %%
-        %convert headings
-        if startsWith(tline,'#')
-            indx = strfind(tline,'#');
-            while length(indx) > indx(end)
-                indx = indx(1:end-1);
-            end
-            tline(indx) = strrep(tline(indx),'#','%');
-        end
-        
-        %convert code blocks
-        if any(regexp(tline,md_indent)) && ~any(regexp(strtrim(tline),md_list))
-            
-            %deal with struct output
-            if endsWith(tline,'=')
-                fprintf(outfid,'%s\n','%output');
-                while ~strcmp(tline,'')
-                    tline = ['%' tline];
-                    fprintf(outfid,'%s\n',tline);
-                    tline = fgetl(infid);
-                end
-            end
-            
-        else      
-            %comment out anything else;
-            tline = ['%' tline];
-        end
-    end
-    
-    fprintf(outfid,'%s\n',tline);
-end
+  end
+  
+  if reset_format
+    format = 'comment';
+  end
+  
+end % while not feof
 
 fclose(infid);
 fclose(outfid);
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% SUBFUNCTION
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+function status = match(str, pattern)
+status = ~isempty(regexp(str, pattern, 'once'));
+
+function str = reformat(str)
+str = formatbold(str);
+str = formatitalic(str);
+str = formatunderline(str);
+str = formatmonospace(str);
+
+function str = formatbold(str)
+[startIndex,endIndex] = regexp(str, '\*\*[a-zA-Z0-9]*\*\*');
+for i=1:length(startIndex)
+  part1 = str(1:startIndex(i)-1);
+  part2 = str(startIndex(i):endIndex(i));
+  part3 = str((endIndex(i)+1):end);
+  str = [part1 '*' part2(3:end-2) '*' part3];
+  % correct the subsequent indices
+  startIndex(i+1:end) = startIndex(i+1:end)-2;
+  endIndex(i+1:end) = endIndex(i+1:end)-2;
+end
+
+function str = formatitalic(str)
+% the format is actually the same
+[startIndex,endIndex] = regexp(str, '_[a-z]*_');
+for i=1:length(startIndex)
+  part1 = str(1:startIndex(i)-1);
+  part2 = str(startIndex(i):endIndex(i));
+  part3 = str((endIndex(i)+1):end);
+  str = [part1 '_' part2(2:end-1) '_' part3];
+end
+
+function str = formatunderline(str)
+% this is not supported in the conversion from MATLAB live scripts to normal MATLAB code.
+
+function str = formatmonospace(str)
+[startIndex,endIndex] = regexp(str, '```[a-z]*```');
+for i=1:length(startIndex)
+  part1 = str(1:startIndex(i)-1);
+  part2 = str(startIndex(i):endIndex(i));
+  part3 = str((endIndex(i)+1):end);
+  str = [part1 '|' part2(4:end-3) '|' part3];
+  % correct the subsequent indices
+  startIndex(i+1:end) = startIndex(i+1:end)-4;
+  endIndex(i+1:end) = endIndex(i+1:end)-4;
+end

--- a/utilities/matlab2markdown.m
+++ b/utilities/matlab2markdown.m
@@ -1,99 +1,185 @@
 function matlab2markdown(infile,outfile,varargin)
 
-%This function converts a matlab file to a markdown file, uncommenting all comments,
-%assuming they are in correct markdown syntax, plus transforming headings as marked by
-%additional % to the markdown # syntax. The script also makes sure code will be highlighted as such.
-%As input it takes the name of the file to be converted.
-%Best is to provide the full filepath, otherwise it will look for the file within the current path
-%The outputfile can be converted back to the original input file using the
-%markdown2matlab function.
+% MATLAB2MARKDOWN converts a MATLAB script or function to MarkDown format. All
+% comments are converted to text, comment lines starting with %% are converted to
+% headings, sections with code are properly formatted, and words that appear in bold,
+% italic or monospace are converted.
+%
+% Use as
+%   matlab2markdown(infile, outfile)
+%
+% If no outfile is specified, it will write it to a .md file with the same name as
+% the infile. In case the file exists, it will be written with a numeric suffix.
+%
+% The best is to provide the full filepath, otherwise it will look for the file within
+% the current path.
+%
+% See also MARKDOWN2MATLAB
 
-md_list = '^\*\s|^-\s|^[1-9]*\.\s'; %regex for finding md list syntax
-md_indent = '^\s{4}|^\t';
+% Copyright (C) 2018 Sophie Arana and Robert Oostenveld
+%
+% This file is part of FieldTrip.
+%
+% megconnectome is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% megconnectome is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with megconnectome.  If not, see <http://www.gnu.org/licenses/>.
 
-%check input
-[inpath, inname, inext]   = fileparts(infile);
-if isempty(inpath), [inpath, inname, inext]   = fileparts(which([inname inext])); end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% You can use https://regexr.com to test/debug regular expressions
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+% check input
+[inpath, inname, inext] = fileparts(infile);
+if isempty(inpath), [inpath, inname, inext] = fileparts(which([inname inext])); end
 if ~strcmp(inext,'.m')
-    error('please specify a matlab file')
+  error('please specify a MATLAB file')
 end
 
 if nargin < 2
-    outfile = infile;
+  outfile = infile;
 end
 
-%check output
+% check output
 [outpath, outname,outext] = fileparts(outfile);
 if isempty(outpath), outpath = inpath; end
 if ~strcmp(outext,'.md')
-    outext = '.md';
+  outext = '.md';
 end
 
-%avoid overwriting files
+% add a suffix to avoid overwriting files
 suffix = 1;
 newname = outname;
 while exist(fullfile(outpath,[newname,outext]),'file') == 2
-    newname = [outname sprintf('%0d',suffix)];
-    suffix = suffix+1;
+  newname = [outname sprintf('-%0d',suffix)];
+  suffix = suffix+1;
 end
 outname = newname;
 
 infile = fullfile(inpath,[inname,inext]);
 outfile = fullfile(outpath,[outname,outext]);
 
-%read & convert file line by line
+% read & convert file line by line
 infid = fopen(infile,'r');
 outfid = fopen(outfile,'w');
 
-prevline = '.';
-while 1
-    tline = fgetl(infid);
-    if ~ischar(tline), break, end
+index = 0;
+
+while ~feof(infid)
+  
+  % reset the index, unless otherwise specified
+  reset_index = true;
+  
+  line = fgetl(infid);
+  if ~ischar(line), break, end
+  
+  if isempty(line)
+    % keep the complete line as it is
+    fprintf(outfid, '%s\n', line);
     
-     %delete included code
-        if strcmp(tline,'%include')
-            while ~strcmp(tline,'%include_end')
-                tline = fgetl(infid);
-            end 
-            tline = fgetl(infid);
-        end
-        
-        if strcmp(tline,'%output')
-            tline = fgetl(infid);
-            while ~strcmp(tline,'')
-                tline = tline(2:end); %uncomment & indent as if code
-                fprintf(outfid,'%s\n',tline);
-                tline = fgetl(infid);
-            end
-        end
-    if ~strcmp(tline,'') %ignore blank lines
-               
-        %each line is either commented out, blank or code
-        if any(regexp(tline,md_indent)) && ~any(regexp(strtrim(tline),md_list))
-            %ensure that code blocks are lead by a blank line
-            if ~any(regexp(prevline,md_indent)) && ~strcmp(prevline,'')
-                fprintf(outfid,'%s\n','');
-            end
-        elseif startsWith(tline,'%')
-            %ensure that code blocks are followed by a blank line
-            if any(regexp(prevline,md_indent)) && ~any(regexp(strtrim(prevline),md_list))
-                fprintf(outfid,'%s\n','');end
-            
-            tline = tline (2:end);
-            %convert headings
-            if startsWith(tline,'%')
-                indx = strfind(tline,'%');
-                while length(indx) > indx(end)
-                    indx = indx(1:end-1);
-                end
-                tline(indx) = strrep(tline(indx),'%','#');
-            end
-        end
+  elseif match(line, '^%%')
+    % heading
+    [~,endIndex] = regexp(line, '^%% ');
+    remainder = reformat(line((endIndex+1):end));
+    fprintf(outfid, '# %s\n', remainder);
+    
+  elseif match(line, '^% *\* ')
+    % unordered list
+    [~,endIndex] = regexp(line, '^% *\* ');
+    
+    [~,level] = regexp(line, '^% *');
+    if isempty(level)
+      level = 0;
+    else
+      level = level - 1;
     end
-    %%
-    fprintf(outfid,'%s\n',tline);
-    prevline = tline;
-end
+    level = repmat(' ', 1, level);
+    remainder = reformat(line((endIndex+1):end));
+    fprintf(outfid, '%s- %s\n', level, remainder);
+    
+  elseif match(line, '^% *# ')
+    % ordered list
+    [~,endIndex] = regexp(line, '^% *# ');
+    remainder = reformat(line((endIndex+1):end));
+    index = index + 1;
+    fprintf(outfid, '%d. %s\n', index, remainder);
+    % assume that the next line will be part of the ordered list
+    reset_index = false;
+    
+  elseif match(line, '^% *')
+    % normal text
+    [~,endIndex] = regexp(line, '^% *');
+    remainder = reformat(line((endIndex+1):end));
+    fprintf(outfid, '%s\n', remainder);
+    
+  elseif ~match(line, '^%')
+    % normal code
+    fprintf(outfid, '    %s\n', line);
+    
+  end
+  
+  if reset_index
+    index = 0;
+  end
+  
+end % while not feof
+
 fclose(infid);
 fclose(outfid);
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% SUBFUNCTION
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+function status = match(str, pattern)
+status = ~isempty(regexp(str, pattern, 'once'));
+
+function str = reformat(str)
+str = formatbold(str);
+str = formatitalic(str);
+str = formatunderline(str);
+str = formatmonospace(str);
+
+function str = formatbold(str)
+[startIndex,endIndex] = regexp(str, '\*[a-zA-Z0-9]*\*');
+for i=1:length(startIndex)
+  part1 = str(1:startIndex(i)-1);
+  part2 = str(startIndex(i):endIndex(i));
+  part3 = str((endIndex(i)+1):end);
+  str = [part1 '**' part2(2:end-1) '**' part3];
+  % correct the subsequent indices
+  startIndex(i+1:end) = startIndex(i+1:end)+2;
+  endIndex(i+1:end) = endIndex(i+1:end)+2;
+end
+
+function str = formatitalic(str)
+% the format is actually the same
+[startIndex,endIndex] = regexp(str, '_[a-z]*_');
+for i=1:length(startIndex)
+  part1 = str(1:startIndex(i)-1);
+  part2 = str(startIndex(i):endIndex(i));
+  part3 = str((endIndex(i)+1):end);
+  str = [part1 '_' part2(2:end-1) '_' part3];
+end
+
+function str = formatunderline(str)
+% this is not supported in the conversion from MATLAB live scripts to normal MATLAB code.
+
+function str = formatmonospace(str)
+[startIndex,endIndex] = regexp(str, '\|[a-z]*\|');
+for i=1:length(startIndex)
+  part1 = str(1:startIndex(i)-1);
+  part2 = str(startIndex(i):endIndex(i));
+  part3 = str((endIndex(i)+1):end);
+  str = [part1 '```' part2(2:end-1) '```' part3];
+  % correct the subsequent indices
+  startIndex(i+1:end) = startIndex(i+1:end)+4;
+  endIndex(i+1:end) = endIndex(i+1:end)+4;
 end


### PR DESCRIPTION
I used the following MATLAB test script during development

```
%% Title
%
% This is an example MATLAB script that also works well as "live script" in the
% MATLAB desktop environment. It can be used to test conversion between MATLAB format
% and MarkDown.
%
% See also https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet


%% Heading 1 - ordered list
%
% # ordered list
% # ordered list
% # ordered list

%% Heading 2 - unordered list
%
% * unordered list
% * unordered list
% * unordered list

%% Heading 3 - nested lists
%
% * level 1
%   * level 2
%   * level 2
%     * level 3
%     * level 3
%     * level 3
%   * level 2
%   * level 2
% * level 1

%% Heading 4 - testing font variations
%
% this is normal font, once more normal font
%
% this is *bold* font, once more *bold* font
%
% this is _italic_ font, once more _italic_ font
%
% this is underline font, once more underline font
%
% this is |monospace| font, once more |monospace| font
%
% Multiple font variations on a single line: *bold*, _italic_, |monospace|.

%% Heading 5 - some empty lines

%

%


%% Heading 6 - a piece of code

a = 2;
b = 1;

x = 20;
y = a*x + b;
```