### PR TITLE
improve handling of input and output variables for cfg.reproducescript

### DIFF
--- a/ft_artifact_clip.m
+++ b/ft_artifact_clip.m
@@ -1,8 +1,8 @@
 function [cfg, artifact] = ft_artifact_clip(cfg, data)
 
-% FT_ARTIFACT_CLIP scans the data segments of interest for channels that
-% clip. A clipping artifact is detected by the signal being completely
-% flat for some time.
+% FT_ARTIFACT_CLIP scans the data segments of interest for channels that clip. These
+% artifacts are detected by the signal being completely flat for a given amount of
+% time.
 %
 % Use as
 %   [cfg, artifact] = ft_artifact_clip(cfg)
@@ -11,6 +11,9 @@ function [cfg, artifact] = ft_artifact_clip(cfg, data)
 % or
 %   cfg.headerfile  = string with the filename
 %   cfg.datafile    = string with the filename
+% and optionally
+%   cfg.headerformat
+%   cfg.dataformat
 %
 % Alternatively you can use it as
 %   [cfg, artifact] = ft_artifact_clip(cfg, data)
@@ -213,3 +216,5 @@ cfg.artfctdef.clip.artifact = artifact;
 % do the general cleanup and bookkeeping at the end of the function
 ft_postamble provenance
 ft_postamble previous data
+ft_postamble savevar
+

--- a/ft_artifact_ecg.m
+++ b/ft_artifact_ecg.m
@@ -1,9 +1,9 @@
 function [cfg, artifact] = ft_artifact_ecg(cfg, data)
 
-% FT_ARTIFACT_ECG performs a peak-detection on the ECG-channel and identifies the windows
-% around the QRS peak as artifacts. Using FT_REJECTARTIFACT you can remove these windows from
-% your data, or using FT_REMOVETEMPLATEARTIFACT you can subtract an averaged template artifact
-% from your data.
+% FT_ARTIFACT_ECG performs a peak-detection on the ECG-channel and identifies the
+% windows around the QRS peak as artifacts. Using FT_REJECTARTIFACT you can remove
+% these windows from your data, or using FT_REMOVETEMPLATEARTIFACT you can subtract
+% an averaged template artifact from your data.
 %
 % Use as
 %   [cfg, artifact] = ft_artifact_ecg(cfg)
@@ -149,11 +149,11 @@ end
 
 % set default cfg.continuous
 if ~isfield(cfg, 'continuous')
-    if hdr.nTrials==1
-      cfg.continuous = 'yes';
-    else
-      cfg.continuous = 'no';
-    end
+  if hdr.nTrials==1
+    cfg.continuous = 'yes';
+  else
+    cfg.continuous = 'no';
+  end
 end
 
 % read in the ecg-channel and do demean and squaring
@@ -236,7 +236,7 @@ while accept == 0
   hold off;
   xlabel('samples');
   ylabel('zscore');
-
+  
   fprintf(['\ncurrent %s threshold = %1.3f'], artfctdef.method, artfctdef.cutoff);
   response = input('\nkeep the current value (y/n) ?\n', 's');
   switch response
@@ -322,7 +322,7 @@ while acceptpre == 0 || acceptpst == 0
   height = 2.1*mdat;
   rectangle('Position', [xpos ypos width height], 'FaceColor', 'r');
   hold on; plot(time, dat(1:end-1, :), 'b');
-
+  
   if acceptpre == 0
     fprintf(['\ncurrent pre-peak interval = %1.3f'], artfctdef.pretim);
     response = input('\nkeep the current value (y/n) ?\n', 's');
@@ -366,3 +366,4 @@ cfg.artfctdef.ecg.artifact = artifact;
 % do the general cleanup and bookkeeping at the end of the function
 ft_postamble provenance
 ft_postamble previous data
+ft_postamble savevar

--- a/ft_artifact_eog.m
+++ b/ft_artifact_eog.m
@@ -1,7 +1,7 @@
 function [cfg, artifact] = ft_artifact_eog(cfg, data)
 
-% FT_ARTIFACT_EOG reads the data segments of interest from file and
-% identifies EOG artifacts.
+% FT_ARTIFACT_EOG reads the data segments of interest from file and identifies EOG
+% artifacts.
 %
 % Use as
 %   [cfg, artifact] = ft_artifact_eog(cfg)
@@ -83,6 +83,7 @@ ft_nargout  = nargout;
 % do the general setup of the function
 ft_defaults
 ft_preamble init
+
 % ft_preamble provenance is not needed because just a call to ft_artifact_zvalue
 % ft_preamble loadvar data is not needed because ft_artifact_zvalue will do this
 

--- a/ft_artifact_jump.m
+++ b/ft_artifact_jump.m
@@ -49,8 +49,8 @@ function [cfg, artifact] = ft_artifact_jump(cfg, data)
 % See also FT_REJECTARTIFACT, FT_ARTIFACT_CLIP, FT_ARTIFACT_ECG, FT_ARTIFACT_EOG,
 % FT_ARTIFACT_JUMP, FT_ARTIFACT_MUSCLE, FT_ARTIFACT_THRESHOLD, FT_ARTIFACT_ZVALUE
 
-% Undocumented local options:
-% cfg.method
+% Undocumented local options
+% cfg.artfctdef.jump.method
 
 % Copyright (C) 2003-2011, Jan-Mathijs Schoffelen & Robert Oostenveld
 %
@@ -80,6 +80,7 @@ ft_nargout  = nargout;
 % do the general setup of the function
 ft_defaults
 ft_preamble init
+
 % ft_preamble provenance is not needed because just a call to ft_artifact_zvalue
 % ft_preamble loadvar data is not needed because ft_artifact_zvalue will do this
 

--- a/ft_artifact_muscle.m
+++ b/ft_artifact_muscle.m
@@ -84,6 +84,7 @@ ft_nargout  = nargout;
 % do the general setup of the function
 ft_defaults
 ft_preamble init
+
 % ft_preamble provenance is not needed because just a call to ft_artifact_zvalue
 % ft_preamble loadvar data is not needed because ft_artifact_zvalue will do this
 

--- a/ft_artifact_nan.m
+++ b/ft_artifact_nan.m
@@ -96,3 +96,5 @@ cfg.artfctdef.nan.artifact = artifact;
 ft_postamble debug
 ft_postamble trackconfig
 ft_postamble previous   data
+ft_postamble savevar
+

--- a/ft_artifact_threshold.m
+++ b/ft_artifact_threshold.m
@@ -285,3 +285,5 @@ cfg.artfctdef.threshold.artifact = artifact;        % detected artifacts
 % do the general cleanup and bookkeeping at the end of the function
 ft_postamble provenance
 ft_postamble previous data
+ft_postamble savevar
+

--- a/ft_artifact_tms.m
+++ b/ft_artifact_tms.m
@@ -19,35 +19,31 @@ function [cfg, artifact] = ft_artifact_tms(cfg, data)
 % where the input data is a structure as obtained from FT_PREPROCESSING.
 %
 % In both cases the configuration should also contain
-%   cfg.trl         = structure that defines the data segments of interest. See FT_DEFINETRIAL
-%   cfg.continuous  = 'yes' or 'no' whether the file contains continuous data (default   = 'yes')
+%   cfg.trl         = structure that defines the data segments of interest, see FT_DEFINETRIAL
+%   cfg.continuous  = 'yes' or 'no' whether the file contains continuous data (default = 'yes')
 % and
 %   cfg.method      = 'detect' or 'marker', see below.
-%                     markers written in the EEG.
-%   cfg.prestim     = scalar, time in seconds prior to onset of detected
-%                     event to mark as artifactual (default = 0.005 seconds)
-%   cfg.poststim    = scalar, time in seconds post onset of detected even to
-%                     mark as artifactual (default = 0.010 seconds)
+%   cfg.prestim     = scalar, time in seconds prior to onset of detected event to mark as artifactual (default = 0.005 seconds)
+%   cfg.poststim    = scalar, time in seconds post onset of detected even to mark as artifactual (default = 0.010 seconds)
 %
-% METHOD SPECIFIC OPTIONS AND DESCRIPTIONS
+% The different methods are described in detail below.
 %
-% With cfg.method='detect', TMS-artifacts are detected by preprocessing the data to be
-% sensitive to transient high gradients, typical for TMS-pulses.  The data is preprocessed
-% (again) with the following configuration parameters, which are optimal for identifying tms
-% artifacts. This acts as a wrapper around ft_artifact_zvalue
+% With cfg.method='detect', TMS-artifact are detected on basis of transient
+% high-amplidude gradients that are typical for TMS-pulses. The data is preprocessed
+% (again) with the following settings, which are optimal for identifying TMS-pulses.
+% Artifacts are identified by means of thresholding the z-transformed value of the
+% preprocessed data. This method acts as a wrapper around FT_ARTIFACT_ZVALUE.
 %   cfg.artfctdef.tms.derivative  = 'yes'
-% Artifacts are identified by means of thresholding the z-transformed value
-% of the preprocessed data.
 %   cfg.artfctdef.tms.channel     = Nx1 cell-array with selection of channels, see FT_CHANNELSELECTION for details
 %   cfg.artfctdef.tms.cutoff      = z-value at which to threshold (default = 4)
 %   cfg.artfctdef.tms.trlpadding  = 0.1
 %   cfg.artfctdef.tms.fltpadding  = 0.1
-%   cfg.artfctdef.tms.artpadding  = 0.01 
+%   cfg.artfctdef.tms.artpadding  = 0.01
 % Be aware that if one artifact falls within this specified range of another artifact, both
 % artifact will be counted as one. Depending on cfg.prestim and cfg.poststim you may not mark
-% enough data as artifactual.)
+% enough data as artifactual.
 %
-% With cfg.method='marker', TMS-artifact onset and offsets are based on markers/triggers that
+% With cfg.method='marker', TMS-artifact onsets and offsets are based on markers/triggers that
 % are written into the EEG dataset. This method acts as a wrapper around FT_DEFINETRIAL to
 % determine on- and offsets of TMS pulses by reading markers in the EEG.
 %   cfg.trialfun            = function name, see below (default = 'ft_trialfun_general')
@@ -103,6 +99,7 @@ ft_nargout  = nargout;
 % do the general setup of the function
 ft_defaults
 ft_preamble init
+
 % ft_preamble provenance is not needed because just a call to ft_artifact_zvalue
 % ft_preamble loadvar data is not needed because ft_artifact_zvalue will do this
 
@@ -144,10 +141,10 @@ switch cfg.method
     if isfield(cfg, 'dataformat'),   tmpcfg.dataformat       = cfg.dataformat;    end
     if isfield(cfg, 'headerformat'), tmpcfg.headerformat     = cfg.headerformat;  end
     % call the zvalue artifact detection function
-
+    
     % the data is either passed into the function by the user or read from file with cfg.inputfile
     hasdata = exist('data', 'var');
-
+    
     if hasdata
       % read the header
       cfg = ft_checkconfig(cfg, 'forbidden', {'dataset', 'headerfile', 'datafile'});
@@ -163,24 +160,24 @@ switch cfg.method
       [tmpcfg, artifact] = ft_artifact_zvalue(tmpcfg);
     end
     cfg.artfctdef.tms = tmpcfg.artfctdef.zvalue;
-
+    
     % adjust artifact definition so that Nx2 matrix contains detected TMS
     % events with user-specified pre- and post stimulus period included.
     % The reason for this is that ft_artifact_zvalue centers the period
     % marked as artifactual around the detected event. In the case of a TMS
     % pulse the window you would like to mark as artifactual is not
     % symmetrical around the onset of the pulse.
-
+    
     % get values and express in samples
     prestim = round(cfg.prestim * fsample);
     poststim = round(cfg.poststim * fsample);
-
+    
     % adjust Nx2 artifact matrix to be centered non-symmetrically around
     % detected TMS-pulse
     artifact(:,1) = (artifact(:,1)+artifact(:,2))./2 - prestim;
     artifact(:,2) = artifact(:,1) + poststim;
     cfg.artfctdef.tms.artifact = artifact;
-
+    
   case 'marker'
     % Check if the cfg is correct for this method
     cfg = ft_checkconfig(cfg, 'dataset2files', 'yes');
@@ -190,20 +187,23 @@ switch cfg.method
     trialdef.prestim = cfg.prestim;
     trialdef.poststim = cfg.poststim;
     cfg.trialdef = ft_checkconfig(trialdef, 'required', {'eventvalue', 'eventtype'});
-
+    
     % Get the trialfun
     cfg.trialfun = ft_getuserfun(cfg.trialfun, 'trialfun');
-
+    
     % Evaluate the trialfun
     fprintf('evaluating trialfunction ''%s''\n', func2str(cfg.trialfun));
     trl   = feval(cfg.trialfun, cfg);
-
+    
     % Prepare the found events for output
     artifact = trl(:,1:2);
     cfg.artfctdef.tms.artifact = artifact;
     fprintf('found %d events\n', size(artifact,1));
+    
   otherwise
-    ft_error('unsupported method'); % This should be redundant as ft_checkconfig does not allow other methods than the supported ones.
+    % This should be redundant as ft_checkconfig does not allow other methods than the supported ones.
+    ft_error('unsupported method');
 end
 
-cfg = rmfield(cfg, 'method'); % FIXME - not removing this causes problems when passing to ft_preprocessing
+% FIXME - not removing this causes problems when passing to ft_preprocessing
+cfg = rmfield(cfg, 'method');

--- a/ft_artifact_zvalue.m
+++ b/ft_artifact_zvalue.m
@@ -37,12 +37,12 @@ function [cfg, artifact] = ft_artifact_zvalue(cfg, data)
 %   cfg.artfctdef.zvalue.artfctpeak  = 'yes' or 'no'
 %   cfg.artfctdef.zvalue.interactive = 'yes' or 'no'
 %
-% If you specify artfctpeak='yes', the maximum value of the artifact within its range
-% will be found and saved into cfg.artfctdef.zvalue.peaks.
+% If you specify cfg.artfctdef.zvalue.artfctpeak='yes', the maximum value of the
+% artifact within its range will be found and saved into cfg.artfctdef.zvalue.peaks.
 %
-% If you specify interactive='yes', a GUI will be started and you can manually
-% accept/reject detected artifacts, and/or change the threshold. To control the
-% graphical interface via keyboard, use the following keys:
+% If you specify cfg.artfctdef.zvalue.interactive='yes', a GUI will be started and
+% you can manually accept/reject detected artifacts, and/or change the threshold. To
+% control the graphical interface via keyboard, use the following keys:
 %
 %     q                 : Stop
 %
@@ -608,6 +608,8 @@ delete(h);
 % do the general cleanup and bookkeeping at the end of the function
 ft_postamble provenance
 ft_postamble previous data
+ft_postamble savevar
+
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % SUBFUNCTION

--- a/ft_definetrial.m
+++ b/ft_definetrial.m
@@ -120,6 +120,7 @@ ft_nargout  = nargout;
 % do the general setup of the function
 ft_defaults
 ft_preamble init
+ft_preamble loadvar
 ft_preamble provenance
 
 % the ft_abort variable is set to true or false in ft_preamble_init
@@ -196,3 +197,4 @@ cfg.trl = trl;
 
 % do the general cleanup and bookkeeping at the end of the function
 ft_postamble provenance
+ft_postamble savevar

--- a/ft_detect_movement.m
+++ b/ft_detect_movement.m
@@ -18,7 +18,7 @@ function [cfg, movement] = ft_detect_movement(cfg, data)
 % CLUSTERING - detects movements according to "Otero-Millan et al., (2014) J Vis 14".
 %
 % Use as
-%   movement = ft_detect_movement(cfg, data)
+%   [cfg, movement] = ft_detect_movement(cfg, data)
 % where the input data should be organised in a structure as obtained from the
 % FT_PREPROCESSING function.
 %

--- a/ft_detect_movement.m
+++ b/ft_detect_movement.m
@@ -1,47 +1,39 @@
-function [cfg movement] = ft_detect_movement(cfg, data)
+function [cfg, movement] = ft_detect_movement(cfg, data)
 
-% FT_SACCADE_DETECTION performs micro/saccade detection on time series data
-% over multiple trials
+% FT_SACCADE_DETECTION performs detection of movements such as saccades and
+% microsaccades, but also joystick movements, from time series data over multiple
+% trials. Different methods for detecting movements are implemented, which are
+% described in detail below:
 %
-% Use as
-%   movement = ft_detect_movement(cfg, data)
-%
-% The input data should be organised in a structure as obtained from the
-% FT_PREPROCESSING function. The configuration depends on the type of
-% computation that you want to perform.
-%
-% The configuration should contain:
-%  cfg.method   = different methods of detecting different movement types
-%                'velocity2D', Micro/saccade detection based on Engbert R,
-%                   Kliegl R (2003) Vision Res 43:1035-1045. The method
-%                   computes thresholds based on velocity changes from
-%                   eyetracker data (horizontal and vertical components).
-%                'clustering', Micro/saccade detection based on
-%                   Otero-Millan et al., (2014) J Vis 14 (not implemented
-%                   yet)
-%   cfg.channel = Nx1 cell-array with selection of channels, see
-%                 FT_CHANNELSELECTION for details, (default = 'all')
-%   cfg.trials  = 'all' or a selection given as a 1xN vector (default = 'all')
-%
-% METHOD SPECIFIC OPTIONS AND DESCRIPTIONS
-%
-%  VELOCITY2D
-%   VELOCITY2D detects micro/saccades using a two-dimensional (2D) velocity
-%   space velocity. The vertical and the horizontal eyetracker time series
-%   (one eye) are transformed into velocities and microsaccades are
-%   indentified as "outlier" eye movements that exceed a given velocity and
-%   duration threshold.
+% VELOCITY2D - detects micro/saccades using a two-dimensional (2D) velocity according
+% to "Engbert R, Kliegl R (2003) Vision Res 43:1035-1045". The vertical and the
+% horizontal eyetracker time series (for one eye) are transformed into velocities and
+% microsaccades are indentified as "outlier" eye movements that exceed a given
+% threshold for velocity and duration. This method has the additional options
 %     cfg.velocity2D.kernel   = vector 1 x nsamples, kernel to compute velocity (default = [1 1 0 -1 -1].*(data.fsample/6);
 %     cfg.velocity2D.demean   = 'no' or 'yes', whether to apply centering correction (default = 'yes')
 %     cfg.velocity2D.mindur   = minimum microsaccade durantion in samples (default = 3);
 %     cfg.velocity2D.velthres = threshold for velocity outlier detection (default = 6);
 %
-% The output argument "movement" is a Nx3 matrix. The first and second
-% columns specify the begining and end samples of a movement period
-% (saccade, joystic...), and the third column contains the peak
-% velocity/acceleration movement. This last thrid column will allow to
-% convert movements into spike data representation, making the spike
-% toolbox functions compatible (not implemented yet).
+% CLUSTERING - detects movements according to "Otero-Millan et al., (2014) J Vis 14".
+%
+% Use as
+%   movement = ft_detect_movement(cfg, data)
+% where the input data should be organised in a structure as obtained from the
+% FT_PREPROCESSING function.
+%
+% The configuration can contain the following options
+%   cfg.method  = string representing the method for movement detection
+%                 'velocity2D' detects microsaccades using the 2D velocity
+%                 'clustering' use unsupervised clustering method to detect microsaccades
+%   cfg.channel = Nx1 cell-array with selection of channels, see FT_CHANNELSELECTION for details, (default = 'all')
+%   cfg.trials  = 'all' or a selection given as a 1xN vector (default = 'all')
+%
+% The output argument "movement" is a Nx3 matrix. The first and second columns
+% specify the begining and end samples of a movement period (saccade, joystick, ...),
+% and the third column contains the peak velocity/acceleration movement. The thrid
+% column allows to convert movements into spike data representation, making it
+% compatible with the spike toolbox functions.
 %
 % To facilitate data-handling and distributed computing you can use
 %   cfg.inputfile   =  ...
@@ -51,11 +43,29 @@ function [cfg movement] = ft_detect_movement(cfg, data)
 % files should contain only a single variable, corresponding with the
 % input/output structure.
 %
-% See also FT_PLOT_MOVEMENT (not implemented yet)
+% See also FT_DATABROWSER, FT_DATATYPE_SPIKE
 
-% Copyright (C) 2014, Diego Lozano-Soldevilla, Robert Oostenveld
+% Copyright (C) 2014, Diego Lozano-Soldevilla
+%
+% This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
+% for the documentation and details.
+%
+%    FieldTrip is free software: you can redistribute it and/or modify
+%    it under the terms of the GNU General Public License as published by
+%    the Free Software Foundation, either version 3 of the License, or
+%    (at your option) any later version.
+%
+%    FieldTrip is distributed in the hope that it will be useful,
+%    but WITHOUT ANY WARRANTY; without even the implied warranty of
+%    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%    GNU General Public License for more details.
+%
+%    You should have received a copy of the GNU General Public License
+%    along with FieldTrip. If not, see <http://www.gnu.org/licenses/>.
 %
 % $Id$
+
+% FIXME the help mentioned the
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % the initial part deals with parsing the input options and data
@@ -79,7 +89,7 @@ ft_preamble trackconfig
 % read from an old *.mat file
 data = ft_checkdata(data, 'datatype', {'raw'}, 'feedback', 'yes', 'hassampleinfo', 'yes');
 
-if isfield(data, 'fsample');
+if isfield(data, 'fsample')
   fsample = getsubfield(data, 'fsample');
 else
   fsample = 1./(mean(diff(data.time{1})));
@@ -125,26 +135,24 @@ ft_progress('init', cfg.feedback, 'processing trials');
 % do all the computations
 for i=1:ntrial
   ft_progress(i/ntrial, 'finding microsaccades trial %d of %d\n', i, ntrial);
-
+  
   dat = data.trial{i};
-  time = data.time{i};
-
-  ndatsample = size(dat,2);
-
+  nsample = size(dat,2);
+  
   switch cfg.method
     case 'velocity2D'
-
+      
       % demean horizontal and vertical time courses
-      if strcmp(cfg.velocity2D.demean, 'yes');
-        dat = ft_preproc_polyremoval(dat, 0, 1, ndatsample);
+      if strcmp(cfg.velocity2D.demean, 'yes')
+        dat = ft_preproc_polyremoval(dat, 0, 1, nsample);
       end
-
+      
       %% eye velocity computation
       % deal with padding
       n = size(cfg.velocity2D.kernel,2);
       pad = ceil(n/2);
       dat = ft_preproc_padding(dat, 'localmean', pad);
-
+      
       % convolution. See Engbert et al (2003) Vis Res, eqn. (1)
       if n<100
         % heuristic: for large kernel the convolution is faster when done along
@@ -156,18 +164,18 @@ for i=1:ntrial
       end
       % cut the eges
       vel = ft_preproc_padding(vel, 'remove', pad);
-
+      
       %% microsaccade detection
       % compute velocity thresholds as in Engbert et al (2003) Vis Res, eqn. (2)
       medianstd = sqrt( median(vel.^2,2) - (median(vel,2)).^2 );
-
+      
       % Engbert et al (2003) Vis Res, eqn. (3)
       radius = cfg.velocity2D.velthres*medianstd;
-
+      
       % compute test criterion: ellipse equation
-      test = sum((vel./radius(:,ones(1,ndatsample))).^2,1);
+      test = sum((vel./radius(:,ones(1,nsample))).^2,1);
       sacsmp = find(test>1);% microsaccade's indexing
-
+      
       %% determine microsaccades per trial
       % first find eye movements of n-consecutive time points
       j = find(diff(sacsmp)==1);
@@ -175,17 +183,17 @@ for i=1:ntrial
       com = intersect(j,j+1);
       cut = ~ismember(j1,com);
       sacidx = reshape(j1(cut),2,[]);
-
-      for k=1:size(sacidx,2);
+      
+      for k=1:size(sacidx,2)
         duration = sacidx(1,k):sacidx(2,k);
-        if size(duration,2) >= cfg.velocity2D.mindur;
+        if size(duration,2) >= cfg.velocity2D.mindur
           % finding peak velocity by Pitagoras
           begtrl = sacsmp(duration(1,1));
           endtrl = sacsmp(duration(1,end));
-
-          [peakvel smptrl] = max(sqrt(sum(vel(:,begtrl:endtrl).^2,1)));
+          
+          [peakvel, smptrl] = max(sqrt(sum(vel(:,begtrl:endtrl).^2,1)));
           veltrl = sacsmp(duration(1,smptrl));% peak velocity microsaccade sample -> important for spike conversion
-
+          
           trlsmp = data.sampleinfo(i,1):data.sampleinfo(i,2);
           begsample = trlsmp(1, begtrl); % begining microsaccade sample
           endsample = trlsmp(1, endtrl); % end microsaccade sample
@@ -193,9 +201,9 @@ for i=1:ntrial
           movement(end+1,:) = [begsample endsample velsample];
         end
       end
-
-    case 'clustering';
-      %not implemented yet
+      
+    case 'clustering'
+      % not implemented yet
   end
 end
 ft_progress('close');

--- a/ft_examplefunction.m
+++ b/ft_examplefunction.m
@@ -1,4 +1,4 @@
-function dataout = ft_examplefunction(cfg, datain)
+function [dataout] = ft_examplefunction(cfg, datain)
 
 % FT_EXAMPLEFUNCTION demonstrates to new developers how a FieldTrip function should look like
 %

--- a/ft_globalmeanfield.m
+++ b/ft_globalmeanfield.m
@@ -1,4 +1,4 @@
-function dataout = ft_globalmeanfield(cfg, datain)
+function [dataout] = ft_globalmeanfield(cfg, datain)
 
 % FT_GLOBALMEANFIELD calculates global mean field amplitude or power of input data
 %

--- a/ft_interpolatenan.m
+++ b/ft_interpolatenan.m
@@ -1,4 +1,4 @@
-function dataout = ft_interpolatenan(cfg, datain)
+function [dataout] = ft_interpolatenan(cfg, datain)
 
 % FT_INTERPOLATENAN interpolates time series that contains segments of nans obtained
 % by replacing artifactual data with nans using, for example, FT_REJECTARTIFACT, or

--- a/ft_math.m
+++ b/ft_math.m
@@ -1,4 +1,4 @@
-function data = ft_math(cfg, varargin)
+function [data] = ft_math(cfg, varargin)
 
 % FT_MATH performs mathematical operations on FieldTrip data structures,
 % such as addition, subtraction, division, etc.

--- a/ft_meshrealign.m
+++ b/ft_meshrealign.m
@@ -1,4 +1,4 @@
-function mesh_realigned = ft_meshrealign(cfg, mesh)
+function [mesh_realigned] = ft_meshrealign(cfg, mesh)
 
 % FT_MESHREALIGN rotates, translates and optionally scales electrode positions. The
 % different methods are described in detail below.

--- a/ft_preprocessing.m
+++ b/ft_preprocessing.m
@@ -556,7 +556,7 @@ else
             ft_error('unsupported requested direction of padding');
         end
         
-        if strcmp(cfg.padtype, 'data');
+        if strcmp(cfg.padtype, 'data')
           begsample  = cfg.trl(i,1) - begpadding;
           endsample  = cfg.trl(i,2) + endpadding;
         else

--- a/ft_removetemplateartifact.m
+++ b/ft_removetemplateartifact.m
@@ -1,4 +1,4 @@
-function data = ft_removetemplateartifact(cfg, data, template)
+function [data] = ft_removetemplateartifact(cfg, data, template)
 
 % FT_REMOVETEMPLATEARTIFACT removes an artifact from preprocessed data by template
 % subtraction. The template can for example be formed by averaging an ECG-triggered

--- a/ft_sourceparcellate.m
+++ b/ft_sourceparcellate.m
@@ -1,4 +1,4 @@
-function parcel = ft_sourceparcellate(cfg, source, parcellation)
+function [parcel] = ft_sourceparcellate(cfg, source, parcellation)
 
 % FT_SOURCEPARCELLATE combines the source-reconstruction parameters over the parcels, for
 % example by averaging all the values in the anatomically or functionally labeled parcel.

--- a/ft_volumebiascorrect.m
+++ b/ft_volumebiascorrect.m
@@ -1,11 +1,11 @@
-function mri_unbias = ft_volumebiascorrect(cfg, mri)
+function [mri_unbias] = ft_volumebiascorrect(cfg, mri)
 
 % FT_VOLUMEBIASCORRECT corrects the image inhomogeneity bias in an anatomical MRI
 %
 % Use as
 %   mri_unbias = ft_volumebiascorrect(cfg, mri)
-% where the input mri should be a single anatomical volume that was for example read with
-% FT_READ_MRI. 
+% where the input mri should be a single anatomical volume organised in a structure
+% as obtained from the FT_READ_MRI function
 %
 % The configuration structure can contain
 %   cfg.spmversion     = string, 'spm8', 'spm12' (default = 'spm8')
@@ -14,6 +14,26 @@ function mri_unbias = ft_volumebiascorrect(cfg, mri)
 %                        more information.
 %
 % See also FT_VOLUMEREALIGN FT_VOLUMESEGMENT FT_VOLUMENORMALISE
+
+% Copyright (C) 2017, Jan-Mathijs Schoffelen
+%
+% This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
+% for the documentation and details.
+%
+%    FieldTrip is free software: you can redistribute it and/or modify
+%    it under the terms of the GNU General Public License as published by
+%    the Free Software Foundation, either version 3 of the License, or
+%    (at your option) any later version.
+%
+%    FieldTrip is distributed in the hope that it will be useful,
+%    but WITHOUT ANY WARRANTY; without even the implied warranty of
+%    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%    GNU General Public License for more details.
+%
+%    You should have received a copy of the GNU General Public License
+%    along with FieldTrip. If not, see <http://www.gnu.org/licenses/>.
+%
+% $Id$
 
 ft_revision = '$Id$';
 ft_nargin = nargin;

--- a/ft_wizard.m
+++ b/ft_wizard.m
@@ -1,4 +1,4 @@
-function varargout = ft_wizard(wizard_filename)
+function [varargout] = ft_wizard(wizard_filename)
 
 % FT_WIZARD is a graphical user interface to evaluate a FieldTrip analysis
 % script one step at a time, allowing you to go to the next step if you are

--- a/loreta2fieldtrip.m
+++ b/loreta2fieldtrip.m
@@ -1,4 +1,4 @@
-function source = loreta2fieldtrip(filename, varargin)
+function [source] = loreta2fieldtrip(filename, varargin)
 
 % LORETA2FIELDTRIP reads and converts a LORETA source reconstruction into a
 % FieldTrip data structure, which subsequently can be used for statistical

--- a/spm2fieldtrip.m
+++ b/spm2fieldtrip.m
@@ -1,4 +1,4 @@
-function data = spm2fieldtrip(D)
+function [data] = spm2fieldtrip(D)
 
 % SPM2FIELDTRIP converts an SPM8 meeg object into a FieldTrip raw data structure
 %

--- a/utilities/private/ft_postamble_savevar.m
+++ b/utilities/private/ft_postamble_savevar.m
@@ -41,11 +41,11 @@ if (isfield(cfg, 'outputfile') && ~isempty(cfg.outputfile)) || exist('Fief7bee_r
     % write the function output variable(s) to a MATLAB file
     iW1aenge_now = datestr(now, 30);
     cfg.outputfile = {};
-    for i=1:(ft_nargout)
+    for i=1:numel(iW1aenge_postamble)
       cfg.outputfile{i} = fullfile(Fief7bee_reproducescript, sprintf('%s_output_%s', iW1aenge_now, iW1aenge_postamble{i}));
     end
-    % write a snippet of MATLAB code with the configuration and function call
-    reproducescript(fullfile(Fief7bee_reproducescript, 'script.m'), cfg)
+    % write a snippet of MATLAB code with the user-specified configuration and function call
+    reproducescript(fullfile(Fief7bee_reproducescript, 'script.m'), Fief7bee_cfg, isempty(iW1aenge_postamble))
   else
     cfg.outputfile = {};
   end

--- a/utilities/private/ft_postamble_savevar.m
+++ b/utilities/private/ft_postamble_savevar.m
@@ -45,7 +45,7 @@ if (isfield(cfg, 'outputfile') && ~isempty(cfg.outputfile)) || exist('Fief7bee_r
       cfg.outputfile{i} = fullfile(Fief7bee_reproducescript, sprintf('%s_output_%s', iW1aenge_now, iW1aenge_postamble{i}));
     end
     % write a snippet of MATLAB code with the user-specified configuration and function call
-    reproducescript(fullfile(Fief7bee_reproducescript, 'script.m'), Fief7bee_cfg, isempty(iW1aenge_postamble))
+    reproducescript(fullfile(Fief7bee_reproducescript, 'script.m'), cfg, isempty(iW1aenge_postamble))
   else
     cfg.outputfile = {};
   end

--- a/utilities/private/ft_preamble_init.m
+++ b/utilities/private/ft_preamble_init.m
@@ -132,6 +132,8 @@ if isfield(cfg, 'reproducescript') && ~isempty(cfg.reproducescript)
     % this variable is used in loadvar, savevar and savefig
     Fief7bee_reproducescript = cfg.reproducescript;
     cfg = rmfield(cfg, 'reproducescript');
+    % remember the user-specified configuration at the start of the FieldTrip function
+    Fief7bee_cfg = cfg;
     % pause one second to ensure that subsequent file names (which contain the time stamp) are unique
     pause(1);
   end

--- a/utilities/private/ft_preamble_init.m
+++ b/utilities/private/ft_preamble_init.m
@@ -132,8 +132,6 @@ if isfield(cfg, 'reproducescript') && ~isempty(cfg.reproducescript)
     % this variable is used in loadvar, savevar and savefig
     Fief7bee_reproducescript = cfg.reproducescript;
     cfg = rmfield(cfg, 'reproducescript');
-    % remember the user-specified configuration at the start of the FieldTrip function
-    Fief7bee_cfg = cfg;
     % pause one second to ensure that subsequent file names (which contain the time stamp) are unique
     pause(1);
   end

--- a/utilities/private/ignorefields.m
+++ b/utilities/private/ignorefields.m
@@ -114,6 +114,7 @@ switch purpose
       'checksize'
       'debug'
       'notification'
+      'reproducescript'
       'showcallinfo'
       'trackcallinfo'
       'trackconfig'

--- a/utilities/private/ignorefields.m
+++ b/utilities/private/ignorefields.m
@@ -130,6 +130,8 @@ switch purpose
       'checksize'
       'debug'
       'notification'
+      'callinfo'
+      'version'
       'showcallinfo'
       'trackcallinfo'
       'trackconfig'
@@ -145,6 +147,7 @@ switch purpose
       'grad'
       'elec'
       'opto'
+      'event'
       };
 
   case 'trackconfig'

--- a/utilities/private/reproducescript.m
+++ b/utilities/private/reproducescript.m
@@ -1,4 +1,4 @@
-function reproducescript(filename, cfg)
+function reproducescript(filename, cfg, outputcfg)
 
 % This is a helper function to create a script that reproduces the analysis. It
 % appends the configuration and the function call to a MATLAB script.
@@ -23,7 +23,12 @@ function reproducescript(filename, cfg)
 %
 % $Id$
 
-tmpcfg = removefields(cfg.callinfo.usercfg, ignorefields('reproducescript'));
+if isfield(cfg, 'callinfo') && isfield(cfg.callinfo, 'usercfg')
+  tmpcfg = removefields(cfg.callinfo.usercfg, ignorefields('reproducescript'));
+else
+  tmpcfg = removefields(cfg, ignorefields('reproducescript'));
+end
+
 tmpcfg = copyfields(cfg, tmpcfg, {'inputfile', 'outputfile'});
 tmpcfg = printstruct('cfg', tmpcfg);
 
@@ -36,6 +41,12 @@ fprintf(fid, "cfg = [];\n");
 fprintf(fid, "%s\n", tmpcfg);
 
 st = dbstack(2);
-fprintf(fid, '%s(cfg);\n\n', st(2).name);
+
+if outputcfg
+  % this is for ft_definetrial, ft_artifact_zvalue, etc.
+  fprintf(fid, 'cfg = %s(cfg);\n\n', st(2).name);
+else
+  fprintf(fid, '%s(cfg);\n\n', st(2).name);
+end
 
 fclose(fid);


### PR DESCRIPTION
I tested some standard (but not so common) analysis steps in a simple script, and ran into issues with functions such as ft_definetrial and the artifact detection functions, which work mostly by outputting a cfg. This PR cleans up those functions and adds support for writing their calls to a script as well. 