### PR TITLE
ft_preproc_dftfilter: updated reference for spectrum interpolation

### DIFF
--- a/preproc/ft_preproc_dftfilter.m
+++ b/preproc/ft_preproc_dftfilter.m
@@ -16,9 +16,9 @@ function [filt] = ft_preproc_dftfilter(dat, Fs, Fl, varargin)
 % used to estimate the line noise. The estimate is subtracted from the
 % complete data.
 %
-% B) Alternatively line noise is reduced via spectrum interpolation 
-% (introduced by Mewett et al., 2004, Med. Biol. Eng. Comput. 42, 
-% doi:10.1007/BF02350994). 
+% B) Alternatively line noise is reduced via spectrum interpolation
+% (Leske & Dalal, 2019, NeuroImage 189,
+%  doi: 10.1016/j.neuroimage.2019.01.026)
 % The signal is:
 % I)   transformed into the frequency domain via a discrete Fourier 
 %       transform (DFT), 


### PR DESCRIPTION
ft_preproc_dftfilter: updated reference for spectrum interpolation to newly published Leske & Dalal, NeuroImage, 2019