### PR TITLE
small change to documentation of baseline, no functional change

### DIFF
--- a/ft_movieplotER.m
+++ b/ft_movieplotER.m
@@ -15,7 +15,7 @@ function [cfg] = ft_movieplotER(cfg, data)
 %   cfg.framespersec = number, frames per second (default = 5)
 %   cfg.framesfile   = [], no file saved, or 'string', filename of saved frames.mat (default = []);
 %   cfg.layout       = specification of the layout, see below
-%   cfg.baseline     = 'yes','no' or [time1 time2] (default = 'no'), see FT_TIMELOCKBASELINE or FT_FREQBASELINE
+%   cfg.baseline     = 'yes','no' or [time1 time2] (default = 'no'), see FT_TIMELOCKBASELINE
 %   cfg.baselinetype = 'absolute' or 'relative' (default = 'absolute')
 %   cfg.colorbar     = 'yes', 'no' (default = 'no')
 %
@@ -88,13 +88,12 @@ if ~strcmp(cfg.baseline, 'no')
   tmpcfg = keepfields(cfg, {'baseline', 'baselinetype', 'parameter', 'showcallinfo'});
   data = ft_timelockbaseline(tmpcfg, data);
   [cfg, data] = rollback_provenance(cfg, data);
-  % prevent the baseline correction from happening in ft_movieplotTFR
-  cfg = removefields(cfg, {'baseline', 'baselinetype'});
 end
 
-cfg = ft_movieplotTFR(cfg, data);
+% prevent the baseline correction from happening in ft_movieplotTFR
+tmpcfg = removefields(cfg, {'baseline', 'baselinetype'});
+tmpcfg = ft_movieplotTFR(tmpcfg, data);
 
 % do the general cleanup and bookkeeping at the end of the function
-% this will replace the ft_movieplotTFR callinfo with that of ft_movieplotER
 ft_postamble provenance
 ft_postamble previous data

--- a/test/dccnpath.m
+++ b/test/dccnpath.m
@@ -1,18 +1,17 @@
 function file = dccnpath(filename)
 
-% DCCNPATH updates the full path specificaion to a file for all files
-% on DCCN home central storage.
+% DCCNPATH updates the path in the filename of a test file located on DCCN central
+% storage. It helps to read test file from Linux, Windows or macOS computers in the
+% DCCN.
 %
 % Use as
 %  filename = dccnpath(filename)
 %
-% The function assumes that on a Windows machine the DCCN home network
-% drive is mapped to H:. The function basically converts between H:\ and
-% /home and uses the appropriate file seperator depending on the operating
-% system.
+% The function assumes that on a Windows machine the DCCN home network drive is
+% mapped to the H: drive on Windows, or that it is mounted on /Volume/home for macOS.
 %
-% An in-place implementation of this function can be realized with an
-% anonymous function like this:
+% Similar functionality as this function could be realized with an anonymous function
+% like this:
 %
 % if ispc
 %   dccnpath = @(filename) strrep(strrep(filename,'/home','H:'),'/','\');
@@ -20,7 +19,7 @@ function file = dccnpath(filename)
 %   dccnpath = @(filename) strrep(strrep(filename,'H:','/home'),'\','/');
 % end
 
-% Copyright (C) 2012, Donders Centre for Cognitive Neuroimaging, Nijmegen, NL
+% Copyright (C) 2012-2019, Donders Centre for Cognitive Neuroimaging, Nijmegen, NL
 %
 % This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
 % for the documentation and details.
@@ -51,7 +50,8 @@ end
 [p, f, x] = fileparts(file);
 
 alternative1 = [f x];
-alternative2 = strrep(filename, '/home/common/matlab/fieldtrip/data/test', '/Volumes/128GB/bug');
+alternative2 = strrep(filename, '/home/common/matlab/fieldtrip', '/Volumes/home/common/matlab/fieldtrip');
+alternative3 = strrep(filename, '/home/common/matlab/fieldtrip', '/Volumes/128GB/data/test');
 
 if ~exist(file, 'file') && exist(alternative1, 'file')
   warning('using local copy %s instead of %s', alternative1, file);
@@ -59,5 +59,8 @@ if ~exist(file, 'file') && exist(alternative1, 'file')
 elseif ~exist(file, 'file') && exist(alternative2, 'file')
   warning('using local copy %s instead of %s', alternative2, file);
   file = alternative2;
+elseif ~exist(file, 'file') && exist(alternative3, 'file')
+  warning('using local copy %s instead of %s', alternative3, file);
+  file = alternative3;
 end
 

--- a/test/test_ft_movieplotTFR.m
+++ b/test/test_ft_movieplotTFR.m
@@ -5,7 +5,7 @@ function test_ft_movieplotTFR
 
 % TEST ft_movieplotTFR ft_movieplotER
 
-% the frequency analysis is based on the tutorials
+% the timelock and frequency analysis is based on the tutorials
 
 load(dccnpath('/home/common/matlab/fieldtrip/data/ftp/tutorial/timefrequencyanalysis/dataFIC.mat'));
 
@@ -44,7 +44,7 @@ cfg = [];
 cfg.layout = 'CTF151.lay';
 ft_movieplotTFR(cfg, freqFIC);
 
-% non interactive TFR movie along frequencies
+% non-interactive TFR movie along frequencies
 figure
 cfg = [];
 cfg.interactive = 'no';
@@ -53,19 +53,11 @@ cfg.movierpt    = 3;
 cfg.layout      = 'CTF151.lay';
 ft_movieplotTFR(cfg, freqFIC);
 
-% non interactive TFR movie along frequencies
+% non-interactive TFR movie along frequencies
 figure
 cfg = [];
 cfg.interactive = 'no';
 cfg.moviefreq   = 2;
 cfg.movierpt    = 3;
-cfg.layout = 'CTF151.lay';
+cfg.layout      = 'CTF151.lay';
 ft_movieplotTFR(cfg, freqFIC);
-
-% ensure that all figures are updated before XUnit starts to close the figures
-drawnow
-close all
-
-
-drawnow
-


### PR DESCRIPTION
in reaction to #917 I checked `ft_movieplotER` since it was *not* calling ft_freqbaseline. But that actually makes sense, because the data is forced to be a timelock structure and averaging over a frequency range is not implemented. It is also not really needed, since `ft_movieplotTFR` allows the user to loop over time for a specific frequency.    