### PR TITLE
the first control statement more strictly checks for the <setseed> va…

### DIFF
--- a/utilities/private/randomseed.m
+++ b/utilities/private/randomseed.m
@@ -40,7 +40,8 @@ end
 
 state = [];
 
-if isempty(setseed) || strcmp(setseed, 'yes')
+if isempty(setseed) || (ischar(setseed) && strcmp(setseed, 'yes'))
+
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   % save out rand state for later use
   


### PR DESCRIPTION
…riable type to prevent crashing if <setseed> is manually set to anything else then char

@schoffelen Thanks, your suggestion worked fine (on updated ft master branch). PR-ing. 