### PR TITLE
ENH: added option to map right hemisphere electrodes onto the left 

### DIFF
--- a/ft_electroderealign.m
+++ b/ft_electroderealign.m
@@ -623,7 +623,7 @@ end % if method
 switch cfg.method
   case {'template', 'headshape'}
     if strcmpi(cfg.warp, 'dykstra2012') || strcmpi(cfg.warp, 'hermes2010') || ...
-        strcmpi(cfg.warp, 'fsaverage') || strcmpi(cfg.warp, 'fsinflated') || strcmpi(cfg.warp, 'fsaverage_sym')
+        strcmpi(cfg.warp, 'fsaverage') || strcmpi(cfg.warp, 'fsaverage_sym') || strcmpi(cfg.warp, 'fsinflated')
       elec_realigned = norm;
       elec_realigned.label = label_original;
     else
@@ -679,6 +679,8 @@ switch cfg.method
         elec_realigned.coordsys = elec_original.coordsys;
       elseif strcmp(cfg.warp, 'fsaverage')
         elec_realigned.coordsys = 'fsaverage';
+      elseif strcmp(cfg.warp, 'fsaverage_sym')
+        elec_realigned.coordsys = 'fsaverage_sym';
       end
     end
   case 'fiducial'

--- a/ft_electroderealign.m
+++ b/ft_electroderealign.m
@@ -409,7 +409,9 @@ elseif strcmp(cfg.method, 'headshape')
   elseif strcmp(cfg.warp, 'fsaverage')
     norm.elecpos = warp_fsaverage(cfg, elec);
   elseif strcmp(cfg.warp, 'fsinflated')
-    norm.elecpos = warp_fsinflated(cfg, elec); 
+    norm.elecpos = warp_fsinflated(cfg, elec);
+  elseif strcmp(cfg.warp, 'fsaverage_sym')
+    norm.elecpos = warp_fsaverage_sym(cfg, elec); 
   else
     fprintf('warping electrodes to skin surface... '); % the newline comes later
     [norm.elecpos, norm.m] = ft_warp_optim(elec.elecpos, headshape, cfg.warp);
@@ -619,7 +621,8 @@ end % if method
 % electrode labels by their case-sensitive original values
 switch cfg.method
   case {'template', 'headshape'}
-    if strcmpi(cfg.warp, 'dykstra2012') || strcmpi(cfg.warp, 'hermes2010') || strcmpi(cfg.warp, 'fsaverage') || strcmpi(cfg.warp, 'fsinflated')
+    if strcmpi(cfg.warp, 'dykstra2012') || strcmpi(cfg.warp, 'hermes2010') || ...
+        strcmpi(cfg.warp, 'fsaverage') || strcmpi(cfg.warp, 'fsinflated') || strcmpi(cfg.warp, 'fsaverage_sym')
       elec_realigned = norm;
       elec_realigned.label = label_original;
     else

--- a/ft_electroderealign.m
+++ b/ft_electroderealign.m
@@ -55,8 +55,9 @@ function [elec_realigned] = ft_electroderealign(cfg, elec_original)
 %                        'nonlin4'         apply a 4th order non-linear warp
 %                        'nonlin5'         apply a 5th order non-linear warp
 %                        'dykstra2012'     non-linear wrap only for headshape method, useful for projecting ECoG onto cortex hull
-%                        'fsaverage'       surface-based realignment with FreeSurfer fsaverage brain
-%                        'fsinflated'      surface-based realignment with FreeSurfer individual subject inflated brain
+%                        'fsaverage'       surface-based realignment with FreeSurfer fsaverage brain (left->left or right->right)
+%                        'fsaverage_sym'   surface-based realignment with FreeSurfer fsaverage_sym left hemisphere (left->left or right->left)
+%                        'fsinflated'      surface-based realignment with FreeSurfer individual subject inflated brain (left->left or right->right)
 %   cfg.channel        = Nx1 cell-array with selection of channels (default = 'all'),
 %                        see  FT_CHANNELSELECTION for details
 %   cfg.keepchannel    = string, 'yes' or 'no' (default = 'no')
@@ -408,10 +409,10 @@ elseif strcmp(cfg.method, 'headshape')
     norm.elecpos = warp_hermes2010(cfg, elec, headshape);
   elseif strcmp(cfg.warp, 'fsaverage')
     norm.elecpos = warp_fsaverage(cfg, elec);
+  elseif strcmp(cfg.warp, 'fsaverage_sym')
+    norm.elecpos = warp_fsaverage_sym(cfg, elec);
   elseif strcmp(cfg.warp, 'fsinflated')
     norm.elecpos = warp_fsinflated(cfg, elec);
-  elseif strcmp(cfg.warp, 'fsaverage_sym')
-    norm.elecpos = warp_fsaverage_sym(cfg, elec); 
   else
     fprintf('warping electrodes to skin surface... '); % the newline comes later
     [norm.elecpos, norm.m] = ft_warp_optim(elec.elecpos, headshape, cfg.warp);

--- a/private/warp_fsaverage_sym.m
+++ b/private/warp_fsaverage_sym.m
@@ -1,6 +1,6 @@
-function [coord_norm] = warp_fsaverage(cfg, elec)
+function [coord_norm] = warp_fsaverage_sym(cfg, elec)
 
-% WARP_FSAVERAGE maps electrodes onto FreeSurfer's fsaverage brain.
+% WARP_FSAVERAGE_SYM maps electrodes onto FreeSurfer's fsaverage brain.
 % This surface-based registration technique solely considers the curvature
 % patterns of the cortex and thus can be used for the spatial normalization
 % of electrodes located on or near the cortical surface. To perform
@@ -40,8 +40,8 @@ subj_reg = ft_read_headshape([PATHSTR filesep NAME '.sphere.reg']);
 if ~isfolder([cfg.fshome filesep 'subjects' filesep 'fsaverage' filesep 'surf'])
   ft_error(['freesurfer dir ' cfg.fshome filesep 'subjects' filesep 'fsaverage' filesep 'surf cannot be found'])
 end
-fsavg_pial = ft_read_headshape([cfg.fshome filesep 'subjects' filesep 'fsaverage' filesep 'surf' filesep NAME '.pial']);
-fsavg_reg = ft_read_headshape([cfg.fshome filesep 'subjects' filesep 'fsaverage' filesep 'surf' filesep NAME '.sphere.reg']);
+fsavg_pial = ft_read_headshape([cfg.fshome filesep 'subjects' filesep 'fsaverage_sym' filesep 'surf' filesep 'lh.pial']);
+fsavg_reg = ft_read_headshape([cfg.fshome filesep 'subjects' filesep 'fsaverage_sym' filesep 'surf' filesep 'lh.sphere']);
 
 for e = 1:numel(elec.label)
   % subject space (3D surface): electrode pos -> vertex index

--- a/private/warp_fsaverage_sym.m
+++ b/private/warp_fsaverage_sym.m
@@ -3,9 +3,9 @@ function [coord_norm] = warp_fsaverage_sym(cfg, elec)
 % WARP_FSAVERAGE_SYM maps left or right hemisphere electrodes onto 
 % FreeSurfer's fsaverage_sym's left hemisphere. To perform this mapping, 
 % you first need to have processed the subject's MRI with FreeSurfer's 
-% recon-all functionality and additionaly registered the subject's resulting 
-% surfaces to freesurfer fsaverage_sym template as described at
-% https://surfer.nmr.mgh.harvard.edu/fswiki/Xhemi
+% recon-all functionality and additionaly have registered the subject's resulting 
+% surfaces to freesurfer fsaverage_sym template using surfreg as described 
+% in section 1.2 of https://surfer.nmr.mgh.harvard.edu/fswiki/Xhemi
 %
 % The configuration must contain the following options
 %   cfg.headshape      = string, filename containing subject headshape
@@ -39,7 +39,7 @@ subj_pial = ft_read_headshape(cfg.headshape);
 if strcmp(NAME, 'lh')
   subj_reg = ft_read_headshape([PATHSTR filesep 'lh.fsaverage_sym.sphere.reg']);
 elseif strcmp(NAME, 'rh')
-  subj_reg = ft_read_headshape([PATHSTR(1:strfind(PATHSTR, [filesep 'surf'])-1) filesep 'xhemi' filesep 'surf' filesep 'lh.fsaverage_sym.sphere.reg']); % FIXME pathstr wont work
+  subj_reg = ft_read_headshape([PATHSTR(1:strfind(PATHSTR, [filesep 'surf'])-1) filesep 'xhemi' filesep 'surf' filesep 'lh.fsaverage_sym.sphere.reg']);
 end
 if ~isfolder([cfg.fshome filesep 'subjects' filesep 'fsaverage_sym']) || ~isfolder([PATHSTR(1:strfind(PATHSTR, [filesep 'surf'])-1) filesep 'xhemi'])
   ft_error(['fsaverage_sym and/or xhemi folders cannot be found'])

--- a/private/warp_fsaverage_sym.m
+++ b/private/warp_fsaverage_sym.m
@@ -1,20 +1,20 @@
 function [coord_norm] = warp_fsaverage_sym(cfg, elec)
 
-% WARP_FSAVERAGE_SYM maps electrodes onto FreeSurfer's fsaverage brain.
-% This surface-based registration technique solely considers the curvature
-% patterns of the cortex and thus can be used for the spatial normalization
-% of electrodes located on or near the cortical surface. To perform
-% surface-based normalization, you first need to process the subject's MRI
-% with FreeSurfer's recon-all functionality.
+% WARP_FSAVERAGE_SYM maps left or right hemisphere electrodes onto 
+% FreeSurfer's fsaverage_sym's left hemisphere. To perform this mapping, 
+% you first need to have processed the subject's MRI with FreeSurfer's 
+% recon-all functionality and additionaly registered the subject's resulting 
+% surfaces to freesurfer fsaverage_sym template as described at
+% https://surfer.nmr.mgh.harvard.edu/fswiki/Xhemi
 %
 % The configuration must contain the following options
-%   cfg.headshape      = string, filename containing subject headshape 
+%   cfg.headshape      = string, filename containing subject headshape
 %                      (e.g. <path to freesurfer/surf/lh.pial>)
 %   cfg.fshome         = string, path to freesurfer
 %
-% See also FT_ELECTRODEREALIGN, FT_PREPARE_MESH
+% See also FT_ELECTRODEREALIGN, WARP_FSAVERAGE
 
-% Copyright (C) 2017, Arjen Stolk
+% Copyright (C) 2019, Arjen Stolk
 %
 % This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
 % for the documentation and details.
@@ -36,12 +36,16 @@ function [coord_norm] = warp_fsaverage_sym(cfg, elec)
 
 subj_pial = ft_read_headshape(cfg.headshape);
 [PATHSTR, NAME] = fileparts(cfg.headshape); % lh or rh
-subj_reg = ft_read_headshape([PATHSTR filesep NAME '.sphere.reg']);
-if ~isfolder([cfg.fshome filesep 'subjects' filesep 'fsaverage' filesep 'surf'])
-  ft_error(['freesurfer dir ' cfg.fshome filesep 'subjects' filesep 'fsaverage' filesep 'surf cannot be found'])
+if strcmp(NAME, 'lh')
+  subj_reg = ft_read_headshape([PATHSTR filesep 'lh.fsaverage_sym.sphere.reg']);
+elseif strcmp(NAME, 'rh')
+  subj_reg = ft_read_headshape([PATHSTR(1:strfind(PATHSTR, [filesep 'surf'])-1) filesep 'xhemi' filesep 'surf' filesep 'lh.fsaverage_sym.sphere.reg']); % FIXME pathstr wont work
+end
+if ~isfolder([cfg.fshome filesep 'subjects' filesep 'fsaverage_sym']) || ~isfolder([PATHSTR(1:strfind(PATHSTR, [filesep 'surf'])-1) filesep 'xhemi'])
+  ft_error(['fsaverage_sym and/or xhemi folders cannot be found'])
 end
 fsavg_pial = ft_read_headshape([cfg.fshome filesep 'subjects' filesep 'fsaverage_sym' filesep 'surf' filesep 'lh.pial']);
-fsavg_reg = ft_read_headshape([cfg.fshome filesep 'subjects' filesep 'fsaverage_sym' filesep 'surf' filesep 'lh.sphere']);
+fsavg_reg = ft_read_headshape([cfg.fshome filesep 'subjects' filesep 'fsaverage_sym' filesep 'surf' filesep 'lh.sphere.reg']); % always map onto the left hemi
 
 for e = 1:numel(elec.label)
   % subject space (3D surface): electrode pos -> vertex index


### PR DESCRIPTION
Freesurfer comes with a fsaverage_sym brain that is symmetrical across the two hemispheres.
Warp_fsaverage_sym allows mapping electrodes onto the left hemisphere of this fsaverage_sym brain, irrespectively of whether those electrodes were originally on the left or right hemisphere of the subject. That way, group comparison of different ECoG subjects is facilitated.