### PR TITLE
FIX: removed preamble and postamble

### DIFF
--- a/besa2fieldtrip.m
+++ b/besa2fieldtrip.m
@@ -44,15 +44,6 @@ function data = besa2fieldtrip(input)
 %
 % $Id$
 
-% these are used by the ft_preamble/ft_postamble function and scripts
-ft_revision = '$Id$';
-ft_nargin   = nargin;
-ft_nargout  = nargout;
-
-% do the general setup of the function
-ft_defaults
-ft_preamble callinfo
-
 if isstruct(input) && numel(input)>1
   % use a recursive call to convert multiple inputs
   data = cell(size(input));
@@ -381,10 +372,6 @@ elseif isstruct(input) && ~isfield(input, 'datafile')
 elseif ischar(input)
   cfg.filename = input;
 end
-
-% do the general cleanup and bookkeeping at the end of the function
-ft_postamble callinfo
-ft_postamble history data
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/besa2fieldtrip.m
+++ b/besa2fieldtrip.m
@@ -362,18 +362,6 @@ elseif ischar(input)
 end % isstruct || ischar
 
 
-% construct and add a configuration to the output
-cfg = [];
-
-if isstruct(input) && isfield(input, 'datafile')
-  cfg.filename = input.datafile;
-elseif isstruct(input) && ~isfield(input, 'datafile')
-  cfg.filename = 'Unknown';
-elseif ischar(input)
-  cfg.filename = input;
-end
-
-
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % SUBFUNCTION that fixes the channel labels, should be a cell-array
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/loreta2fieldtrip.m
+++ b/loreta2fieldtrip.m
@@ -136,8 +136,3 @@ else
   source.mom  = activity(lorind);
   fprintf('returning the activity at one timepoint as a single distribution of power\n');
 end
-
-% add the options used here to the configuration
-cfg = [];
-cfg.timeframe = timeframe;
-cfg.filename  = filename;

--- a/loreta2fieldtrip.m
+++ b/loreta2fieldtrip.m
@@ -38,14 +38,8 @@ function source = loreta2fieldtrip(filename, varargin)
 %
 % $Id$
 
-% these are used by the ft_preamble/ft_postamble function and scripts
-ft_revision = '$Id$';
-ft_nargin   = nargin;
-ft_nargout  = nargout;
-
 % do the general setup of the function
 ft_defaults
-ft_preamble callinfo
 
 is_txt = ft_filetype(filename, 'ascii_txt'); %FIXME text file only implemented for slor, don't know what text files look for for old loreta
 
@@ -147,7 +141,3 @@ end
 cfg = [];
 cfg.timeframe = timeframe;
 cfg.filename  = filename;
-
-% do the general cleanup and bookkeeping at the end of the function
-ft_postamble callinfo
-ft_postamble history source

--- a/spass2fieldtrip.m
+++ b/spass2fieldtrip.m
@@ -126,9 +126,6 @@ end
 stm = stm.data{1}(:);
 bhv = bhv.data{1}(:);
 
-% store some additional information in the cfg structure
-cfg = [];
-
 % remember where the lfp trials are on the imaginary continuous timeaxis,
 % this links both the LFP and the spike timestamps to a common continuous
 % timeaxis
@@ -139,7 +136,6 @@ for i=1:ntrials
   offset    = 0;
   trl(i,:) = [begsample endsample offset];
 end
-cfg.trl = trl;
 
 % store the header information
 lfp.hdr.FirstTimeStamp = 0;

--- a/spass2fieldtrip.m
+++ b/spass2fieldtrip.m
@@ -38,16 +38,6 @@ function [lfp, spike, stm, bhv] = spass2fieldtrip(dirname, varargin)
 %
 % $Id$
 
-% these are used by the ft_preamble/ft_postamble function and scripts
-ft_revision = '$Id$';
-ft_nargin   = nargin;
-ft_nargout  = nargout;
-
-% do the general setup of the function
-ft_defaults
-ft_preamble init
-ft_preamble provenance
-
 fsample_ana = ft_getopt(varargin, 'fsample_ana', 1000);
 fsample_swa = ft_getopt(varargin, 'fsample_swa', 32000);
 
@@ -154,7 +144,3 @@ cfg.trl = trl;
 % store the header information
 lfp.hdr.FirstTimeStamp = 0;
 lfp.hdr.TimeStampPerSample = fsample_swa./fsample_ana;
-
-% do the general cleanup and bookkeeping at the end of the function
-ft_postamble provenance lfp spike
-ft_postamble history lfp spike


### PR DESCRIPTION
Following a bug reported on the mailing list: 

Hello, Arjen. 

Yes, I did add fieldtrip and its subdirectories but I'm encountering the same error: 

>> addpath C:\Toolbox\fieldtrip-20190113
>> ft_defaults
>> loreta2fieldtrip
다음 사용 중 오류가 발생함: ft_preamble (line 80)
Could not run ft_preamble_callinfo - does not seem to exist

오류 발생: loreta2fieldtrip (line 48)
ft_preamble callinfo
 
Should I install any external toolbox for preamble/postamble or are they already inside the default?

Thanks,
Eunchan