### PR TITLE
FIX #947 - revert the state specifically for the warning message

### DIFF
--- a/test/test_issue947.m
+++ b/test/test_issue947.m
@@ -1,0 +1,92 @@
+function test_issue947
+
+% WALLTIME 00:10:00
+% MEM 2gb
+
+% the warning state is kept in the global ft_default structure
+global ft_default
+
+
+%%
+
+ft_default = [];
+
+% both should show
+ft_warning('a:a', 'a')
+ft_warning('b:b', 'b')
+
+%%
+
+ft_warning('off', 'a:a')
+
+% only b should show
+ft_warning('a:a', 'a')
+ft_warning('b:b', 'b')
+
+%%
+
+ft_default = [];
+
+ft_warning('off')
+
+% none of them should show
+ft_warning('a:a', 'a')
+ft_warning('b:b', 'b')
+
+%%
+
+ft_warning('on')
+
+% both of them should show again
+ft_warning('a:a', 'a')
+ft_warning('b:b', 'b')
+
+%%
+
+ft_default = [];
+
+ft_warning('off', 'a:a')
+ft_warning('off', 'b:b')
+
+% none of them should show
+ft_warning('a:a', 'a')
+ft_warning('b:b', 'b')
+
+%%
+
+ft_default = [];
+
+wsa = ft_warning('off', 'a:a')
+wsb = ft_warning('off', 'b:b')
+
+% none of them should show
+ft_warning('a:a', 'a')
+ft_warning('b:b', 'b')
+
+% revert the state of a
+ft_warning(wsa)
+
+% only a should show
+ft_warning('a:a', 'a')
+ft_warning('b:b', 'b')
+
+% revert the state of b
+ft_warning(wsb)
+
+% both should show
+ft_warning('a:a', 'a')
+ft_warning('b:b', 'b')
+
+%%
+
+ft_default = [];
+
+% the desired behaviour in the following is not really well defined
+
+wsa = ft_warning('off', 'a:a')
+ft_warning('off')
+ft_warning(wsa) % revert the state for a
+ft_warning('a:a', 'a') % this shows
+ft_warning('b:b', 'b') % this not
+ft_warning('c:c', 'c') % this not
+

--- a/utilities/private/ft_notification.m
+++ b/utilities/private/ft_notification.m
@@ -118,7 +118,7 @@ if ~ismember('verbose', {s.identifier})
   switch level
     case 'warning'
       defaultverbose = true;
-      t = warning('query', 'verbose');% get the default state
+      t = warning('query', 'verbose'); % get the default state
       s = setstate(s, 'verbose', t.state);
     otherwise
       s = setstate(s, 'verbose', 'off');
@@ -149,10 +149,13 @@ if strcmp(level, 'warning')
 end
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%% set the notification state according to the input
+%% set the state according to the input
 
-if numel(varargin)>0 && (isstruct(varargin{1}) || isempty(varargin{1}))
-  ft_default.notification.(level) = varargin{1};
+if numel(varargin)==1 && isstruct(varargin{1})
+  for i=1:numel(varargin{1})
+    s = setstate(s, varargin{1}(i).identifier, varargin{1}(i).state);
+  end
+  ft_default.notification.(level) = s;
   return
 end
 


### PR DESCRIPTION
that is specified, do not overwrite the full state