### PR TITLE
Plotvecalpha

### DIFF
--- a/ft_multiplotER.m
+++ b/ft_multiplotER.m
@@ -189,6 +189,7 @@ cfg.maskparameter  = ft_getopt(cfg, 'maskparameter');
 cfg.linestyle      = ft_getopt(cfg, 'linestyle', '-');
 cfg.linewidth      = ft_getopt(cfg, 'linewidth', 0.5);
 cfg.maskstyle      = ft_getopt(cfg, 'maskstyle', 'box');
+cfg.maskfacealpha  = ft_getopt(cfg, 'maskfacealpha', 1);
 cfg.channel        = ft_getopt(cfg, 'channel', 'all');
 cfg.directionality = ft_getopt(cfg, 'directionality', '');
 cfg.figurename     = ft_getopt(cfg, 'figurename');
@@ -475,7 +476,7 @@ for m=1:length(selchan)
   % Clip out of bounds y values:
   yval(yval > ymax) = ymax;
   yval(yval < ymin) = ymin;
-  ft_plot_vector(xval, yval, 'width', chanWidth(m), 'height', chanHeight(m), 'hpos', chanX(m), 'vpos', chanY(m), 'hlim', [xmin xmax], 'vlim', [ymin ymax], 'color', graphcolor(i), 'style', cfg.linestyle{i}, 'linewidth', cfg.linewidth, 'axis', cfg.axes, 'highlight', mask, 'highlightstyle', cfg.maskstyle);
+  ft_plot_vector(xval, yval, 'width', chanWidth(m), 'height', chanHeight(m), 'hpos', chanX(m), 'vpos', chanY(m), 'hlim', [xmin xmax], 'vlim', [ymin ymax], 'color', graphcolor(i), 'style', cfg.linestyle{i}, 'linewidth', cfg.linewidth, 'axis', cfg.axes, 'highlight', mask, 'highlightstyle', cfg.maskstyle, 'maskfacealpha', cfg.maskfacealpha);
   end
 end % for number of channels
 

--- a/ft_multiplotER.m
+++ b/ft_multiplotER.m
@@ -20,6 +20,7 @@ function [cfg] = ft_multiplotER(cfg, varargin)
 %   cfg.parameter     = field to be plotted on y-axis, for example 'avg', 'powspctrm' or 'cohspctrm' (default is automatic)
 %   cfg.maskparameter = field in the first dataset to be used for marking significant data
 %   cfg.maskstyle     = style used for masking of data, 'box', 'thickness' or 'saturation' (default = 'box')
+%   cfg.maskfacealpha = mask transparency value between 0 and 1
 %   cfg.xlim          = 'maxmin' or [xmin xmax] (default = 'maxmin')
 %   cfg.ylim          = 'maxmin', 'maxabs', 'zeromax', 'minzero', or [ymin ymax] (default = 'maxmin')
 %   cfg.gradscale     = number, scaling to apply to the MEG gradiometer channels prior to display

--- a/ft_multiplotER.m
+++ b/ft_multiplotER.m
@@ -477,7 +477,7 @@ for m=1:length(selchan)
   % Clip out of bounds y values:
   yval(yval > ymax) = ymax;
   yval(yval < ymin) = ymin;
-  ft_plot_vector(xval, yval, 'width', chanWidth(m), 'height', chanHeight(m), 'hpos', chanX(m), 'vpos', chanY(m), 'hlim', [xmin xmax], 'vlim', [ymin ymax], 'color', graphcolor(i), 'style', cfg.linestyle{i}, 'linewidth', cfg.linewidth, 'axis', cfg.axes, 'highlight', mask, 'highlightstyle', cfg.maskstyle, 'maskfacealpha', cfg.maskfacealpha);
+  ft_plot_vector(xval, yval, 'width', chanWidth(m), 'height', chanHeight(m), 'hpos', chanX(m), 'vpos', chanY(m), 'hlim', [xmin xmax], 'vlim', [ymin ymax], 'color', graphcolor(i), 'style', cfg.linestyle{i}, 'linewidth', cfg.linewidth, 'axis', cfg.axes, 'highlight', mask, 'highlightstyle', cfg.maskstyle, 'facealpha', cfg.maskfacealpha);
   end
 end % for number of channels
 

--- a/ft_singleplotER.m
+++ b/ft_singleplotER.m
@@ -439,7 +439,7 @@ mask = squeeze(mean(maskmatrix, 1)); % over channels
 for i=1:Ndata
 ft_plot_vector(xval, yval(i,:), 'style', cfg.linestyle{i}, 'color', graphcolor(i), ...
   'highlight', mask, 'highlightstyle', cfg.maskstyle, 'linewidth', cfg.linewidth, ...
-  'hlim', [xmin xmax], 'vlim', [ymin ymax],'facealpha', cfg.maskfacealpha);
+  'hlim', [xmin xmax], 'vlim', [ymin ymax], 'facealpha', cfg.maskfacealpha);
 end
 colorLabels = [];
 if Ndata > 1

--- a/ft_singleplotER.m
+++ b/ft_singleplotER.m
@@ -439,7 +439,7 @@ mask = squeeze(mean(maskmatrix, 1)); % over channels
 for i=1:Ndata
 ft_plot_vector(xval, yval(i,:), 'style', cfg.linestyle{i}, 'color', graphcolor(i), ...
   'highlight', mask, 'highlightstyle', cfg.maskstyle, 'linewidth', cfg.linewidth, ...
-  'hlim', [xmin xmax], 'vlim', [ymin ymax],'maskfacealpha', cfg.maskfacealpha);
+  'hlim', [xmin xmax], 'vlim', [ymin ymax],'facealpha', cfg.maskfacealpha);
 end
 colorLabels = [];
 if Ndata > 1

--- a/ft_singleplotER.m
+++ b/ft_singleplotER.m
@@ -162,6 +162,7 @@ cfg.maskparameter   = ft_getopt(cfg, 'maskparameter',  []);
 cfg.linestyle       = ft_getopt(cfg, 'linestyle',     '-');
 cfg.linewidth       = ft_getopt(cfg, 'linewidth',      0.5);
 cfg.maskstyle       = ft_getopt(cfg, 'maskstyle',     'box');
+cfg.maskfacealpha   = ft_getopt(cfg, 'maskfacealpha', 1);
 cfg.channel         = ft_getopt(cfg, 'channel',       'all');
 cfg.title           = ft_getopt(cfg, 'title',          []);
 cfg.directionality  = ft_getopt(cfg, 'directionality', []);
@@ -437,7 +438,7 @@ mask = squeeze(mean(maskmatrix, 1)); % over channels
 for i=1:Ndata
 ft_plot_vector(xval, yval(i,:), 'style', cfg.linestyle{i}, 'color', graphcolor(i), ...
   'highlight', mask, 'highlightstyle', cfg.maskstyle, 'linewidth', cfg.linewidth, ...
-  'hlim', [xmin xmax], 'vlim', [ymin ymax]);
+  'hlim', [xmin xmax], 'vlim', [ymin ymax],'maskfacealpha', cfg.maskfacealpha);
 end
 colorLabels = [];
 if Ndata > 1

--- a/ft_singleplotER.m
+++ b/ft_singleplotER.m
@@ -20,6 +20,7 @@ function [cfg] = ft_singleplotER(cfg, varargin)
 %                       (not possible for mean over multiple channels, or when input contains multiple subjects
 %                       or trials)
 %   cfg.maskstyle     = style used for masking of data, 'box', 'thickness' or 'saturation' (default = 'box')
+%   cfg.maskfacealpha = mask transparency value between 0 and 1
 %   cfg.xlim          = 'maxmin' or [xmin xmax] (default = 'maxmin')
 %   cfg.ylim          = 'maxmin', 'maxabs', 'zeromax', 'minzero', or [ymin ymax] (default = 'maxmin')
 %   cfg.channel       = nx1 cell-array with selection of channels (default = 'all')

--- a/plotting/ft_plot_vector.m
+++ b/plotting/ft_plot_vector.m
@@ -13,13 +13,14 @@ function [varargout] = ft_plot_vector(varargin)
 %   'highlight'       = a logical vector of size Y, where 1 means that the corresponding values in Y are highlighted (according to the highlightstyle)
 %   'highlightstyle'  = can be 'box', 'thickness', 'saturation', 'difference' (default='box')
 %   'color'           = see MATLAB standard line properties and see below
+%   'facecolor'       = color for the highlighted box (default = [0.6 0.6 0.6])
+%   'facealpha'       = transparency for the highlighted box, between 0 and 1 (default = 1)
 %   'linewidth'       = see MATLAB standard line properties
 %   'markersize'      = see MATLAB standard line properties
 %   'markerfacecolor' = see MATLAB standard line properties
 %   'style'           = see MATLAB standard line properties
 %   'tag'             = string, the name assigned to the object. All tags with the same name can be deleted in a figure, without deleting other parts of the figure.
 %   'box'             = draw a box around the local axes, can be 'yes' or 'no'
-%   'facealpha'       = transparency value between 0 and 1
 %
 % The line color can be specified in a variety of ways
 %   - as a string with one character per line that you want to plot. Supported colors are teh same as in PLOT, i.e. 'bgrcmykw'.
@@ -133,6 +134,8 @@ fontsize        = ft_getopt(varargin, 'fontsize',   get(0, 'defaulttextfontsize'
 fontname        = ft_getopt(varargin, 'fontname',   get(0, 'defaulttextfontname'));
 fontweight      = ft_getopt(varargin, 'fontweight', get(0, 'defaulttextfontweight'));
 fontunits       = ft_getopt(varargin, 'fontunits',  get(0, 'defaulttextfontunits'));
+% FIXME these are now only used for the highlighted box, but shoudl also be used for the difference 
+facecolor       = ft_getopt(varargin, 'facecolor', [0.6 0.6 0.6]);
 facealpha       = ft_getopt(varargin, 'facealpha', 1);
 
 % if any(size(vdat)==1)
@@ -287,7 +290,7 @@ switch highlightstyle
     for i=1:length(begsample)
       begx = hdat(begsample(i));
       endx = hdat(endsample(i));
-      ft_plot_box([begx endx vpos-height/2 vpos+height/2], 'facecolor', [.6 .6 .6], 'edgecolor', 'none', 'parent', parent, 'facealpha', facealpha);
+      ft_plot_box([begx endx vpos-height/2 vpos+height/2], 'facecolor', facecolor, , 'facealpha', facealpha, 'edgecolor', 'none', 'parent', parent);
     end
     
   case 'thickness'
@@ -362,7 +365,7 @@ switch highlightstyle
     for i=1:length(begsample)
       X = [hdatbeg(1,begsample(i)) hdat(1,begsample(i):endsample(i)) hdatend(1,endsample(i)) hdatend(1,endsample(i)) hdat(1,endsample(i):-1:begsample(i)) hdatbeg(1,begsample(i))];
       Y = [vdatbeg(1,begsample(i)) vdat(1,begsample(i):endsample(i)) vdatend(1,endsample(i)) vdatend(2,endsample(i)) vdat(2,endsample(i):-1:begsample(i)) vdatbeg(2,begsample(i))];
-      h = patch(X, Y, [.6 .6 .6]);
+      h = patch(X, Y, [.6 .6 .6]); % FIXME this should also use ... 'facecolor', facecolor, , 'facealpha', facealpha
       set(h, 'linestyle', 'no');
       if ~isempty(parent)
         set(h, 'Parent', parent);

--- a/plotting/ft_plot_vector.m
+++ b/plotting/ft_plot_vector.m
@@ -19,6 +19,7 @@ function [varargout] = ft_plot_vector(varargin)
 %   'style'           = see MATLAB standard line properties
 %   'tag'             = string, the name assigned to the object. All tags with the same name can be deleted in a figure, without deleting other parts of the figure.
 %   'box'             = draw a box around the local axes, can be 'yes' or 'no'
+%   'facealpha'       = transparency value between 0 and 1
 %
 % The line color can be specified in a variety of ways
 %   - as a string with one character per line that you want to plot. Supported colors are teh same as in PLOT, i.e. 'bgrcmykw'.
@@ -132,7 +133,7 @@ fontsize        = ft_getopt(varargin, 'fontsize',   get(0, 'defaulttextfontsize'
 fontname        = ft_getopt(varargin, 'fontname',   get(0, 'defaulttextfontname'));
 fontweight      = ft_getopt(varargin, 'fontweight', get(0, 'defaulttextfontweight'));
 fontunits       = ft_getopt(varargin, 'fontunits',  get(0, 'defaulttextfontunits'));
-maskfacealpha   = ft_getopt(varargin, 'maskfacealpha', 1);
+facealpha       = ft_getopt(varargin, 'facealpha', 1);
 
 % if any(size(vdat)==1)
 %   % ensure that it is a column vector
@@ -286,7 +287,7 @@ switch highlightstyle
     for i=1:length(begsample)
       begx = hdat(begsample(i));
       endx = hdat(endsample(i));
-      ft_plot_box([begx endx vpos-height/2 vpos+height/2], 'facecolor', [.6 .6 .6], 'edgecolor', 'none', 'parent', parent, 'facealpha', maskfacealpha);
+      ft_plot_box([begx endx vpos-height/2 vpos+height/2], 'facecolor', [.6 .6 .6], 'edgecolor', 'none', 'parent', parent, 'facealpha', facealpha);
     end
     
   case 'thickness'

--- a/plotting/ft_plot_vector.m
+++ b/plotting/ft_plot_vector.m
@@ -132,6 +132,7 @@ fontsize        = ft_getopt(varargin, 'fontsize',   get(0, 'defaulttextfontsize'
 fontname        = ft_getopt(varargin, 'fontname',   get(0, 'defaulttextfontname'));
 fontweight      = ft_getopt(varargin, 'fontweight', get(0, 'defaulttextfontweight'));
 fontunits       = ft_getopt(varargin, 'fontunits',  get(0, 'defaulttextfontunits'));
+facealpha       = ft_getopt(varargin, 'facealpha', 1);
 
 % if any(size(vdat)==1)
 %   % ensure that it is a column vector
@@ -285,7 +286,7 @@ switch highlightstyle
     for i=1:length(begsample)
       begx = hdat(begsample(i));
       endx = hdat(endsample(i));
-      ft_plot_box([begx endx vpos-height/2 vpos+height/2], 'facecolor', [.6 .6 .6], 'edgecolor', 'none', 'parent', parent);
+      ft_plot_box([begx endx vpos-height/2 vpos+height/2], 'facecolor', [.6 .6 .6], 'edgecolor', 'none', 'parent', parent, 'facealpha', facealpha);
     end
     
   case 'thickness'

--- a/plotting/ft_plot_vector.m
+++ b/plotting/ft_plot_vector.m
@@ -132,7 +132,7 @@ fontsize        = ft_getopt(varargin, 'fontsize',   get(0, 'defaulttextfontsize'
 fontname        = ft_getopt(varargin, 'fontname',   get(0, 'defaulttextfontname'));
 fontweight      = ft_getopt(varargin, 'fontweight', get(0, 'defaulttextfontweight'));
 fontunits       = ft_getopt(varargin, 'fontunits',  get(0, 'defaulttextfontunits'));
-facealpha       = ft_getopt(varargin, 'facealpha', 1);
+maskfacealpha   = ft_getopt(varargin, 'maskfacealpha', 1);
 
 % if any(size(vdat)==1)
 %   % ensure that it is a column vector
@@ -286,7 +286,7 @@ switch highlightstyle
     for i=1:length(begsample)
       begx = hdat(begsample(i));
       endx = hdat(endsample(i));
-      ft_plot_box([begx endx vpos-height/2 vpos+height/2], 'facecolor', [.6 .6 .6], 'edgecolor', 'none', 'parent', parent, 'facealpha', facealpha);
+      ft_plot_box([begx endx vpos-height/2 vpos+height/2], 'facecolor', [.6 .6 .6], 'edgecolor', 'none', 'parent', parent, 'facealpha', maskfacealpha);
     end
     
   case 'thickness'


### PR DESCRIPTION
It'd be nice to allow facealpha option in ft_plot_vector to allow transparencies when you want to plot significance in your stats. Here an example:

cfg = [];
% cfg.zlim        = [0 90];
cfg.elec          = elec;
cfg.colorbar      = 'no';
cfg.maskparameter = 'mask';  % use the thresholded probability to mask the data
cfg.maskstyle     = 'box';
cfg.parameter     = 'powspctrm_b';
cfg.maskfacealpha = 0.1;
figure;ft_multiplotER(cfg,base_sedation_avg,mild_sedation_avg,mode_sedation_avg,reco_sedation_avg)

