### PR TITLE
implement cfg.reproducescript option

### DIFF
--- a/contrib/nutmegtrip/private/getdimord.m
+++ b/contrib/nutmegtrip/private/getdimord.m
@@ -324,7 +324,7 @@ switch field
       dimord = 'pos_freq_time';
     end
     
-  case {'pow' 'noise' 'rv'}
+  case {'pow' 'noise' 'rv' 'nai'}
     if isequal(datsiz, [npos ntime])
       dimord = 'pos_time';
     elseif isequal(datsiz, [npos nfreq])

--- a/fileio/private/getdimord.m
+++ b/fileio/private/getdimord.m
@@ -324,7 +324,7 @@ switch field
       dimord = 'pos_freq_time';
     end
     
-  case {'pow' 'noise' 'rv'}
+  case {'pow' 'noise' 'rv' 'nai'}
     if isequal(datsiz, [npos ntime])
       dimord = 'pos_time';
     elseif isequal(datsiz, [npos nfreq])

--- a/fileio/private/loadvar.m
+++ b/fileio/private/loadvar.m
@@ -1,6 +1,8 @@
 function value = loadvar(filename, varname)
 
 % LOADVAR is a helper function for cfg.inputfile
+%
+% See also SAVEVAR
 
 % Copyright (C) 2010, Robert Oostenveld
 %
@@ -9,10 +11,10 @@ function value = loadvar(filename, varname)
 assert(ischar(filename), 'file name should be a string');
 
 if nargin<2
-  fprintf('reading variable from file ''%s''\n', filename);
+  ft_info('reading variable from file ''%s''\n', filename);
 else
   assert(ischar(varname), 'variable name should be a string');
-  fprintf('reading ''%s'' from file ''%s''\n', varname, filename);
+  ft_info('reading ''%s'' from file ''%s''\n', varname, filename);
 end
 
 % note that this sometimes fails, returning an empty var

--- a/ft_analysispipeline.m
+++ b/ft_analysispipeline.m
@@ -682,7 +682,7 @@ function pipeline2htmlfile(cfg, pipeline)
 filename = fullfile(p, [f '.html']);
 
 % skip the data-like fields and the fields that probably were not added by the user himself
-skipfields = {'previous', 'grid', 'headmodel', 'event', 'warning', 'progress', 'trackconfig', 'checkconfig', 'checksize', 'showcallinfo', 'debug', 'outputfilepresent', 'trackcallinfo', 'trackdatainfo', 'trackusage'};
+skipfields = ignorefields('html');
 
 fprintf('exporting HTML file to ''%s''\n', filename);
 

--- a/ft_analysispipeline.m
+++ b/ft_analysispipeline.m
@@ -681,9 +681,6 @@ function pipeline2htmlfile(cfg, pipeline)
 [p, f, x] = fileparts(cfg.filename);
 filename = fullfile(p, [f '.html']);
 
-% skip the data-like fields and the fields that probably were not added by the user himself
-skipfields = ignorefields('html');
-
 fprintf('exporting HTML file to ''%s''\n', filename);
 
 html = '';
@@ -695,14 +692,14 @@ for k = 1:numel(pipeline)
   ft_progress(k/numel(pipeline), 'serialising cfg-structure %d from %d', k, numel(pipeline));
   
   % strip away the cfg.previous fields, and all data-like fields
-  tmpcfg = removefields(pipeline(k).cfg, skipfields);
+  tmpcfg = removefields(pipeline(k).cfg, ignorefields('html'));
   
   usercfg = [];
   
   % record the usercfg and proctime if present
   if isfield(tmpcfg, 'callinfo')
     if isfield(tmpcfg.callinfo, 'usercfg')
-      usercfg = removefields(tmpcfg.callinfo.usercfg, skipfields);
+      usercfg = removefields(tmpcfg.callinfo.usercfg, ignorefields('html'));
       
       % avoid processing usercfg twice
       tmpcfg.callinfo = rmfield(tmpcfg.callinfo, 'usercfg');

--- a/ft_clusterplot.m
+++ b/ft_clusterplot.m
@@ -460,6 +460,7 @@ ft_postamble debug
 ft_postamble trackconfig
 ft_postamble previous stat
 ft_postamble provenance
+ft_postamble savefig
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % SUBFUNCTION

--- a/ft_connectivityplot.m
+++ b/ft_connectivityplot.m
@@ -336,3 +336,5 @@ ft_postamble debug
 ft_postamble trackconfig
 ft_postamble previous varargin
 ft_postamble provenance
+ft_postamble savefig
+

--- a/ft_defaults.m
+++ b/ft_defaults.m
@@ -24,6 +24,7 @@ function ft_defaults
 %   ft_default.toolbox.signal    = string, can be 'compat' or 'matlab' (default = 'compat')
 %   ft_default.toolbox.stats     = string, can be 'compat' or 'matlab' (default = 'compat')
 %   ft_default.toolbox.images    = string, can be 'compat' or 'matlab' (default = 'compat')
+%   ft_default.reproducescript   = string, directory to which the script and intermediate data are written (default = [])
 %
 % If you want to overrule these default settings, you can add something like this in your startup.m script
 %   ft_defaults

--- a/ft_dipolesimulation.m
+++ b/ft_dipolesimulation.m
@@ -200,9 +200,9 @@ ft_progress('init', cfg.feedback, 'computing simulated data');
 for trial=1:Ntrials
   ft_progress(trial/Ntrials, 'computing simulated data for trial %d\n', trial);
   if numel(cfg.chanunit) == numel(cfg.channel)
-      lf = ft_compute_leadfield(dippos{trial}, sens, headmodel, 'dipoleunit', cfg.dipoleunit, 'chanunit', cfg.chanunit);
+    lf = ft_compute_leadfield(dippos{trial}, sens, headmodel, 'dipoleunit', cfg.dipoleunit, 'chanunit', cfg.chanunit);
   else
-      lf = ft_compute_leadfield(dippos{trial}, sens, headmodel);
+    lf = ft_compute_leadfield(dippos{trial}, sens, headmodel);
   end
   nsamples = size(dipsignal{trial},2);
   nchannels = size(lf,1);

--- a/ft_layoutplot.m
+++ b/ft_layoutplot.m
@@ -221,3 +221,5 @@ ft_postamble debug
 ft_postamble trackconfig
 ft_postamble provenance
 ft_postamble previous data
+ft_postamble savefig
+

--- a/ft_movieplotER.m
+++ b/ft_movieplotER.m
@@ -97,3 +97,5 @@ tmpcfg = ft_movieplotTFR(tmpcfg, data);
 % do the general cleanup and bookkeeping at the end of the function
 ft_postamble provenance
 ft_postamble previous data
+ft_postamble savefig
+

--- a/ft_movieplotTFR.m
+++ b/ft_movieplotTFR.m
@@ -397,6 +397,7 @@ ft_postamble trackconfig
 ft_postamble previous   data
 ft_postamble provenance data
 ft_postamble history    data
+ft_postamble savefig
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/ft_multiplotCC.m
+++ b/ft_multiplotCC.m
@@ -150,4 +150,5 @@ ft_postamble trackconfig
 ft_postamble previous   data
 ft_postamble history    data
 ft_postamble provenance
+ft_postamble savefig
 

--- a/ft_multiplotER.m
+++ b/ft_multiplotER.m
@@ -587,6 +587,7 @@ ft_postamble debug
 ft_postamble trackconfig
 ft_postamble previous varargin
 ft_postamble provenance
+ft_postamble savefig
 
 if ~nargout 
   % don't return anything

--- a/ft_multiplotTFR.m
+++ b/ft_multiplotTFR.m
@@ -616,6 +616,7 @@ ft_postamble debug
 ft_postamble trackconfig
 ft_postamble previous data
 ft_postamble provenance
+ft_postamble savefig
 
 if ~nargout 
   % don't return anything

--- a/ft_neighbourplot.m
+++ b/ft_neighbourplot.m
@@ -222,6 +222,7 @@ ft_postamble debug
 ft_postamble trackconfig
 ft_postamble previous data
 ft_postamble provenance
+ft_postamble savefig
 
 end % main function
 

--- a/ft_singleplotER.m
+++ b/ft_singleplotER.m
@@ -545,6 +545,7 @@ ft_postamble debug
 ft_postamble trackconfig
 ft_postamble previous varargin
 ft_postamble provenance
+ft_postamble savefig
 
 if ~nargout
   % don't return anything

--- a/ft_singleplotTFR.m
+++ b/ft_singleplotTFR.m
@@ -485,6 +485,7 @@ ft_postamble debug
 ft_postamble trackconfig
 ft_postamble previous data
 ft_postamble provenance
+ft_postamble savefig
 
 if ~nargout
   % don't return anything

--- a/ft_sourceplot.m
+++ b/ft_sourceplot.m
@@ -1431,6 +1431,7 @@ ft_postamble debug
 ft_postamble trackconfig
 ft_postamble previous functional
 ft_postamble provenance
+ft_postamble savefig
 
 % add a menu to the figure
 % also, delete any possibly existing previous menu, this is safe because delete([]) does nothing

--- a/ft_topoplotCC.m
+++ b/ft_topoplotCC.m
@@ -324,6 +324,7 @@ ft_postamble debug
 ft_postamble trackconfig
 ft_postamble previous freq
 ft_postamble provenance
+ft_postamble savefig
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/ft_topoplotER.m
+++ b/ft_topoplotER.m
@@ -219,6 +219,7 @@ ft_postamble debug
 ft_postamble trackconfig
 ft_postamble previous varargin
 ft_postamble provenance
+ft_postamble savefig
 
 if ~nargout
   clear cfg

--- a/ft_topoplotIC.m
+++ b/ft_topoplotIC.m
@@ -202,6 +202,7 @@ ft_postamble debug
 ft_postamble trackconfig
 ft_postamble previous comp
 ft_postamble provenance
+ft_postamble savefig
 
 if ~nargout
   clear cfg

--- a/ft_topoplotTFR.m
+++ b/ft_topoplotTFR.m
@@ -224,6 +224,7 @@ ft_postamble debug
 ft_postamble trackconfig
 ft_postamble previous varargin
 ft_postamble provenance
+ft_postamble savefig
 
 if ~nargout
   clear cfg

--- a/private/getdimord.m
+++ b/private/getdimord.m
@@ -324,7 +324,7 @@ switch field
       dimord = 'pos_freq_time';
     end
     
-  case {'pow' 'noise' 'rv'}
+  case {'pow' 'noise' 'rv' 'nai'}
     if isequal(datsiz, [npos ntime])
       dimord = 'pos_time';
     elseif isequal(datsiz, [npos nfreq])

--- a/private/ignorefields.m
+++ b/private/ignorefields.m
@@ -178,6 +178,26 @@ switch purpose
       'cfg'
       };
     
+  case 'html'
+    % when generating a html-formatted pipeline, ignore data-like fields and fields that probably were not added by the user himself
+    ignore = {
+      'previous'
+      'grid'
+      'headmodel'
+      'event'
+      'warning'
+      'progress'
+      'trackconfig'
+      'checkconfig'
+      'checksize'
+      'showcallinfo'
+      'debug'
+      'outputfilepresent'
+      'trackcallinfo'
+      'trackdatainfo'
+      'trackusage'
+      };
+    
   otherwise
     ft_error('invalid purpose');
 end % switch purpose

--- a/private/loadvar.m
+++ b/private/loadvar.m
@@ -1,6 +1,8 @@
 function value = loadvar(filename, varname)
 
 % LOADVAR is a helper function for cfg.inputfile
+%
+% See also SAVEVAR
 
 % Copyright (C) 2010, Robert Oostenveld
 %
@@ -9,10 +11,10 @@ function value = loadvar(filename, varname)
 assert(ischar(filename), 'file name should be a string');
 
 if nargin<2
-  fprintf('reading variable from file ''%s''\n', filename);
+  ft_info('reading variable from file ''%s''\n', filename);
 else
   assert(ischar(varname), 'variable name should be a string');
-  fprintf('reading ''%s'' from file ''%s''\n', varname, filename);
+  ft_info('reading ''%s'' from file ''%s''\n', varname, filename);
 end
 
 % note that this sometimes fails, returning an empty var

--- a/private/savevar.m
+++ b/private/savevar.m
@@ -1,6 +1,8 @@
 function savevar(filename, varname, value)
 
 % SAVEVAR is a helper function for cfg.outputfile
+%
+% See also LOADVAR
 
 % Copyright (C) 2010, Robert Oostenveld
 %
@@ -9,7 +11,7 @@ function savevar(filename, varname, value)
 assert(ischar(filename), 'file name should be a string');
 assert(ischar(varname), 'variable name should be a string');
 
-fprintf('writing ''%s'' to file ''%s''\n', varname, filename);
+ft_info('writing ''%s'' to file ''%s''\n', varname, filename);
 
 eval(sprintf('%s = value;', varname));
 

--- a/test/private/getdimord.m
+++ b/test/private/getdimord.m
@@ -324,7 +324,7 @@ switch field
       dimord = 'pos_freq_time';
     end
     
-  case {'pow' 'noise' 'rv'}
+  case {'pow' 'noise' 'rv' 'nai'}
     if isequal(datsiz, [npos ntime])
       dimord = 'pos_time';
     elseif isequal(datsiz, [npos nfreq])

--- a/test/private/loadvar.m
+++ b/test/private/loadvar.m
@@ -1,6 +1,8 @@
 function value = loadvar(filename, varname)
 
 % LOADVAR is a helper function for cfg.inputfile
+%
+% See also SAVEVAR
 
 % Copyright (C) 2010, Robert Oostenveld
 %
@@ -9,10 +11,10 @@ function value = loadvar(filename, varname)
 assert(ischar(filename), 'file name should be a string');
 
 if nargin<2
-  fprintf('reading variable from file ''%s''\n', filename);
+  ft_info('reading variable from file ''%s''\n', filename);
 else
   assert(ischar(varname), 'variable name should be a string');
-  fprintf('reading ''%s'' from file ''%s''\n', varname, filename);
+  ft_info('reading ''%s'' from file ''%s''\n', varname, filename);
 end
 
 % note that this sometimes fails, returning an empty var

--- a/utilities/ft_preamble.m
+++ b/utilities/ft_preamble.m
@@ -48,29 +48,29 @@ function ft_preamble(cmd, varargin)
 % this is a trick to pass the input arguments into the ft_preamble_xxx script
 assignin('caller', 'iW1aenge_preamble', varargin);
 
-full_cmd=['ft_preamble_' cmd];
-cmd_exists=false;
+full_cmd = ['ft_preamble_' cmd];
+cmd_exists = false;
 
 if exist(full_cmd, 'file')
   % Matlab can find commands in a private subdirectory; Octave cannot.
   % If pwd is already the private directory, or if using Matlab then
   % the command can be evaluated directly
   cmd_exists = true;
-
+  
 elseif ~ft_platform_supports('exists-in-private-directory')
   % Octave does not find files by name in a private directory, so the full
   % filename must be specified.
   private_dir=fullfile(fileparts(which(mfilename)),'private');
   full_path=fullfile(private_dir,[full_cmd '.m']);
-
+  
   cmd_exists=exist(full_path,'file');
-  full_cmd_parts={'ft_tmp_orig_pwd=pwd();',...
-                  'ft_tmp_orig_pwd_cleaner='...
-                                'onCleanup(@()cd(ft_tmp_orig_pwd));',...
-                  sprintf('cd(''%s'');',private_dir),...
-                  [full_cmd ';'],...
-                  'clear ft_tmp_orig_pwd_cleaner;'};
-  full_cmd=sprintf('%s',full_cmd_parts{:});
+  full_cmd_parts = {'ft_tmp_orig_pwd=pwd();',...
+    'ft_tmp_orig_pwd_cleaner='...
+    'onCleanup(@()cd(ft_tmp_orig_pwd));',...
+    sprintf('cd(''%s'');',private_dir),...
+    [full_cmd ';'],...
+    'clear ft_tmp_orig_pwd_cleaner;'};
+  full_cmd = sprintf('%s',full_cmd_parts{:});
 end
 
 if ~cmd_exists

--- a/utilities/ft_selectdata.m
+++ b/utilities/ft_selectdata.m
@@ -287,14 +287,14 @@ if hastime,    [seltime,    cfg] = getselection_time   (cfg, varargin{:}, cfg.to
 keepfield = datfield;
 
 for i=1:numel(varargin)
-
+  
   for j=1:numel(datfield)
     dimtok = tokenize(dimord{j}, '_');
-
+    
     % the rpt selection should only work with a single data argument
     % in case tapers were kept, selrpt~=selrpttap, otherwise selrpt==selrpttap
     [selrpt{i}, dum, rptdim{i}, selrpttap{i}] = getselection_rpt(cfg, varargin{i}, dimord{j});
-
+    
     % check for the presence of each dimension in each datafield
     fieldhasspike   = ismember('spike',   dimtok);
     fieldhaspos     = ismember('pos',     dimtok) || ismember('{pos}', dimtok);
@@ -304,9 +304,9 @@ for i=1:numel(varargin)
     fieldhasfreq    = ismember('freq',    dimtok);
     fieldhasrpt     = ismember('rpt',     dimtok) | ismember('subj', dimtok) | ismember('{rpt}', dimtok);
     fieldhasrpttap  = ismember('rpttap',  dimtok);
-
+    
     % cfg.latency is used to select individual spikes, not to select from a continuously sampled time axis
-
+    
     if fieldhasspike,   varargin{i} = makeselection(varargin{i}, datfield{j}, dimtok, find(strcmp(dimtok,'spike')),             selspike{i},   false,           'intersect', average); end
     if fieldhaspos,     varargin{i} = makeselection(varargin{i}, datfield{j}, dimtok, find(ismember(dimtok, {'pos', '{pos}'})), selpos{i},     avgoverpos,      cfg.select, average);  end
     if fieldhaschan,    varargin{i} = makeselection(varargin{i}, datfield{j}, dimtok, find(ismember(dimtok,{'chan' '{chan}'})), selchan{i},    avgoverchan,     cfg.select, average);  end
@@ -315,39 +315,39 @@ for i=1:numel(varargin)
     if fieldhasfreq,    varargin{i} = makeselection(varargin{i}, datfield{j}, dimtok, find(strcmp(dimtok,'freq')),              selfreq{i},    avgoverfreq,     cfg.select, average);  end
     if fieldhasrpt,     varargin{i} = makeselection(varargin{i}, datfield{j}, dimtok, rptdim{i},                                selrpt{i},     avgoverrpt,      'intersect', average); end
     if fieldhasrpttap,  varargin{i} = makeselection(varargin{i}, datfield{j}, dimtok, rptdim{i},                                selrpttap{i},  avgoverrpt,      'intersect', average); end
-
+    
     % update the fields that should be kept in the structure as a whole
     % and update the dimord for this specific datfield
     keepdim = true(size(dimtok));
-
+    
     if avgoverchan && ~keepchandim
       keepdim(strcmp(dimtok, 'chan')) = false;
       keepfield = setdiff(keepfield, 'label');
     else
       keepfield = [keepfield 'label'];
     end
-
+    
     if avgoverchancmb && ~keepchancmbdim
       keepdim(strcmp(dimtok, 'chancmb')) = false;
       keepfield = setdiff(keepfield, 'labelcmb');
     else
       keepfield = [keepfield 'labelcmb'];
     end
-
+    
     if avgoverfreq && ~keepfreqdim
       keepdim(strcmp(dimtok, 'freq')) = false;
       keepfield = setdiff(keepfield, 'freq');
     else
       keepfield = [keepfield 'freq'];
     end
-
+    
     if avgovertime && ~keeptimedim
       keepdim(strcmp(dimtok, 'time')) = false;
       keepfield = setdiff(keepfield, 'time');
     else
       keepfield = [keepfield 'time'];
     end
-
+    
     if avgoverpos && ~keepposdim
       keepdim(strcmp(dimtok, 'pos'))   = false;
       keepdim(strcmp(dimtok, '{pos}')) = false;
@@ -358,13 +358,13 @@ for i=1:numel(varargin)
     else
       keepfield = [keepfield {'pos' '{pos}' 'dim'}];
     end
-
+    
     if avgoverrpt && ~keeprptdim
       keepdim(strcmp(dimtok, 'rpt'))    = false;
       keepdim(strcmp(dimtok, 'rpttap')) = false;
       keepdim(strcmp(dimtok, 'subj'))   = false;
     end
-
+    
     % update the sampleinfo, if possible, and needed
     if strcmp(datfield{j}, 'sampleinfo') && ~isequal(cfg.latency, 'all')
       if iscell(seltime{i}) && numel(seltime{i})==size(varargin{i}.sampleinfo,1)
@@ -377,15 +377,15 @@ for i=1:numel(varargin)
         varargin{i}.sampleinfo = varargin{i}.sampleinfo(:,[1 1]) - 1 + repmat(seltime{i}([1 end]),nrpt,1);
       end
     end
-
+    
     varargin{i}.(datfield{j}) = squeezedim(varargin{i}.(datfield{j}), ~keepdim);
-
+    
   end % for datfield
-
+  
   % also update the fields that describe the dimensions, time/freq/pos have been dealt with as data
   if haschan,    varargin{i} = makeselection_chan   (varargin{i}, selchan{i}, avgoverchan); end % update the label field
   if haschancmb, varargin{i} = makeselection_chancmb(varargin{i}, selchancmb{i}, avgoverchancmb); end % update the labelcmb field
-
+  
 end % for varargin
 
 if strcmp(cfg.select, 'union')
@@ -419,7 +419,7 @@ end
 % restore the original dimord fields in the data
 for i=1:length(orgdim1)
   dimtok = tokenize(orgdim2{i}, '_');
-
+  
   % using a setdiff may result in double occurrences of chan and pos to
   % disappear, so this causes problems as per bug 2962
   % if ~keeprptdim, dimtok = setdiff(dimtok, {'rpt' 'rpttap' 'subj'}); end
@@ -432,7 +432,7 @@ for i=1:length(orgdim1)
   if ~keepchandim, dimtok = dimtok(~ismember(dimtok, {'chan'})); end
   if ~keepfreqdim, dimtok = dimtok(~ismember(dimtok, {'freq'})); end
   if ~keeptimedim, dimtok = dimtok(~ismember(dimtok, {'time'})); end
-
+  
   dimord = sprintf('%s_', dimtok{:});
   dimord = dimord(1:end-1); % remove the trailing _
   for j=1:length(varargin)
@@ -514,7 +514,7 @@ switch selmode
           data.(datfield){j} = cellmatselect(data.(datfield){j}, seldim-1, selindx{j}, numel(dimtok)==1);
         end
       end
-
+      
     else
       % there is a single selection in a single vector
       if ~isempty(selindx) && all(isnan(selindx))
@@ -523,11 +523,11 @@ switch selmode
         data.(datfield) = cellmatselect(data.(datfield), seldim, selindx, numel(dimtok)==1);
       end
     end
-
+    
     if avgoverdim
       data.(datfield) = cellmatmean(data.(datfield), seldim, average);
     end
-
+    
   case 'union'
     if ~isempty(selindx) && all(isnan(selindx))
       % no selection needs to be made
@@ -554,7 +554,7 @@ switch selmode
           ft_error('unsupported dimension (%d) for making a selection for %s', seldim, datfield);
       end
     end
-
+    
     if avgoverdim
       data.(datfield) = average(data.(datfield), seldim);
     end
@@ -732,9 +732,9 @@ if ~isfield(cfg, 'channelcmb')
     % the nan return value specifies that no selection was specified
     chancmbindx{k} = nan;
   end
-
+  
 else
-
+  
   switch selmode
     case 'intersect'
       for k=1:ndata
@@ -744,35 +744,35 @@ else
           cfg.channelcmb = ft_channelcombination(cfg.channelcmb, varargin{k}.label);
         end
       end
-
+      
       ncfgcmb = size(cfg.channelcmb,1);
       cfgcmb  = cell(ncfgcmb, 1);
       for i=1:ncfgcmb
         cfgcmb{i} = sprintf('%s&%s', cfg.channelcmb{i,1}, cfg.channelcmb{i,2});
       end
-
+      
       for k=1:ndata
         ndatcmb = size(varargin{k}.labelcmb,1);
         datcmb = cell(ndatcmb, 1);
         for i=1:ndatcmb
           datcmb{i} = sprintf('%s&%s', varargin{k}.labelcmb{i,1}, varargin{k}.labelcmb{i,2});
         end
-
+        
         % return the order according to the (joint) configuration, not according to the (individual) data
         % FIXME this should adhere to the general code guidelines, where
         % the order returned will be according to the first data argument!
         [dum, chancmbindx{k}] = match_str(cfgcmb, datcmb);
       end
-
+      
     case 'union'
       % FIXME this is not yet implemented
       ft_error('union of channel combination is not yet supported');
-
+      
     otherwise
       ft_error('invalid value for cfg.select');
   end % switch
-
-
+  
+  
 end
 
 end % function getselection_chancmb
@@ -900,8 +900,8 @@ end
 if iscell(varargin{1}.time) && ischar(cfg.latency)&& ~strcmp(cfg.latency, 'minperiod')
   % if the input data arguments are of type 'raw', temporarily set the
   % selmode to union, otherwise the potentially different length trials
-  % will be truncated to the shorted epoch, prior to latency selection. 
-  selmode = 'union'; 
+  % will be truncated to the shorted epoch, prior to latency selection.
+  selmode = 'union';
 elseif ischar(cfg.latency) && strcmp(cfg.latency, 'minperiod')
   % enforce intersect
   selmode = 'intersect';
@@ -943,7 +943,7 @@ if isempty(cfg.latency)
     % this signifies that all time bins are deselected and should be removed
     timeindx{k} = [];
   end
-
+  
 elseif numel(cfg.latency)==1
   % this single value should be within the time axis of each input data structure
   if numel(alltimevec)>1
@@ -952,11 +952,11 @@ elseif numel(cfg.latency)==1
     tbin = nearest(alltimevec, cfg.latency, true, false); % don't consider tolerance
   end
   cfg.latency = alltimevec(tbin);
-
+  
   for k = 1:ndata
     timeindx{k} = indx(tbin, k);
   end
-
+  
 elseif numel(cfg.latency)==2
   % the [min max] range can be specifed with +inf or -inf, but should
   % at least partially overlap with the time axis of the input data
@@ -968,7 +968,7 @@ elseif numel(cfg.latency)==2
   tbeg = nearest(alltimevec, cfg.latency(1), false, false);
   tend = nearest(alltimevec, cfg.latency(2), false, false);
   cfg.latency = alltimevec([tbeg tend]);
-
+  
   for k = 1:numel(alltimecell)
     timeindx{k} = indx(tbeg:tend, k);
     % if the input data arguments are of type 'raw', the non-finite values
@@ -978,10 +978,10 @@ elseif numel(cfg.latency)==2
       timeindx{k} = timeindx{k}(isfinite(timeindx{k}));
     end
   end
-
+  
 elseif size(cfg.latency,2)==2
   % this may be used for specification of the computation, not for data selection
-
+  
 else
   ft_error('incorrect specification of cfg.latency');
 end
@@ -1031,7 +1031,7 @@ freqaxis = zeros(1,0);
 for k = 1:ndata
   % the nan return value specifies that no selection was specified
   freqindx{k} = nan;
-
+  
   % update the axis along which the frequencies are defined
   freqaxis = union(freqaxis, round(varargin{k}.freq(:)/tol)*tol);
 end
@@ -1073,7 +1073,7 @@ if isfield(cfg, 'frequency')
       ft_error('incorrect specification of cfg.frequency');
     end
   end
-
+  
   % deal with numeric selection
   if isempty(cfg.frequency)
     for k = 1:ndata
@@ -1081,7 +1081,7 @@ if isfield(cfg, 'frequency')
       % this signifies that all frequency bins are deselected and should be removed
       freqindx{k} = [];
     end
-
+    
   elseif numel(cfg.frequency)==1
     % this single value should be within the frequency axis of each input data structure
     if numel(freqaxis)>1
@@ -1090,11 +1090,11 @@ if isfield(cfg, 'frequency')
       fbin = nearest(freqaxis, cfg.frequency, true, false); % don't consider tolerance
     end
     cfg.frequency = freqaxis(fbin);
-
+    
     for k = 1:ndata
       freqindx{k} = indx(fbin,k);
     end
-
+    
   elseif numel(cfg.frequency)==2
     % the [min max] range can be specifed with +inf or -inf, but should
     % at least partially overlap with the freq axis of the input data
@@ -1106,14 +1106,14 @@ if isfield(cfg, 'frequency')
     fbeg = nearest(freqaxis, cfg.frequency(1), false, false);
     fend = nearest(freqaxis, cfg.frequency(2), false, false);
     cfg.frequency = freqaxis([fbeg fend]);
-
+    
     for k = 1:ndata
       freqindx{k} = indx(fbeg:fend,k);
     end
-
+    
   elseif size(cfg.frequency,2)==2
     % this may be used for specification of the computation, not for data selection
-
+    
   else
     ft_error('incorrect specification of cfg.frequency');
   end
@@ -1142,25 +1142,25 @@ rptdim = find(strcmp(dimtok, '{rpt}') | strcmp(dimtok, 'rpt') | strcmp(dimtok, '
 if isequal(cfg.trials, 'all')
   rptindx    = nan; % the nan return value specifies that no selection was specified
   rpttapindx = nan; % the nan return value specifies that no selection was specified
-
+  
 elseif isempty(rptdim)
   % FIXME should [] not mean that none of the trials is to be selected?
   rptindx    = nan; % the nan return value specifies that no selection was specified
   rpttapindx = nan; % the nan return value specifies that no selection was specified
-
+  
 else
   rptindx = ft_getopt(cfg, 'trials');
-
+  
   if islogical(rptindx)
     % convert from booleans to indices
     rptindx = find(rptindx);
   end
-
+  
   rptindx = unique(sort(rptindx));
-
+  
   if strcmp(dimtok{rptdim}, 'rpttap') && isfield(data, 'cumtapcnt')
     % there are tapers in the data
-
+    
     % determine for each taper to which trial it belongs
     nrpt = size(data.cumtapcnt, 1);
     taper = zeros(nrpt, 1);
@@ -1171,7 +1171,7 @@ else
       taper(begtapcnt(i):endtapcnt(i)) = i;
     end
     rpttapindx = find(ismember(taper, rptindx));
-
+    
   else
     % there are no tapers in the data
     rpttapindx = rptindx;

--- a/utilities/ft_selectdata.m
+++ b/utilities/ft_selectdata.m
@@ -458,7 +458,8 @@ ft_postamble provenance varargout
 ft_postamble history varargout
 ft_postamble savevar varargout
 
-if nargout>numel(varargout)
+% the varargout variable can be cleared when written to outputfile
+if exist('varargout', 'var') && ft_nargout>numel(varargout)
   % also return the input cfg with the combined selection over all input data structures
   varargout{end+1} = cfg;
 end

--- a/utilities/markdown2matlab.m
+++ b/utilities/markdown2matlab.m
@@ -96,6 +96,9 @@ while ~feof(infid)
   linenumber = linenumber + 1;
   if ~ischar(line), break, end
   
+  % replace each tab by two spaces
+  line = strrep(line, sprintf('\t'), '  ');
+  
   if match(line, '^---$') && linenumber==1
     state = 'jekyllheader';
     reset_state = false;

--- a/utilities/private/ft_postamble_savefig.m
+++ b/utilities/private/ft_postamble_savefig.m
@@ -29,43 +29,28 @@
 %
 % $Id$
 
-if exist('Fief7bee_reproducescript', 'var')
-  cfg.reproducescript = Fief7bee_reproducescript;
-end
-
 % the output data should be saved to a MATLAB file
-if (isfield(cfg, 'outputfile') && ~isempty(cfg.outputfile)) || (isfield(cfg, 'reproducescript') && ~isempty(cfg.reproducescript))
+if (isfield(cfg, 'outputfile') && ~isempty(cfg.outputfile)) || exist('Fief7bee_reproducescript', 'var')
   
   if isfield(cfg, 'outputlock') && ~isempty(cfg.outputlock)
     mutexlock(cfg.outputlock);
   end
   
-  % WARNING: the following code is shared between ft_preamble_savefig and ft_preamble_savevar
-  if isfield(cfg, 'reproducescript') && ~isempty(cfg.reproducescript)
+  if exist('Fief7bee_reproducescript', 'var')
+    % write the output figure to a MATLAB file
     iW1aenge_now = datestr(now, 30);
-    cfg.outputfile = sprintf('%s_output.fig', iW1aenge_now);
-    
-    % write the script that reproduces the analysis
-    iW1aenge_cfg = removefields(cfg.callinfo.usercfg, ignorefields('reproducescript'));
-    iW1aenge_cfg = copyfields(cfg, iW1aenge_cfg, {'outputfile'});
-    iW1aenge_cfg = printstruct('cfg', iW1aenge_cfg);
-    iW1aenge_fid = fopen(cfg.reproducescript, 'a+');
-    fprintf(iW1aenge_fid, "%%%%\n\n");
-    fprintf(iW1aenge_fid, "cfg = [];\n");
-    fprintf(iW1aenge_fid, "%s\n", iW1aenge_cfg);
-    iW1aenge_st = dbstack(2);
-    fprintf(iW1aenge_fid, '%s(cfg);\n\n', iW1aenge_st(1).name);
-    fclose(iW1aenge_fid);
+    cfg.outputfile = fullfile(Fief7bee_reproducescript, sprintf('%s_output', iW1aenge_now));
+    % write a snippet of MATLAB code with the configuration and function call
+    reproducescript(fullfile(Fief7bee_reproducescript, 'script.m'), cfg)
+  else
+    cfg.outputfile = [];
   end
   
-  if isequal(iW1aenge_postamble, {'varargout'}) && ~iscell(cfg.outputfile)
-    % this should be a cell-array, oterwise it cannot be matched with varargout
-    cfg.outputfile = {cfg.outputfile};
+  if ~isempty(cfg.outputfile)
+    % save the current figure to a MATLAB .fig file
+    ft_info('writing output figure to file ''%s''\n', cfg.outputfile);
+    savefig(gcf, cfg.outputfile, 'compact')
   end
-  
-  % save the current figure to a MATLAB .fig file
-  ft_info('writing output figure to file ''%s''\n', cfg.outputfile);
-  savefig(gcf, cfg.outputfile, 'compact')
   
   if isfield(cfg, 'outputlock') && ~isempty(cfg.outputlock)
     mutexunlock(cfg.outputlock);

--- a/utilities/private/ft_postamble_savefig.m
+++ b/utilities/private/ft_postamble_savefig.m
@@ -47,9 +47,15 @@ if (isfield(cfg, 'outputfile') && ~isempty(cfg.outputfile)) || exist('Fief7bee_r
   end
   
   if ~isempty(cfg.outputfile)
-    % save the current figure to a MATLAB .fig file
-    ft_info('writing output figure to file ''%s''\n', cfg.outputfile);
+    % save the current figure to a MATLAB .fig and to a .png file
+    [Fief7bee_p, Fief7bee_f, Fief7bee_x] = fileparts(cfg.outputfile);
+    Fief7bee_outputfile = fullfile(Fief7bee_p, [Fief7bee_f, '.fig']);
+    ft_info('writing output figure to file ''%s''\n', Fief7bee_outputfile);
     savefig(gcf, cfg.outputfile, 'compact')
+    Fief7bee_outputfile = fullfile(Fief7bee_p, [Fief7bee_f, '.png']);
+    ft_info('writing screenshot to file ''%s''\n', Fief7bee_outputfile);
+    set(gcf, 'PaperOrientation', 'portrait');
+    print(Fief7bee_outputfile, '-dpng');
   end
   
   if isfield(cfg, 'outputlock') && ~isempty(cfg.outputlock)

--- a/utilities/private/ft_postamble_savefig.m
+++ b/utilities/private/ft_postamble_savefig.m
@@ -1,0 +1,61 @@
+% FT_POSTAMBLE_SAVEVAR is a helper script that optionally saves the output
+% FieldTrip data structures to a *.mat file on disk. This is useful for
+% batching and for distributed processing. This makes use of the
+% cfg.outputfile variable.
+%
+% Use as
+%   ft_postamble savevar data
+%   ft_postamble savevar source mri
+%
+% See also FT_PREAMBLE, FT_POSTAMBLE, FT_POSTAMBLE_SAVEVAR
+
+% Copyright (C) 2019, Robert Oostenveld, DCCN
+%
+% This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
+% for the documentation and details.
+%
+%    FieldTrip is free software: you can redistribute it and/or modify
+%    it under the terms of the GNU General Public License as published by
+%    the Free Software Foundation, either version 3 of the License, or
+%    (at your option) any later version.
+%
+%    FieldTrip is distributed in the hope that it will be useful,
+%    but WITHOUT ANY WARRANTY; without even the implied warranty of
+%    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%    GNU General Public License for more details.
+%
+%    You should have received a copy of the GNU General Public License
+%    along with FieldTrip. If not, see <http://www.gnu.org/licenses/>.
+%
+% $Id$
+
+if exist('Fief7bee_rewritescript', 'var')
+  cfg.rewritescript = Fief7bee_rewritescript;
+end
+
+% the output data should be saved to a MATLAB file
+if (isfield(cfg, 'outputfile') && ~isempty(cfg.outputfile)) || (isfield(cfg, 'rewritescript') && ~isempty(cfg.rewritescript))
+  
+  if isfield(cfg, 'outputlock') && ~isempty(cfg.outputlock)
+    mutexlock(cfg.outputlock);
+  end
+  
+  if isfield(cfg, 'rewritescript') && ~isempty(cfg.rewritescript)
+    iW1aenge_now = datestr(now, 30);
+    cfg.outputfile = sprintf('%s_output.fig', iW1aenge_now);
+  end
+  
+  if isequal(iW1aenge_postamble, {'varargout'}) && ~iscell(cfg.outputfile)
+    % this should be a cell-array, oterwise it cannot be matched with varargout
+    cfg.outputfile = {cfg.outputfile};
+  end
+  
+  % save the current figure to a MATLAB .fig file
+  ft_info('writing output figure to file ''%s''\n', cfg.outputfile);
+  savefig(gcf, cfg.outputfile, 'compact')
+  
+  if isfield(cfg, 'outputlock') && ~isempty(cfg.outputlock)
+    mutexunlock(cfg.outputlock);
+  end
+  
+end

--- a/utilities/private/ft_postamble_savefig.m
+++ b/utilities/private/ft_postamble_savefig.m
@@ -29,20 +29,33 @@
 %
 % $Id$
 
-if exist('Fief7bee_rewritescript', 'var')
-  cfg.rewritescript = Fief7bee_rewritescript;
+if exist('Fief7bee_reproducescript', 'var')
+  cfg.reproducescript = Fief7bee_reproducescript;
 end
 
 % the output data should be saved to a MATLAB file
-if (isfield(cfg, 'outputfile') && ~isempty(cfg.outputfile)) || (isfield(cfg, 'rewritescript') && ~isempty(cfg.rewritescript))
+if (isfield(cfg, 'outputfile') && ~isempty(cfg.outputfile)) || (isfield(cfg, 'reproducescript') && ~isempty(cfg.reproducescript))
   
   if isfield(cfg, 'outputlock') && ~isempty(cfg.outputlock)
     mutexlock(cfg.outputlock);
   end
   
-  if isfield(cfg, 'rewritescript') && ~isempty(cfg.rewritescript)
+  % WARNING: the following code is shared between ft_preamble_savefig and ft_preamble_savevar
+  if isfield(cfg, 'reproducescript') && ~isempty(cfg.reproducescript)
     iW1aenge_now = datestr(now, 30);
     cfg.outputfile = sprintf('%s_output.fig', iW1aenge_now);
+    
+    % write the script that reproduces the analysis
+    iW1aenge_cfg = removefields(cfg.callinfo.usercfg, ignorefields('reproducescript'));
+    iW1aenge_cfg = copyfields(cfg, iW1aenge_cfg, {'outputfile'});
+    iW1aenge_cfg = printstruct('cfg', iW1aenge_cfg);
+    iW1aenge_fid = fopen(cfg.reproducescript, 'a+');
+    fprintf(iW1aenge_fid, "%%%%\n\n");
+    fprintf(iW1aenge_fid, "cfg = [];\n");
+    fprintf(iW1aenge_fid, "%s\n", iW1aenge_cfg);
+    iW1aenge_st = dbstack(2);
+    fprintf(iW1aenge_fid, '%s(cfg);\n\n', iW1aenge_st(1).name);
+    fclose(iW1aenge_fid);
   end
   
   if isequal(iW1aenge_postamble, {'varargout'}) && ~iscell(cfg.outputfile)

--- a/utilities/private/ft_postamble_savevar.m
+++ b/utilities/private/ft_postamble_savevar.m
@@ -7,7 +7,7 @@
 %   ft_postamble savevar data
 %   ft_postamble savevar source mri
 %
-% See also FT_PREAMBLE, FT_POSTAMBLE, FT_PREAMBLE_SAVEFIG
+% See also FT_PREAMBLE, FT_POSTAMBLE, FT_POSTAMBLE_SAVEFIG
 
 % Copyright (C) 2011-2019, Robert Oostenveld, DCCN
 %

--- a/utilities/private/ft_postamble_savevar.m
+++ b/utilities/private/ft_postamble_savevar.m
@@ -7,7 +7,7 @@
 %   ft_postamble savevar data
 %   ft_postamble savevar source mri
 %
-% See also FT_PREAMBLE, FT_POSTAMBLE, FT_PREAMBLE_LOADVAR
+% See also FT_PREAMBLE, FT_POSTAMBLE, FT_PREAMBLE_SAVEFIG
 
 % Copyright (C) 2011-2019, Robert Oostenveld, DCCN
 %
@@ -29,36 +29,25 @@
 %
 % $Id$
 
-if exist('Fief7bee_reproducescript', 'var')
-  cfg.reproducescript = Fief7bee_reproducescript;
-end
 
 % the output data should be saved to a MATLAB file
-if (isfield(cfg, 'outputfile') && ~isempty(cfg.outputfile)) || (isfield(cfg, 'reproducescript') && ~isempty(cfg.reproducescript))
+if (isfield(cfg, 'outputfile') && ~isempty(cfg.outputfile)) || exist('Fief7bee_reproducescript', 'var')
   
   if isfield(cfg, 'outputlock') && ~isempty(cfg.outputlock)
     mutexlock(cfg.outputlock);
   end
   
-  % WARNING: the following code is shared between ft_preamble_savefig and ft_preamble_savevar
-  if isfield(cfg, 'reproducescript') && ~isempty(cfg.reproducescript)
+  if exist('Fief7bee_reproducescript', 'var')
+    % write the function output variable(s) to a MATLAB file
     iW1aenge_now = datestr(now, 30);
     cfg.outputfile = {};
     for i=1:(ft_nargout)
-      cfg.outputfile{i} = sprintf('%s_output_%s', iW1aenge_now, iW1aenge_postamble{i});
+      cfg.outputfile{i} = fullfile(Fief7bee_reproducescript, sprintf('%s_output_%s', iW1aenge_now, iW1aenge_postamble{i}));
     end
-    
-    % write the script that reproduces the analysis
-    iW1aenge_cfg = removefields(cfg.callinfo.usercfg, ignorefields('reproducescript'));
-    iW1aenge_cfg = copyfields(cfg, iW1aenge_cfg, {'outputfile'});
-    iW1aenge_cfg = printstruct('cfg', iW1aenge_cfg);
-    iW1aenge_fid = fopen(cfg.reproducescript, 'a+');
-    fprintf(iW1aenge_fid, "%%%%\n\n");
-    fprintf(iW1aenge_fid, "cfg = [];\n");
-    fprintf(iW1aenge_fid, "%s\n", iW1aenge_cfg);
-    iW1aenge_st = dbstack(2);
-    fprintf(iW1aenge_fid, '%s(cfg);\n\n', iW1aenge_st(1).name);
-    fclose(iW1aenge_fid);
+    % write a snippet of MATLAB code with the configuration and function call
+    reproducescript(fullfile(Fief7bee_reproducescript, 'script.m'), cfg)
+  else
+    cfg.outputfile = {};
   end
   
   if isequal(iW1aenge_postamble, {'varargout'}) && ~iscell(cfg.outputfile)

--- a/utilities/private/ft_preamble_init.m
+++ b/utilities/private/ft_preamble_init.m
@@ -117,6 +117,21 @@ else
   ft_abort = false;
 end % if chiL7fee_outputfile{i}
 
+
+if isfield(cfg, 'reproducescript') && ~isempty(cfg.reproducescript)
+  % this should only be done in the top-level calling functions, not by lower-level functions
+  [ft_ver, ft_path] = ft_version;
+  st = dbstack('-completenames', 2);
+  % st(1) is the direct calling function
+  if numel(st)>1 && startsWith(st(2).file, ft_path)
+    % st(2) is also a FieldTrip function, which means that we are called in a lower-level function
+    cfg.reproducescript = [];
+  else
+    % this variable gets passed on to FT
+    Fief7bee_reproducescript = cfg.reproducescript;
+  end
+end
+
 if false
   % this is currently generating too much data and therefore disabled
   if isfield(cfg, 'trackusage') && ~(isequal(cfg.trackusage, false) || isequal(cfg.trackusage, 'no') || isequal(cfg.trackusage, 'off'))

--- a/utilities/private/ft_preamble_init.m
+++ b/utilities/private/ft_preamble_init.m
@@ -117,18 +117,23 @@ else
   ft_abort = false;
 end % if chiL7fee_outputfile{i}
 
-
 if isfield(cfg, 'reproducescript') && ~isempty(cfg.reproducescript)
-  % this should only be done in the top-level calling functions, not by lower-level functions
+  % the reproducescript code should only be executed in a top-level FT function
+  st = dbstack(2, '-completenames');
   [ft_ver, ft_path] = ft_version;
-  st = dbstack('-completenames', 2);
-  % st(1) is the direct calling function
   if numel(st)>1 && startsWith(st(2).file, ft_path)
-    % st(2) is also a FieldTrip function, which means that we are called in a lower-level function
-    cfg.reproducescript = [];
+    % we are in a FT function that was called by another FT function
+    cfg = rmfield(cfg, 'reproducescript');
   else
-    % this variable gets passed on to FT
+    % we are in a top-level FT function
+    if ~isfolder(cfg.reproducescript)
+      mkdir(cfg.reproducescript);
+    end
+    % this variable is used in loadvar, savevar and savefig
     Fief7bee_reproducescript = cfg.reproducescript;
+    cfg = rmfield(cfg, 'reproducescript');
+    % pause one second to ensure that subsequent file names (which contain the time stamp) are unique
+    pause(1);
   end
 end
 

--- a/utilities/private/ft_preamble_loadvar.m
+++ b/utilities/private/ft_preamble_loadvar.m
@@ -13,7 +13,7 @@
 %
 % See also FT_PREAMBLE, FT_POSTAMBLE, FT_POSTAMBLE_SAVEVAR, FT_PREAMBLE_PROVENANCE
 
-% Copyright (C) 2011-2012, Robert Oostenveld, DCCN
+% Copyright (C) 2011-2019, Robert Oostenveld, DCCN
 %
 % This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
 % for the documentation and details.
@@ -36,13 +36,34 @@
 % use an anonymous function
 assign = @(var, val) assignin('caller', var, val);
 
-if isfield(cfg, 'inputfile') && ~isempty(cfg.inputfile)
-
+if (isfield(cfg, 'inputfile') && ~isempty(cfg.inputfile)) || (isfield(cfg, 'reproducescript') && ~isempty(cfg.reproducescript))
+   
   % the input data should be read from file
-  if (ft_nargin>1)
+  
+  if ft_nargin>1 && isfield(cfg, 'reproducescript') && ~isempty(cfg.reproducescript)
+    % write the input data to an input file, this complements the script that is being constructed
+    % the first input argument is the cfg, the subsequent ones contain input data
+    
+    if isequal(iW1aenge_preamble, {'varargin'})
+      cfg.inputfile = {};
+      iW1aenge_now = datestr(now, 30);
+      for i=1:(ft_nargin-1)
+        cfg.inputfile{i} = sprintf('%s_input_%s_%d', iW1aenge_now, iW1aenge_preamble{i}, i);
+        savevar(cfg.inputfile{i}, iW1aenge_preamble{i}, varargin{i});
+      end
+    else
+      cfg.inputfile = {};
+      iW1aenge_now = datestr(now, 30);
+      for i=1:(ft_nargin-1)
+        cfg.inputfile{i} = sprintf('%s_input_%s', iW1aenge_now, iW1aenge_preamble{i});
+        savevar(cfg.inputfile{i}, iW1aenge_preamble{i}, eval(iW1aenge_preamble{i}));
+      end
+    end
+    
+  elseif ft_nargin>1
     ft_error('cfg.inputfile should not be used in conjunction with giving input data to this function');
   end
-
+  
   if isfield(cfg, 'inputlock') && ~isempty(cfg.inputlock)
     mutexlock(cfg.inputlock);
   end

--- a/utilities/private/ft_preamble_loadvar.m
+++ b/utilities/private/ft_preamble_loadvar.m
@@ -36,26 +36,25 @@
 % use an anonymous function
 assign = @(var, val) assignin('caller', var, val);
 
-if (isfield(cfg, 'inputfile') && ~isempty(cfg.inputfile)) || (isfield(cfg, 'reproducescript') && ~isempty(cfg.reproducescript))
-   
+if (isfield(cfg, 'inputfile') && ~isempty(cfg.inputfile)) || exist('Fief7bee_reproducescript', 'var')
   % the input data should be read from file
   
-  if ft_nargin>1 && isfield(cfg, 'reproducescript') && ~isempty(cfg.reproducescript)
-    % write the input data to an input file, this complements the script that is being constructed
-    % the first input argument is the cfg, the subsequent ones contain input data
+  if exist('Fief7bee_reproducescript', 'var')
+    % the script, input and output files are written to a directory
     
+    % write the function input variables to a MATLAB file
     if isequal(iW1aenge_preamble, {'varargin'})
       cfg.inputfile = {};
       iW1aenge_now = datestr(now, 30);
       for i=1:(ft_nargin-1)
-        cfg.inputfile{i} = sprintf('%s_input_%s_%d', iW1aenge_now, iW1aenge_preamble{i}, i);
+        cfg.inputfile{i} = fullfile(Fief7bee_reproducescript, sprintf('%s_input_%s_%d', iW1aenge_now, iW1aenge_preamble{i}, i));
         savevar(cfg.inputfile{i}, iW1aenge_preamble{i}, varargin{i});
       end
     else
       cfg.inputfile = {};
       iW1aenge_now = datestr(now, 30);
       for i=1:(ft_nargin-1)
-        cfg.inputfile{i} = sprintf('%s_input_%s', iW1aenge_now, iW1aenge_preamble{i});
+        cfg.inputfile{i} = fullfile(Fief7bee_reproducescript, sprintf('%s_input_%s', iW1aenge_now, iW1aenge_preamble{i}));
         savevar(cfg.inputfile{i}, iW1aenge_preamble{i}, eval(iW1aenge_preamble{i}));
       end
     end
@@ -99,3 +98,4 @@ if (isfield(cfg, 'inputfile') && ~isempty(cfg.inputfile)) || (isfield(cfg, 'repr
   end
   
 end % if inputfile
+

--- a/utilities/private/ignorefields.m
+++ b/utilities/private/ignorefields.m
@@ -122,6 +122,30 @@ switch purpose
       'warning'
       };
     
+  case {'reproducescript'}
+    ignore = {
+      % these should not be included in the output script
+      'checkconfig'
+      'checksize'
+      'debug'
+      'notification'
+      'showcallinfo'
+      'trackcallinfo'
+      'trackconfig'
+      'trackdatainfo'
+      'trackusage'
+      'warning'
+      'reproducescript'
+      'checkpath'
+      'toolbox'
+      'progress'
+      'outputfilepresent'
+      'grid'
+      'grad'
+      'elec'
+      'opto'
+      };
+
   case 'trackconfig'
     ignore = {
       % these fields from the user should be ignored

--- a/utilities/private/ignorefields.m
+++ b/utilities/private/ignorefields.m
@@ -178,6 +178,26 @@ switch purpose
       'cfg'
       };
     
+  case 'html'
+    % when generating a html-formatted pipeline, ignore data-like fields and fields that probably were not added by the user himself
+    ignore = {
+      'previous'
+      'grid'
+      'headmodel'
+      'event'
+      'warning'
+      'progress'
+      'trackconfig'
+      'checkconfig'
+      'checksize'
+      'showcallinfo'
+      'debug'
+      'outputfilepresent'
+      'trackcallinfo'
+      'trackdatainfo'
+      'trackusage'
+      };
+    
   otherwise
     ft_error('invalid purpose');
 end % switch purpose

--- a/utilities/private/loadvar.m
+++ b/utilities/private/loadvar.m
@@ -1,6 +1,8 @@
 function value = loadvar(filename, varname)
 
 % LOADVAR is a helper function for cfg.inputfile
+%
+% See also SAVEVAR
 
 % Copyright (C) 2010, Robert Oostenveld
 %
@@ -9,10 +11,10 @@ function value = loadvar(filename, varname)
 assert(ischar(filename), 'file name should be a string');
 
 if nargin<2
-  fprintf('reading variable from file ''%s''\n', filename);
+  ft_info('reading variable from file ''%s''\n', filename);
 else
   assert(ischar(varname), 'variable name should be a string');
-  fprintf('reading ''%s'' from file ''%s''\n', varname, filename);
+  ft_info('reading ''%s'' from file ''%s''\n', varname, filename);
 end
 
 % note that this sometimes fails, returning an empty var

--- a/utilities/private/reproducescript.m
+++ b/utilities/private/reproducescript.m
@@ -1,0 +1,41 @@
+function reproducescript(filename, cfg)
+
+% This is a helper function to create a script that reproduces the analysis. It
+% appends the configuration and the function call to a MATLAB script.
+
+% Copyright (C) 2019, Robert Oostenveld
+%
+% This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
+% for the documentation and details.
+%
+%    FieldTrip is free software: you can redistribute it and/or modify
+%    it under the terms of the GNU General Public License as published by
+%    the Free Software Foundation, either version 3 of the License, or
+%    (at your option) any later version.
+%
+%    FieldTrip is distributed in the hope that it will be useful,
+%    but WITHOUT ANY WARRANTY; without even the implied warranty of
+%    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%    GNU General Public License for more details.
+%
+%    You should have received a copy of the GNU General Public License
+%    along with FieldTrip. If not, see <http://www.gnu.org/licenses/>.
+%
+% $Id$
+
+tmpcfg = removefields(cfg.callinfo.usercfg, ignorefields('reproducescript'));
+tmpcfg = copyfields(cfg, tmpcfg, {'inputfile', 'outputfile'});
+tmpcfg = printstruct('cfg', tmpcfg);
+
+ft_info('writing script to file ''%s''\n', filename);
+
+fid = fopen(filename, 'a+');
+
+fprintf(fid, "%%%%\n\n");
+fprintf(fid, "cfg = [];\n");
+fprintf(fid, "%s\n", tmpcfg);
+
+st = dbstack(2);
+fprintf(fid, '%s(cfg);\n\n', st(2).name);
+
+fclose(fid);

--- a/utilities/private/savevar.m
+++ b/utilities/private/savevar.m
@@ -1,6 +1,8 @@
 function savevar(filename, varname, value)
 
 % SAVEVAR is a helper function for cfg.outputfile
+%
+% See also LOADVAR
 
 % Copyright (C) 2010, Robert Oostenveld
 %
@@ -9,7 +11,7 @@ function savevar(filename, varname, value)
 assert(ischar(filename), 'file name should be a string');
 assert(ischar(varname), 'variable name should be a string');
 
-fprintf('writing ''%s'' to file ''%s''\n', varname, filename);
+ft_info('writing ''%s'' to file ''%s''\n', varname, filename);
 
 eval(sprintf('%s = value;', varname));
 


### PR DESCRIPTION
for re-creating a simplified but still full analysis script during the execution of the users own (possibly convoluted) analysis script.