### PR TITLE
Differently localize electrodes with 3d scanner

### DIFF
--- a/plotting/ft_select_point3d.m
+++ b/plotting/ft_select_point3d.m
@@ -103,7 +103,7 @@ view(az,el);
 while ~done
   k = waitforbuttonpress;
   currkey=get(gcf,'CurrentKey');
-    if k==0 && strcmp(get(gcf,'SelectionType'), 'extend')
+    if k==0 && strcmp(get(gcf,'SelectionType'), 'extend') % 'extend' for middle button, 'alt' for the right button
         [p, v, ~, ~, ~] = sk_select3d(h);
         % a new point was selected
         if nearest
@@ -118,7 +118,7 @@ while ~done
         end
         set(gcf,'SelectionType','normal');
     elseif k==1 && (strcmp(currkey, 'q') || strcmp(currkey, 'r') || strcmp(currkey, '+') || strcmp(currkey, '-') || strcmp(currkey, 'w')|| strcmp(currkey, 'a') || strcmp(currkey, 's')|| strcmp(currkey, 'd'))% You also want to use strcmp here.
-        key = get(gcf,'CurrentCharacter'); % which key was pressed (if any)?
+        key = get(gcf,'CurrentCharacter'); % which key was pressed ?
         if strcmp(key, 'q')
             % finished selecting points
             done = true;

--- a/plotting/ft_select_point3d.m
+++ b/plotting/ft_select_point3d.m
@@ -102,61 +102,55 @@ view(az,el);
 
 while ~done
   k = waitforbuttonpress;
-  [p, v, vi, facev, facei] = select3d(h);
-  if k == 1 %checks if waitforbuttonpress was a key
-    key = get(gcf,'CurrentCharacter'); % which key was pressed (if any)?
-    if strcmp(key, 'q')
-      % finished selecting points
-      done = true;
-    elseif strcmp(key, 'r')
-      % remove last point
-      if ~isempty(selected)
+  currkey=get(gcf,'CurrentKey');
+    if k==0 && strcmp(get(gcf,'SelectionType'), 'extend')
+        [p, v, ~, ~, ~] = sk_select3d(h);
+        % a new point was selected
+        if nearest
+            selected(end+1,:) = v;
+        else
+            selected(end+1,:) = p;
+        end % if nearest
+        fprintf('selected point at [%f %f %f]\n', selected(end,1), selected(end,2), selected(end,3));
         if ~isempty(marker)
-          delete(findobj('marker', '*'));
-          hs = plot3(selected(1:end-1,1), selected(1:end-1,2), selected(1:end-1,3), [markercolor marker]);
-          set(hs, 'MarkerSize', markersize);
+            hs = plot3(selected(end,1), selected(end,2), selected(end,3), [markercolor marker]);
+            set(hs, 'MarkerSize', markersize);
         end
-        fprintf('removed latest point at [%f %f %f]\n', selected(end,1), selected(end,2), selected(end,3));
-        selected = selected(1:end-1,:);
-      end
-    elseif strcmp(key,'+')
-      zoom(1.1)
-    elseif strcmp(key,'-')
-      zoom(0.9)
-    elseif strcmp(key,'w')
-      az = az+6;
-      view(az,el)
-    elseif strcmp(key,'a')
-      el = el+6;
-      view(az,el)
-    elseif strcmp(key,'s')
-      az = az-6;
-      view(az,el)
-    elseif strcmp(key,'d')
-      el = el-6;
-      view(az,el)
+        set(gcf,'SelectionType','normal');
+    elseif k==1 && (strcmp(currkey, 'q') || strcmp(currkey, 'r') || strcmp(currkey, '+') || strcmp(currkey, '-') || strcmp(currkey, 'w')|| strcmp(currkey, 'a') || strcmp(currkey, 's')|| strcmp(currkey, 'd'))% You also want to use strcmp here.
+        key = get(gcf,'CurrentCharacter'); % which key was pressed (if any)?
+        if strcmp(key, 'q')
+            % finished selecting points
+            done = true;
+        elseif strcmp(key, 'r')
+            % remove last point
+            if ~isempty(selected)
+                if ~isempty(marker)
+                    delete(findobj('marker', '*'));
+                    hs = plot3(selected(1:end-1,1), selected(1:end-1,2), selected(1:end-1,3), [markercolor marker]);
+                    set(hs, 'MarkerSize', markersize);
+                end
+                fprintf('removed point at [%f %f %f]\n', selected(end,1), selected(end,2), selected(end,3));
+                selected = selected(1:end-1,:);
+            end
+        elseif strcmp(key,'+')
+            zoom(1.1)
+        elseif strcmp(key,'-')
+            zoom(0.9)
+        elseif strcmp(key,'w')
+            az = az+6;
+            view(az,el)
+        elseif strcmp(key,'a')
+            el = el+6;
+            view(az,el)
+        elseif strcmp(key,'s')
+            az = az-6;
+            view(az,el)
+        elseif strcmp(key,'d')
+            el = el-6;
+            view(az,el)
+        end
     end
-    
-  elseif ~isempty(p)
-    % a new point was selected
-    if nearest
-      selected(end+1,:) = v;
-    else
-      selected(end+1,:) = p;
-    end % if nearest
-    
-    if multiple
-      fprintf('selected points at\n');
-      disp(selected);
-    else
-      fprintf('selected point at [%f %f %f]\n', selected(end,1), selected(end,2), selected(end,3));
-    end
-    
-    if ~isempty(marker)
-      hs = plot3(selected(end,1), selected(end,2), selected(end,3), [markercolor marker]);
-      set(hs, 'MarkerSize', markersize);
-    end
-  end
   
   if ~multiple
     done = true;


### PR DESCRIPTION
When you select the elctrode positions manually it is time-comsuming to orient the head model to a desired view with just the keys 'w', 'a','s','d', hence I use the matlab figure window 3D rotate functionality. The problem is that when you want to rotate, the place where you point the mouse cursor gets selected as an electrode position. To avoid this I changed the code where the left mouse button does not select the electrode poisitions. The middle button is used for this purpose, but I have commented the line where the right mouse button can as well be configured to be used for this purpose.