### PR TITLE
Update ft_singleplotER.m

### DIFF
--- a/ft_singleplotER.m
+++ b/ft_singleplotER.m
@@ -434,11 +434,11 @@ hold on
 yval = mean(datamatrix, 2); % over channels
 yval = reshape(yval, size(yval,1), size(yval,3));
 mask = squeeze(mean(maskmatrix, 1)); % over channels
-
-ft_plot_vector(xval, yval, 'style', cfg.linestyle{i}, 'color', graphcolor, ...
+for i=1:Ndata
+ft_plot_vector(xval, yval(i,:), 'style', cfg.linestyle{i}, 'color', graphcolor(i), ...
   'highlight', mask, 'highlightstyle', cfg.maskstyle, 'linewidth', cfg.linewidth, ...
   'hlim', [xmin xmax], 'vlim', [ymin ymax]);
-
+end
 colorLabels = [];
 if Ndata > 1
   for i=1:Ndata


### PR DESCRIPTION
This is a follow up change to have a meaningful cfg.linestyle option. It was nonfunctional both in ft_multiplotER and ft_singleplotER. I edited the ft_multiplotER and submited a Pull request separately. Upon plotting using function ft_multiplotER, in the interactive model when clicking a particular channel ft_singleplotER is called. The changes proposed are essential so the chosen channel reflects the linestyles using in multiplotER.