### PR TITLE
show the location in ft_sourceplot consistently

### DIFF
--- a/ft_sourceplot.m
+++ b/ft_sourceplot.m
@@ -1478,13 +1478,33 @@ opt.ijk = opt.ijk(1:3);
 str1 = sprintf('voxel %d, indices [%d %d %d]', sub2ind(functional.dim(1:3), xi, yi, zi), opt.ijk);
 
 if isfield(functional, 'coordsys') && isfield(functional, 'unit')
-  str2 = sprintf('%s coordinates [%.1f %.1f %.1f] %s', functional.coordsys, xyz(1:3), functional.unit);
+  % print the location with mm accuracy
+  switch functional.unit
+    case 'm'
+      str2 = sprintf('%s coordinates [%.3f %.3f %.3f] %s', functional.coordsys, xyz(1:3), functional.unit);
+    case 'cm'
+      str2 = sprintf('%s coordinates [%.1f %.1f %.1f] %s', functional.coordsys, xyz(1:3), functional.unit);
+    case 'mm'
+      str2 = sprintf('%s coordinates [%.0f %.0f %.0f] %s', functional.coordsys, xyz(1:3), functional.unit);
+    otherwise
+      str2 = sprintf('%s coordinates [%f %f %f] %s', functional.coordsys, xyz(1:3), functional.unit);
+  end
 elseif ~isfield(functional, 'coordsys') && isfield(functional, 'unit')
-  str2 = sprintf('location [%.1f %.1f %.1f] %s', xyz(1:3), functional.unit);
+  % print the location with mm accuracy
+  switch functional.unit
+    case 'm'
+      str2 = sprintf('location [%.3f %.3f %.3f] %s', xyz(1:3), functional.unit);
+    case 'cm'
+      str2 = sprintf('location [%.1f %.1f %.1f] %s', xyz(1:3), functional.unit);
+    case 'mm'
+      str2 = sprintf('location [%.0f %.0f %.0f] %s', xyz(1:3), functional.unit);
+    otherwise
+      str2 = sprintf('location [%f %f %f] %s', xyz(1:3), functional.unit);
+  end
 elseif isfield(functional, 'coordsys') && ~isfield(functional, 'unit')
-  str2 = sprintf('%s coordinates [%.1f %.1f %.1f]', functional.coordsys, xyz(1:3));
+  str2 = sprintf('%s coordinates [%.3f %.3f %.3f]', functional.coordsys, xyz(1:3));
 elseif ~isfield(functional, 'coordsys') && ~isfield(functional, 'unit')
-  str2 = sprintf('location [%.1f %.1f %.1f]', xyz(1:3));
+  str2 = sprintf('location [%.3f %.3f %.3f]', xyz(1:3));
 else
   str2 = '';
 end

--- a/utilities/private/getdimord.m
+++ b/utilities/private/getdimord.m
@@ -324,7 +324,7 @@ switch field
       dimord = 'pos_freq_time';
     end
     
-  case {'pow' 'noise' 'rv'}
+  case {'pow' 'noise' 'rv' 'nai'}
     if isequal(datsiz, [npos ntime])
       dimord = 'pos_time';
     elseif isequal(datsiz, [npos nfreq])


### PR DESCRIPTION
it was hardcoded as showing one digit after the comma which is fine for cm, but not for m. I changed it so that the displayed accuracy is always mm, regardless of the units.

There is another minor unrelated commit.

 