### PR TITLE
reproducescript fix in ft_postamble_savefig

### DIFF
--- a/utilities/private/ft_postamble_savefig.m
+++ b/utilities/private/ft_postamble_savefig.m
@@ -52,7 +52,7 @@ if (isfield(cfg, 'outputfile') && ~isempty(cfg.outputfile)) || exist('Fief7bee_r
     end
     
     % write a snippet of MATLAB code with the user-specified configuration and function call
-    reproducescript(fullfile(Fief7bee_reproducescript, 'script.m'), cfg, isempty(iW1aenge_postamble))
+    reproducescript(fullfile(Fief7bee_reproducescript, 'script.m'), cfg, false)
     
   elseif (isfield(cfg, 'outputfile') && ~isempty(cfg.outputfile))
     % keep the output file as it is


### PR DESCRIPTION
Plotting functions do not have cfg outputs. Therefore, reproducescript should not write "cfg = " before the function call.