### PR TITLE
Add "contributing" doco and .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# EditorConfig file for FieldTrip code style
+# (see https://EditorConfig.org for info)
+
+root = true
+
+[*]
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.m]
+charset = utf-8
+indent_style = space
+indent_size = 2

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+Contributing to FieldTrip
+=========================
+
+## Community interaction
+
+The [FieldTrip GitHub repo](https://github.com/fieldtrip/fieldtrip) is the home for FieldTrip development. Please submit bug reports and pull requests there.
+
+## Style guidelines
+
+Please see the [FieldTrip website guidelines pages](http://www.fieldtriptoolbox.org/tag/guidelines/) for guidelines on contributing to the FieldTrip code base.
+
+### Code style
+
+Please see <http://www.fieldtriptoolbox.org/development/guideline/code/> for a detailed code style guide.
+
+Summary:
+
+* 2 space indents; indent using spaces and not tabs
+* No spaces between function name and opening parenthesis of argument list
+
+### Prose style
+
+* No Oxford commas
+* British English spellings
+

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -17,9 +17,14 @@ Summary:
 
 * 2 space indents; indent using spaces and not tabs
 * No spaces between function name and opening parenthesis of argument list
+* One space after the comma that separates function arguments
+* Vertically align code with spaces in case it improves readability
 
 ### Prose style
 
-* No Oxford commas
-* British English spellings
+Please see <http://www.fieldtriptoolbox.org/development/guideline/documentation/> for a detailed documentation style guide.
+
+Summary:
+
+* American English spelling
 


### PR DESCRIPTION
This PR adds `.editorconfig` and `.github/CONTRIBUTING.md` to make it easier for contributing developers to discover FieldTrip's code style.

The `.github/CONTRIBUTING.md` file will be presented to users automatically by GitHub the first time they make a bug report or pull request. It has a brief summary of FieldTrip's code style, and pointers to the contributors' documentation on the FieldTrip website.

The `.editorconfig` will cause [supporting text editor programs](https://editorconfig.org/#download) to automatically configure line and indentation formatting to match FieldTrip's preferred style. EditorConfig is not supported by Matlab itself, but many other popular text editors support it, so it will work for many users that use an external text editor.