### PR TITLE
Improve handling of loaded variables in cfg fields and cfg.inputfile

### DIFF
--- a/ft_freqstatistics.m
+++ b/ft_freqstatistics.m
@@ -122,6 +122,9 @@ tmpcfg = keepfields(cfg, {'frequency', 'avgoverfreq', 'latency', 'avgovertime', 
 if strcmp(cfg.correctm, 'cluster') && length(varargin{1}.label)>1
   % this is required for clustering with multiple channels
   ft_checkconfig(cfg, 'required', 'neighbours');
+  if ischar(cfg.neighbours) && strcmp(ft_filetype(cfg.neighbours), 'matlab')
+    cfg.neighbours = loadvar(cfg.neighbours);
+  end
 end
 
 dimord = getdimord(varargin{1}, cfg.parameter);

--- a/ft_megplanar.m
+++ b/ft_megplanar.m
@@ -121,11 +121,14 @@ if isfield(cfg, 'headshape') && isa(cfg.headshape, 'config')
   cfg.headshape = struct(cfg.headshape);
 end
 
-if isfield(cfg, 'neighbours') && isa(cfg.neighbours, 'config')
-  % convert the nested config-object back into a normal structure
-  cfg.neighbours = struct(cfg.neighbours);
+if isfield(cfg, 'neighbours')
+  if ischar(cfg.neighbours) && strcmp(ft_filetype(cfg.neighbours), 'matlab')
+    cfg.neighbours = loadvar(cfg.neighbours);
+  elseif isa(cfg.neighbours, 'config')
+    % convert the nested config-object back into a normal structure
+    cfg.neighbours = struct(cfg.neighbours);
+  end
 end
-
 
 % put the low-level options pertaining to the dipole grid in their own field
 cfg = ft_checkconfig(cfg, 'renamed', {'tightgrid', 'tight'}); % this is moved to cfg.sourcemodel.tight by the subsequent createsubcfg

--- a/ft_sourceanalysis.m
+++ b/ft_sourceanalysis.m
@@ -397,7 +397,9 @@ else
   end
   % construct the dipole positions on which the source reconstruction will be done
   sourcemodel = ft_prepare_sourcemodel(tmpcfg);
-
+  if ischar(cfg.sourcemodel)
+    cfg.sourcemodel = sourcemodel;
+  end
 end
 
 if isfield(cfg.sourcemodel, 'filter')

--- a/ft_timelockstatistics.m
+++ b/ft_timelockstatistics.m
@@ -113,6 +113,9 @@ tmpcfg = keepfields(cfg, {'latency', 'avgovertime', 'channel', 'avgoverchan', 'p
 if strcmp(cfg.correctm, 'cluster') && length(varargin{1}.label)>1
   % this is required for clustering with multiple channels
   ft_checkconfig(cfg, 'required', 'neighbours');
+  if ischar(cfg.neighbours) && strcmp(ft_filetype(cfg.neighbours), 'matlab')
+    cfg.neighbours = loadvar(cfg.neighbours);
+  end
 end
 
 dimord = getdimord(varargin{1}, cfg.parameter);

--- a/private/topoplot_common.m
+++ b/private/topoplot_common.m
@@ -342,10 +342,11 @@ if ~strcmp(cfg.baseline, 'no')
   if ~isempty(cfg.maskparameter)
     tempmask = data.(cfg.maskparameter);
   end
+  tmpcfg = removefields(cfg, 'inputfile');
   if strcmp(xparam, 'time') && strcmp(yparam, 'freq')
-    data = ft_freqbaseline(cfg, data);
+    data = ft_freqbaseline(tmpcfg, data);
   elseif strcmp(xparam, 'time') && strcmp(yparam, '')
-    data = ft_timelockbaseline(cfg, data);
+    data = ft_timelockbaseline(tmpcfg, data);
   end
   % put mask-parameter back if it is set
   if ~isempty(cfg.maskparameter)
@@ -425,10 +426,11 @@ if ~ischar(cfg.xlim) && length(cfg.xlim)>2 %&& any(ismember(dimtok, 'time'))
   nplots = numel(xlims)-1;
   nyplot = ceil(sqrt(nplots));
   nxplot = ceil(nplots./nyplot);
+  tmpcfg = removefields(cfg, 'inputfile');
   for i=1:length(xlims)-1
     subplot(nxplot, nyplot, i);
-    cfg.xlim = xlims(i:i+1);
-    ft_topoplotTFR(cfg, data);
+    tmpcfg.xlim = xlims(i:i+1);
+    ft_topoplotTFR(tmpcfg, data);
   end
   return
 end

--- a/utilities/private/ft_preamble_init.m
+++ b/utilities/private/ft_preamble_init.m
@@ -133,7 +133,7 @@ if isfield(cfg, 'reproducescript') && ~isempty(cfg.reproducescript)
     % with cfg.reproducescript functionality, throw error to make them
     % mutually exclusive
     if (isfield(cfg, 'inputfile') && ~isempty(cfg.inputfile)) || ...
-       (isfield(cfg, 'outputfile') && ~isemty(cfg.outputfile))
+       (isfield(cfg, 'outputfile') && ~isempty(cfg.outputfile))
       ft_error('cfg.reproducescript cannot be used together with a user-specified cfg.inputfile or cfg.outputfile');
     end
     % this variable is used in loadvar, savevar and savefig


### PR DESCRIPTION
If cfg fields (headmodel, sourcemodel, neighbours) contain input file names, load these and replace the cfg field by the actual data (instead of leaving the file name in). This is adapted now in ft_freq/timelockstatistics, ft_megplanar and ft_sourceanalysis. Other fields (like elec) and functions (which ones?) have not yet been tested.
Additionally, excluding cfg.inputfile from cfg inputs to  secondary fieldtrip calls.