### PR TITLE
Sourceplot boundary

### DIFF
--- a/bin/synchronize-private.sh
+++ b/bin/synchronize-private.sh
@@ -147,6 +147,14 @@ ARRAY+=(utilities/private/channelposition.m)
 sync ${ARRAY[*]}
 
 ################################################################################
+# combineClusters.m
+
+ARRAY=()
+ARRAY+=(private/combineClusters.m)
+ARRAY+=(plotting/private/combineClusters.m)
+sync ${ARRAY[*]} 
+
+################################################################################
 # combineClusters.mexa64
 
 ARRAY=()
@@ -415,6 +423,14 @@ ARRAY=()
 ARRAY+=(preproc/private/filter_with_correction.m)
 ARRAY+=(specest/private/filter_with_correction.m)
 sync ${ARRAY[*]}
+
+################################################################################
+# findcluster.m
+
+ARRAY=()
+ARRAY+=(private/findcluster.m)
+ARRAY+=(plotting/private/findcluster.m)
+sync ${ARRAY[*]} 
 
 ################################################################################
 # find_innermost_boundary.m
@@ -3420,6 +3436,15 @@ ARRAY+=(plotting/private/translate.m)
 ARRAY+=(private/translate.m)
 ARRAY+=(utilities/private/translate.m)
 sync ${ARRAY[*]}
+
+################################################################################
+# triangle2connectivity.m
+
+ARRAY=()
+ARRAY+=(private/triangle2connectivity.m)
+ARRAY+=(plotting/private/triangle2connectivity.m)
+sync ${ARRAY[*]}
+
 
 ################################################################################
 # triangle4pt.m

--- a/plotting/ft_plot_mesh.m
+++ b/plotting/ft_plot_mesh.m
@@ -36,6 +36,12 @@ function [hs] = ft_plot_mesh(mesh, varargin)
 %   ft_plot_mesh(mesh, 'facecolor', 'skin', 'edgecolor', 'none')
 %   camlight
 %
+% You can plot an additional contour around specified areas using
+%   'contour'           = inside of contour per vertex, either 0 or 1
+%   'contourcolor'      = string, color specification
+%   'contourlinestyle'  = string, line specification 
+%   'contourlinewidth'  = number
+%
 % See also FT_PLOT_HEADSHAPE, FT_PLOT_VOL, TRIMESH, PATCH
 
 % Copyright (C) 2009, Cristiano Micheli
@@ -479,7 +485,6 @@ if vertexindex
     hs = [hs; h];
   end
 end
-
 
 axis off
 axis vis3d

--- a/plotting/ft_plot_mesh.m
+++ b/plotting/ft_plot_mesh.m
@@ -333,9 +333,9 @@ end
 if numel(contour)>1 && any(contour)
     cfg                 = [];
     cfg.connectivity    = triangle2connectivity(tri);
-    channeighbstructmat = full(ft_getopt(cfg, 'connectivity', false));
+    neighcmb            = full(ft_getopt(cfg, 'connectivity', false));
     
-    posclusobs = findcluster(contour,channeighbstructmat,0);%minnbchan=0
+    posclusobs = findcluster(contour,neighcmb,0);%minnbchan=0
     
     for cl = 1:max(posclusobs)
         idxcl = find(posclusobs==cl);

--- a/plotting/ft_plot_mesh.m
+++ b/plotting/ft_plot_mesh.m
@@ -346,11 +346,14 @@ if numel(boundary)>1 && any(boundary)
         end
     end
     hold on
-    
+    % get flatmap info
+    flatmap = ft_getopt(varargin, 'flatmap', []);
+    pnt = flatmap.pnt;
     for cl = 1:max(unique(cluster))
        %(for each cluster) find "boundary" vertices
         indxmask = find(cluster==cl);
         boundpnt = []; 
+        boundpnt_flat = [];
         for i = 1:length(indxmask)
             v = indxmask(i);
             neigh = find(connmat(v,:));
@@ -359,13 +362,14 @@ if numel(boundary)>1 && any(boundary)
                 % For each boundary vertex
                 % Compute new point that lies in between inner and outer
                 % vertex
-                boundpnt = [boundpnt;pos(v,:) - (pos(v,:) - pos(outneigh,:))*boundary(v)];              
+                boundpnt = [boundpnt;pos(v,:) - (pos(v,:) - pos(outneigh,:))*boundary(v)]; 
+                % use flatmap for later sorting
+                boundpnt_flat = [boundpnt_flat;pnt(v,:) - (pnt(v,:) - pnt(outneigh,:))*boundary(v)]; 
             end
         end
-        %sort points simply ignoring 3rd dimension, better would be
-        %projection to 2D, but might still fail
-        c = mean(boundpnt',2);
-        d = bsxfun(@minus, boundpnt',c);
+        %sort points based on flatmap geometry
+        c = mean(boundpnt_flat',2);
+        d = bsxfun(@minus, boundpnt_flat',c);
         th = atan2(d(2,:),d(1,:));
         [~,si] = sort(th);
         boundpnt = boundpnt(si,:);

--- a/plotting/ft_plot_mesh.m
+++ b/plotting/ft_plot_mesh.m
@@ -344,21 +344,28 @@ if numel(boundary)>1 && any(boundary)
         indx2 = any(ismember(tri,indxmask)'); % inner vertex connections
         indxnew = find(indx1 & indx2);
         allpos = [];
-        alledges = [];
+        cnt = 1;
         for  i = 1:length(indxnew)
             indx = ismember(tri(indxnew(i),:),indxmask);
             newpos = pos(tri(indxnew(i),indx),:) - ((pos(tri(indxnew(i),indx),:) - pos(tri(indxnew(i),~indx),:))*0.5);
             p(i) = patch(newpos(:,1),newpos(:,2),newpos(:,3),NaN);
-            allpos = [allpos; newpos];
-            if mod(i,2) == 1
-                alledges = [alledges; i i+1]; 
+            %{
+            if i == 1, allpos = [allpos; newpos]; alledges = [1 2];end
+            [q,idx] = ismember(allpos,newpos,'rows');
+            n = size(allpos,1);
+            if sum(q) == 1
+                newpos(idx(q),:) = [];
+                alledges = [alledges; find(q) n+1];
+                allpos = [allpos; newpos];
+            elseif sum(q) == 0
+                alledges = [alledges; n+1 n+2];
+                allpos = [allpos; newpos];
             end
+            %}
         end
-        %p = patch('Faces', alledges,'Vertices',allpos,'EdgeColor','g')
-        % first collecting all new points and edges does not work
-
-        set(p(:),'EdgeColor','k');
-        set(p(:),'LineStyle','-');
+        %p = patch('Faces', alledges,'Vertices',allpos);
+        %set(p(:),'EdgeColor','k');
+        %set(p(:),'LineStyle','-');
         set(p(:),'LineWidth',2);
     end
 end

--- a/plotting/ft_plot_mesh.m
+++ b/plotting/ft_plot_mesh.m
@@ -357,8 +357,9 @@ if numel(boundary)>1 && any(boundary)
             outneigh = neigh(boundary(neigh)==0);
             if ~isempty(outneigh) && length(outneigh)> 2
                 % For each boundary vertex
-                % Compute new point that lies in between inner and outer vertex
-                boundpnt = [boundpnt;pos(v,:) + (pos(v,:) - pos(outneigh,:))*boundary(v)];
+                % Compute new point that lies in between inner and outer
+                % vertex
+                boundpnt = [boundpnt;pos(v,:) - (pos(v,:) - pos(outneigh,:))*boundary(v)];              
             end
         end
         %sort points simply ignoring 3rd dimension, better would be

--- a/plotting/ft_plot_mesh.m
+++ b/plotting/ft_plot_mesh.m
@@ -319,7 +319,7 @@ switch maskstyle
     if ~isempty(clim); caxis(clim); end % set colorbar scale to match [fcolmin fcolmax]
 end
 
-if numel(boundary)>1
+if numel(boundary)>1 && any(boundary)
     connmat = triangle2connectivity(tri);
     indxmask = find(boundary);
     clustercnt = 0;
@@ -361,7 +361,8 @@ if numel(boundary)>1
                 boundpnt = [boundpnt;pos(v,:) + (pos(v,:) - pos(outneigh,:))*boundary(v)];
             end
         end
-        %sort points 
+        %sort points simply ignoring 3rd dimension, better would be
+        %projection to 2D, but might still fail
         c = mean(boundpnt',2);
         d = bsxfun(@minus, boundpnt',c);
         th = atan2(d(2,:),d(1,:));

--- a/plotting/private/combineClusters.m
+++ b/plotting/private/combineClusters.m
@@ -1,0 +1,39 @@
+function cluster = combineClusters(labelmat, spatdimneighbstructmat, total)
+
+% COMBINECLUSTERS is a helper function for FINDCLUSTER. It searches for
+% adjacent clusters in neighbouring channels and combines them.
+
+% A mex-file is available for this function, as it can take quite long.
+
+replaceby=1:total;
+spatdimlength = size(labelmat, 1);
+for spatdimlev=1:spatdimlength
+  neighbours=find(spatdimneighbstructmat(spatdimlev,:));
+  for nbindx=neighbours
+    indx = find((labelmat(spatdimlev,:)~=0) & (labelmat(nbindx,:)~=0));
+    for i=1:length(indx)
+      a = labelmat(spatdimlev, indx(i));
+      b = labelmat(nbindx, indx(i));
+      if replaceby(a)==replaceby(b)
+        % do nothing
+        continue;
+      elseif replaceby(a)<replaceby(b)
+        % replace all entries with content replaceby(b) by replaceby(a).
+        replaceby(find(replaceby==replaceby(b))) = replaceby(a); 
+      elseif replaceby(b)<replaceby(a)
+        % replace all entries with content replaceby(a) by replaceby(b).
+        replaceby(find(replaceby==replaceby(a))) = replaceby(b); 
+      end
+    end
+  end
+end
+
+% renumber all the clusters
+num = 0;
+cluster = zeros(size(labelmat));
+for uniquelabel=unique(replaceby(:))'
+  num = num+1;
+  cluster(ismember(labelmat(:),find(replaceby==uniquelabel))) = num;
+end
+
+end

--- a/plotting/private/extract_contour.m
+++ b/plotting/private/extract_contour.m
@@ -1,0 +1,41 @@
+ function [X, Y, Z] = extract_contour(pos, tri, indx, mask)
+
+% EXTRACT_BOUNDARY generates contour around specified vertices of a
+% triangulated surface.
+% It returns the coordinates of the vertices which form the contour
+
+% % Use as
+%   [X, Y, Z] = extract_contour(pos, tri, indx, mask)
+%
+% where mask specifies which vertices are inside or outside the contour
+% and indx contains indices of which vertices should be group within a
+% single contour. The return values are each Nx2 for the N line segments making up the contour.
+
+% Copyright (C) Sophie Arana
+%
+% $Id$
+
+outbnd = [];
+for i = 1:length(indx)
+    %For each vertex in mask
+    [row,~]  = find(tri == (indx(i))); %find neighbours
+    neigh = tri(row,:);
+    neigh = unique(neigh(:));
+    outbnd = [outbnd neigh(mask(neigh)==0)'];
+    outbnd(outbnd==indx(i)) = [];
+end %find all "outer" neighbours to this cluster
+outbnd = unique(outbnd);
+
+indx1 = any(ismember(tri,outbnd)');% outer vertex connections
+indx2 = any(ismember(tri,indx)'); % inner vertex connections
+indxnew = find(indx1 & indx2); % triangles spanning at least one outer & one inner vertex
+
+newpos = [];
+for  i = 1:length(indxnew)
+    idx = ismember(tri(indxnew(i),:),indx);
+    newpos = [newpos ; pos(tri(indxnew(i),idx),:) - ((pos(tri(indxnew(i),idx),:) - pos(tri(indxnew(i),~idx),:))*0.5)];
+end
+n = size(newpos,1);
+X = reshape(newpos(:,1),[2 n/2])';
+Y = reshape(newpos(:,2),[2 n/2])';
+Z = reshape(newpos(:,3),[2 n/2])';

--- a/plotting/private/findcluster.m
+++ b/plotting/private/findcluster.m
@@ -1,0 +1,107 @@
+function [cluster, total] = findcluster(onoff, spatdimneighbstructmat, varargin)
+
+% FINDCLUSTER returns all connected clusters in a 3 dimensional matrix
+% with a connectivity of 6.
+%
+% Use as
+%   [cluster, num] = findcluster(onoff, spatdimneighbstructmat, minnbchan)
+% or ar
+%   [cluster, num] = findcluster(onoff, spatdimneighbstructmat, spatdimneighbselmat, minnbchan)
+% where 
+%   onoff                   is a 3D boolean matrix with size N1xN2xN3
+%   spatdimneighbstructmat  defines the neighbouring channels/combinations, see below
+%   minnbchan               the minimum number of neighbouring channels/combinations 
+%   spatdimneighbselmat     is a special neighbourhood matrix that is used for selecting
+%                           channels/combinations on the basis of the minnbchan criterium
+%
+% The neighbourhood structure for the first dimension is specified using 
+% spatdimneighbstructmat, which is a 2D (N1xN1) matrix. Each row and each column corresponds
+% to a channel (combination) along the first dimension and along that row/column, elements
+% with "1" define the neighbouring channel(s) (combinations). The first dimension of
+% onoff should correspond to the channel(s) (combinations).
+%
+% See also SPM_BWLABEL (spm toolbox) 
+
+% Copyright (C) 2004, Robert Oostenveld
+%
+% This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
+% for the documentation and details.
+%
+%    FieldTrip is free software: you can redistribute it and/or modify
+%    it under the terms of the GNU General Public License as published by
+%    the Free Software Foundation, either version 3 of the License, or
+%    (at your option) any later version.
+%
+%    FieldTrip is distributed in the hope that it will be useful,
+%    but WITHOUT ANY WARRANTY; without even the implied warranty of
+%    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%    GNU General Public License for more details.
+%
+%    You should have received a copy of the GNU General Public License
+%    along with FieldTrip. If not, see <http://www.gnu.org/licenses/>.
+%
+% $Id$
+
+spatdimlength = size(onoff, 1);
+nfreq = size(onoff, 2);
+ntime = size(onoff, 3);
+
+if length(size(spatdimneighbstructmat))~=2 || ~all(size(spatdimneighbstructmat)==spatdimlength)
+  ft_error('invalid dimension of spatdimneighbstructmat');
+end
+
+minnbchan=0;
+if length(varargin)==1
+    minnbchan=varargin{1};
+end
+if length(varargin)==2
+    spatdimneighbselmat=varargin{1};
+    minnbchan=varargin{2};
+end
+
+if minnbchan>0
+    % For every (time,frequency)-element, it is calculated how many significant
+    % neighbours this channel has. If a significant channel has less than minnbchan
+    % significant neighbours, then this channel is removed from onoff.
+    
+    if length(varargin)==1
+        selectmat = single(spatdimneighbstructmat | spatdimneighbstructmat');
+    end
+    if length(varargin)==2
+        selectmat = single(spatdimneighbselmat | spatdimneighbselmat');
+    end
+    nremoved=1;
+    while nremoved>0
+        nsigneighb=reshape(selectmat*reshape(single(onoff),[spatdimlength (nfreq*ntime)]),[spatdimlength nfreq ntime]);
+        remove=(onoff.*nsigneighb)<minnbchan;
+        nremoved=length(find(remove.*onoff));
+        onoff(remove)=0;
+    end
+end
+
+% for each channel (combination), find the connected time-frequency clusters
+labelmat = zeros(size(onoff));
+total = 0;
+if nfreq*ntime>1
+  for spatdimlev=1:spatdimlength
+    [labelmat(spatdimlev, :, :), num] = spm_bwlabel(double(reshape(onoff(spatdimlev, :, :), nfreq, ntime)), 6); % the previous code contained a '4' for input
+    labelmat(spatdimlev, :, :) = labelmat(spatdimlev, :, :) + (labelmat(spatdimlev, :, :)~=0)*total;
+    total = total + num;
+  end
+else
+  labelmat(onoff>0) = 1:sum(onoff(:));
+  total = sum(onoff(:));
+end
+% combine the time and frequency dimension for simplicity
+labelmat = reshape(labelmat, spatdimlength, nfreq*ntime);
+
+% combine clusters that are connected in neighbouring channel(s)
+% (combinations). Convert inputs to uint32 as that is required by the mex
+% file (and the values will be positive integers anyway).
+cluster = combineClusters(uint32(labelmat), logical(spatdimneighbstructmat), uint32(total));
+
+% reshape the output to the original format of the data
+cluster = reshape(cluster, spatdimlength, nfreq, ntime);
+
+% update the total number
+total = numel(unique(cluster(:)))-1; % the value of 0 does not count

--- a/plotting/private/triangle2connectivity.m
+++ b/plotting/private/triangle2connectivity.m
@@ -1,0 +1,68 @@
+function [connmat] = triangle2connectivity(tri, pos)
+
+% TRIANGLE2CONNECTIVITY computes a connectivity-matrix from a triangulation.
+%
+% Use as
+%  [connmat] = triangle2connectivity(tri)
+% or
+%  [connmat] = triangle2connectivity(tri, pos)
+%
+% The input tri is an Mx3 matrix describing a triangulated surface,
+% containing indices to connecting vertices. The output connmat is a sparse
+% logical NxN matrix, with ones, where vertices are connected, and zeros
+% otherwise.
+%
+% If you specify the vertex positions in the second input argument as Nx3
+% matrix, the output will be a sparse matrix with the lengths of the
+% edges between the connected vertices.
+
+% Copyright (C) 2015, Jan-Mathijs Schoffelen
+%
+% This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
+% for the documentation and details.
+%
+%    FieldTrip is free software: you can redistribute it and/or modify
+%    it under the terms of the GNU General Public License as published by
+%    the Free Software Foundation, either version 3 of the License, or
+%    (at your option) any later version.
+%
+%    FieldTrip is distributed in the hope that it will be useful,
+%    but WITHOUT ANY WARRANTY; without even the implied warranty of
+%    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%    GNU General Public License for more details.
+%
+%    You should have received a copy of the GNU General Public License
+%    along with FieldTrip. If not, see <http://www.gnu.org/licenses/>.
+%
+% $Id$
+
+% ensure that the vertices are indexed starting from 1
+if min(tri(:))==0,
+  tri = tri + 1;
+end
+
+% ensure that the vertices are indexed according to 1:number of unique vertices
+tri = tri_reindex(tri);
+
+% create the unique edges from the triangulation
+edges  = [tri(:,[1 2]); tri(:,[1 3]); tri(:,[2 3])];
+edges  = double(unique(sort([edges; edges(:,[2 1])],2), 'rows'));
+
+% fill the connectivity matrix
+n        = size(edges,1);
+if nargin<2
+  % create sparse binary matrix
+  connmat = sparse([edges(:,1);edges(:,2)],[edges(:,2);edges(:,1)],true(2*n,1));
+else
+  % create sparse matrix with edge lengths
+  dpos    = sqrt(sum( (pos(edges(:,1),:) - pos(edges(:,2),:)).^2, 2));
+  connmat = sparse([edges(:,1);edges(:,2)],[edges(:,2);edges(:,1)],[dpos(:);dpos(:)]);
+end
+
+function [newtri] = tri_reindex(tri)
+
+% this subfunction reindexes tri such that they run from 1:number of unique vertices
+newtri       = tri;
+[srt, indx]  = sort(tri(:));
+tmp          = cumsum(double(diff([0;srt])>0));
+newtri(indx) = tmp;


### PR DESCRIPTION
This addition to ft_plot_mesh is for plotting a boundary around a user-specified region (ie, provided with a stats mask, draw outline around significatn areas)

example:
load atlas_conte69_8196reg_LR_brodmann_subparc.mat
load('cortex_inflated_8196reg.mat')
atlas.pos = sourcemodel.pnt;
source = []
source.brainordinate = atlas;
source.label = atlas.parcellationlabel;
source.dimord = 'chan_time';
source.pow = atlas.parcellation;
source.mask = zeros(size(source.pow));
source.mask([2320 2322]) = 1;
figure;ft_plot_mesh(atlas,'vertexcolor',source.pow,'boundary',source.mask)