### PR TITLE
ENH: improved cortex hull creation

### DIFF
--- a/private/prepare_mesh_cortexhull.m
+++ b/private/prepare_mesh_cortexhull.m
@@ -12,7 +12,8 @@ function headshape = prepare_mesh_cortexhull(cfg)
 %                     FreeSurfer recon-all ('/path/to/surf/lh.pial')
 %   cfg.resolution   = (optional, default: 1) resolution of the volume
 %                     delimited by headshape being floodfilled by mris_fill
-%   cfg.fshome       = FreeSurfer folder location (default: '/Applications/freesurfer')
+%   cfg.fshome       = FreeSurfer folder location 
+%                     (default: '/Applications/freesurfer')
 %   cfg.outer_surface_sphere = (optional, default: 40) diameter of the sphere
 %                     used by make_outer_surface to close the sulci using
 %                     morphological operations.

--- a/private/prepare_mesh_headshape.m
+++ b/private/prepare_mesh_headshape.m
@@ -216,7 +216,7 @@ M_con = sparse([ts.tri(1,:)';ts.tri(1,:)';ts.tri(2,:)';ts.tri(3,:)';ts.tri(2,:)'
   [ts.tri(2,:)';ts.tri(3,:)';ts.tri(1,:)';ts.tri(1,:)';ts.tri(3,:)';ts.tri(2,:)'], ...
   ones(ts.nr(2)*6,1),ts.nr(1),ts.nr(1));
 
-kpb   = .1;                       % Cutt-off frequency
+kpb   = .00001;                       % Cutt-off frequency
 lam   = .5; mu = lam/(lam*kpb-1); % Parameters for elasticity.
 XYZmm = ts.XYZmm;
 

--- a/private/prepare_mesh_headshape.m
+++ b/private/prepare_mesh_headshape.m
@@ -216,8 +216,8 @@ M_con = sparse([ts.tri(1,:)';ts.tri(1,:)';ts.tri(2,:)';ts.tri(3,:)';ts.tri(2,:)'
   [ts.tri(2,:)';ts.tri(3,:)';ts.tri(1,:)';ts.tri(1,:)';ts.tri(3,:)';ts.tri(2,:)'], ...
   ones(ts.nr(2)*6,1),ts.nr(1),ts.nr(1));
 
-kpb   = .00001;                       % Cutt-off frequency
-lam   = .5; mu = lam/(lam*kpb-1); % Parameters for elasticity.
+kpb   = .1;                       % Cutt-off frequency (default: .1)
+lam   = .5; mu = lam/(lam*kpb-1); % Parameters for elasticity. (default: .5)
 XYZmm = ts.XYZmm;
 
 % smoothing iterations


### PR DESCRIPTION
The default approach would create hulls that were too tight:

<img width="486" alt="screen shot 2018-12-03 at 11 07 46 pm" src="https://user-images.githubusercontent.com/3984917/49424734-54fb4d80-f750-11e8-9d01-4fb8b19a7440.png">

This PR entails changes to the defaults settings as well as the addition of a non-shrinking smoothing step that uses functions from the iso2mesh toolbox. With these changes, the cortex rarely extends past the hull (except for juts in some subjects):

<img width="564" alt="screen shot 2018-12-03 at 10 46 27 pm" src="https://user-images.githubusercontent.com/3984917/49424902-deab1b00-f750-11e8-889d-ac6805998154.png">
 