### PR TITLE
Update ft_postamble_savefig.m

### DIFF
--- a/utilities/private/ft_postamble_savefig.m
+++ b/utilities/private/ft_postamble_savefig.m
@@ -41,7 +41,7 @@ if (isfield(cfg, 'outputfile') && ~isempty(cfg.outputfile)) || exist('Fief7bee_r
     iW1aenge_now = datestr(now, 30);
     cfg.outputfile = fullfile(Fief7bee_reproducescript, sprintf('%s_output', iW1aenge_now));
     % write a snippet of MATLAB code with the configuration and function call
-    reproducescript(fullfile(Fief7bee_reproducescript, 'script.m'), cfg, isempty(iW1aenge_postamble))
+    reproducescript(fullfile(Fief7bee_reproducescript, 'script.m'), cfg, false)
   else
     cfg.outputfile = [];
   end


### PR DESCRIPTION
Update ft_postamble_savefig.m

if the 3rd input to reproducescript is empty (/nonexistent), reproducescript will crash. However, with the current input, it will write a line in script.m like "cfg=ft_sourceplot(cfg)", thus it will ask for an output of the plotting function. Running this line will make ft_sourceplot crash.

Either the third input to reproducescript shoulde be 'false', or potentially (depending on dependencies of other functions) reproducescript should contain something like "if ~exist(outputcfg, 'var'); outputcfg = 'false';"