### PR TITLE
Update ft_multiplotER.m

### DIFF
--- a/ft_multiplotER.m
+++ b/ft_multiplotER.m
@@ -469,13 +469,14 @@ hold on
 % Plot the data
 for m=1:length(selchan)
   mask = maskmatrix(m, :);
-  yval = squeeze(datamatrix(:,m,:));
+  for i=1:Ndata
+  yval = squeeze(datamatrix(i,m,:));
   
   % Clip out of bounds y values:
   yval(yval > ymax) = ymax;
   yval(yval < ymin) = ymin;
-  
-  ft_plot_vector(xval, yval, 'width', chanWidth(m), 'height', chanHeight(m), 'hpos', chanX(m), 'vpos', chanY(m), 'hlim', [xmin xmax], 'vlim', [ymin ymax], 'color', graphcolor, 'style', cfg.linestyle{i}, 'linewidth', cfg.linewidth, 'axis', cfg.axes, 'highlight', mask, 'highlightstyle', cfg.maskstyle);
+  ft_plot_vector(xval, yval, 'width', chanWidth(m), 'height', chanHeight(m), 'hpos', chanX(m), 'vpos', chanY(m), 'hlim', [xmin xmax], 'vlim', [ymin ymax], 'color', graphcolor(i), 'style', cfg.linestyle{i}, 'linewidth', cfg.linewidth, 'axis', cfg.axes, 'highlight', mask, 'highlightstyle', cfg.maskstyle);
+  end
 end % for number of channels
 
 % plot the layout, labels and outline


### PR DESCRIPTION
Currently cfg.linestyle option is meaningless. In the old version on line 478 , cfg.linestyle{i} does not make sense because the line is not even looping around i which should be from 1: Ndata. Proposing the following changes so ft_multiplotER can plot lines of different style (dashed, dotted etc.). I tested the changes and it works. This same change must be done on ft_singleplotER as well, which I will fork/and edit.