### PR TITLE
documentation - fix "juist" typo in code comments

### DIFF
--- a/@config/private/deepcopy.m
+++ b/@config/private/deepcopy.m
@@ -60,7 +60,7 @@ catch
 end
 
 if success
-  % execute the mex file that was juist created
+  % execute the mex file that was just created
   funname   = mfilename;
   funhandle = str2func(funname);
   [varargout{1:nargout}] = funhandle(varargin{:});

--- a/@config/private/increment.m
+++ b/@config/private/increment.m
@@ -52,7 +52,7 @@ catch
 end
 
 if success
-  % execute the mex file that was juist created
+  % execute the mex file that was just created
   funname   = mfilename;
   funhandle = str2func(funname);
   [varargout{1:nargout}] = funhandle(varargin{:});

--- a/@config/private/setzero.m
+++ b/@config/private/setzero.m
@@ -52,7 +52,7 @@ catch
 end
 
 if success
-  % execute the mex file that was juist created
+  % execute the mex file that was just created
   funname   = mfilename;
   funhandle = str2func(funname);
   [varargout{1:nargout}] = funhandle(varargin{:});

--- a/compat/matlablt2010b/@uint64/abs.m
+++ b/compat/matlablt2010b/@uint64/abs.m
@@ -47,7 +47,7 @@ catch
 end
 
 if success
-  % execute the mex file that was juist created
+  % execute the mex file that was just created
   funname   = mfilename;
   funhandle = str2func(funname);
   [varargout{1:nargout}] = funhandle(varargin{:});

--- a/compat/matlablt2010b/@uint64/max.m
+++ b/compat/matlablt2010b/@uint64/max.m
@@ -47,7 +47,7 @@ catch
 end
 
 if success
-  % execute the mex file that was juist created
+  % execute the mex file that was just created
   funname   = mfilename;
   funhandle = str2func(funname);
   [varargout{1:nargout}] = funhandle(varargin{:});

--- a/compat/matlablt2010b/@uint64/min.m
+++ b/compat/matlablt2010b/@uint64/min.m
@@ -47,7 +47,7 @@ catch
 end
 
 if success
-  % execute the mex file that was juist created
+  % execute the mex file that was just created
   funname   = mfilename;
   funhandle = str2func(funname);
   [varargout{1:nargout}] = funhandle(varargin{:});

--- a/compat/matlablt2010b/@uint64/minus.m
+++ b/compat/matlablt2010b/@uint64/minus.m
@@ -47,7 +47,7 @@ catch
 end
 
 if success
-  % execute the mex file that was juist created
+  % execute the mex file that was just created
   funname   = mfilename;
   funhandle = str2func(funname);
   [varargout{1:nargout}] = funhandle(varargin{:});

--- a/compat/matlablt2010b/@uint64/plus.m
+++ b/compat/matlablt2010b/@uint64/plus.m
@@ -47,7 +47,7 @@ catch
 end
 
 if success
-  % execute the mex file that was juist created
+  % execute the mex file that was just created
   funname   = mfilename;
   funhandle = str2func(funname);
   [varargout{1:nargout}] = funhandle(varargin{:});

--- a/compat/matlablt2010b/@uint64/rdivide.m
+++ b/compat/matlablt2010b/@uint64/rdivide.m
@@ -47,7 +47,7 @@ catch
 end
 
 if success
-  % execute the mex file that was juist created
+  % execute the mex file that was just created
   funname   = mfilename;
   funhandle = str2func(funname);
   [varargout{1:nargout}] = funhandle(varargin{:});

--- a/compat/matlablt2010b/@uint64/times.m
+++ b/compat/matlablt2010b/@uint64/times.m
@@ -47,7 +47,7 @@ catch
 end
 
 if success
-  % execute the mex file that was juist created
+  % execute the mex file that was just created
   funname   = mfilename;
   funhandle = str2func(funname);
   [varargout{1:nargout}] = funhandle(varargin{:});

--- a/contrib/spike/private/spike_crossx.m
+++ b/contrib/spike/private/spike_crossx.m
@@ -43,7 +43,7 @@ catch
 end
 
 if success 
-  % execute the mex file that was juist created
+  % execute the mex file that was just created
   funname = mfilename;
   funhandle = str2func(funname);
   [varargout{1:nargout}] = funhandle(varargin{:});

--- a/external/dipoli/private/solid_angle.m
+++ b/external/dipoli/private/solid_angle.m
@@ -116,7 +116,7 @@ catch
 end
 
 if success
-  % execute the mex file that was juist created
+  % execute the mex file that was just created
   funname   = mfilename;
   funhandle = str2func(funname);
   [varargout{1:nargout}] = funhandle(varargin{:});

--- a/external/openmeeg/private/solid_angle.m
+++ b/external/openmeeg/private/solid_angle.m
@@ -116,7 +116,7 @@ catch
 end
 
 if success
-  % execute the mex file that was juist created
+  % execute the mex file that was just created
   funname   = mfilename;
   funhandle = str2func(funname);
   [varargout{1:nargout}] = funhandle(varargin{:});

--- a/fileio/private/read_ctf_shm.m
+++ b/fileio/private/read_ctf_shm.m
@@ -57,7 +57,7 @@ catch
 end
 
 if success
-  % execute the mex file that was juist created
+  % execute the mex file that was just created
   funname   = mfilename;
   funhandle = str2func(funname);
   [varargout{1:nargout}] = funhandle(varargin{:});

--- a/fileio/private/solid_angle.m
+++ b/fileio/private/solid_angle.m
@@ -116,7 +116,7 @@ catch
 end
 
 if success
-  % execute the mex file that was juist created
+  % execute the mex file that was just created
   funname   = mfilename;
   funhandle = str2func(funname);
   [varargout{1:nargout}] = funhandle(varargin{:});

--- a/fileio/private/write_ctf_shm.m
+++ b/fileio/private/write_ctf_shm.m
@@ -54,7 +54,7 @@ catch
 end
 
 if success
-  % execute the mex file that was juist created
+  % execute the mex file that was just created
   funname   = mfilename;
   funhandle = str2func(funname);
   [varargout{1:nargout}] = funhandle(varargin{:});

--- a/forward/private/lmoutr.m
+++ b/forward/private/lmoutr.m
@@ -83,7 +83,7 @@ catch
 end
 
 if success
-  % execute the mex file that was juist created
+  % execute the mex file that was just created
   funname   = mfilename;
   funhandle = str2func(funname);
   [varargout{1:nargout}] = funhandle(varargin{:});

--- a/forward/private/plgndr.m
+++ b/forward/private/plgndr.m
@@ -56,7 +56,7 @@ if ~has_mex_func()
   end
 end
 
-% execute the mex file that was juist created
+% execute the mex file that was just created
 funname   = mfilename;
 funhandle = str2func(funname);
 [varargout{1:nargout}] = funhandle(varargin{:});

--- a/forward/private/ptriproj.m
+++ b/forward/private/ptriproj.m
@@ -65,7 +65,7 @@ catch
 end
 
 if success
-  % execute the mex file that was juist created
+  % execute the mex file that was just created
   funname   = mfilename;
   funhandle = str2func(funname);
   [varargout{1:nargout}] = funhandle(varargin{:});

--- a/forward/private/solid_angle.m
+++ b/forward/private/solid_angle.m
@@ -116,7 +116,7 @@ catch
 end
 
 if success
-  % execute the mex file that was juist created
+  % execute the mex file that was just created
   funname   = mfilename;
   funhandle = str2func(funname);
   [varargout{1:nargout}] = funhandle(varargin{:});

--- a/inverse/private/solid_angle.m
+++ b/inverse/private/solid_angle.m
@@ -116,7 +116,7 @@ catch
 end
 
 if success
-  % execute the mex file that was juist created
+  % execute the mex file that was just created
   funname   = mfilename;
   funhandle = str2func(funname);
   [varargout{1:nargout}] = funhandle(varargin{:});

--- a/plotting/private/ltrisect.m
+++ b/plotting/private/ltrisect.m
@@ -61,7 +61,7 @@ catch
 end
 
 if success
-  % execute the mex file that was juist created
+  % execute the mex file that was just created
   funname   = mfilename;
   funhandle = str2func(funname);
   [varargout{1:nargout}] = funhandle(varargin{:});

--- a/plotting/private/solid_angle.m
+++ b/plotting/private/solid_angle.m
@@ -116,7 +116,7 @@ catch
 end
 
 if success
-  % execute the mex file that was juist created
+  % execute the mex file that was just created
   funname   = mfilename;
   funhandle = str2func(funname);
   [varargout{1:nargout}] = funhandle(varargin{:});

--- a/private/lmoutr.m
+++ b/private/lmoutr.m
@@ -83,7 +83,7 @@ catch
 end
 
 if success
-  % execute the mex file that was juist created
+  % execute the mex file that was just created
   funname   = mfilename;
   funhandle = str2func(funname);
   [varargout{1:nargout}] = funhandle(varargin{:});

--- a/private/plgndr.m
+++ b/private/plgndr.m
@@ -56,7 +56,7 @@ if ~has_mex_func()
   end
 end
 
-% execute the mex file that was juist created
+% execute the mex file that was just created
 funname   = mfilename;
 funhandle = str2func(funname);
 [varargout{1:nargout}] = funhandle(varargin{:});

--- a/private/ptriproj.m
+++ b/private/ptriproj.m
@@ -65,7 +65,7 @@ catch
 end
 
 if success
-  % execute the mex file that was juist created
+  % execute the mex file that was just created
   funname   = mfilename;
   funhandle = str2func(funname);
   [varargout{1:nargout}] = funhandle(varargin{:});

--- a/private/routlm.m
+++ b/private/routlm.m
@@ -68,7 +68,7 @@ catch
 end
 
 if success
-  % execute the mex file that was juist created
+  % execute the mex file that was just created
   funname   = mfilename;
   funhandle = str2func(funname);
   [varargout{1:nargout}] = funhandle(varargin{:});

--- a/private/solid_angle.m
+++ b/private/solid_angle.m
@@ -116,7 +116,7 @@ catch
 end
 
 if success
-  % execute the mex file that was juist created
+  % execute the mex file that was just created
   funname   = mfilename;
   funhandle = str2func(funname);
   [varargout{1:nargout}] = funhandle(varargin{:});

--- a/src/lmoutr.m
+++ b/src/lmoutr.m
@@ -83,7 +83,7 @@ catch
 end
 
 if success
-  % execute the mex file that was juist created
+  % execute the mex file that was just created
   funname   = mfilename;
   funhandle = str2func(funname);
   [varargout{1:nargout}] = funhandle(varargin{:});

--- a/src/ltrisect.m
+++ b/src/ltrisect.m
@@ -61,7 +61,7 @@ catch
 end
 
 if success
-  % execute the mex file that was juist created
+  % execute the mex file that was just created
   funname   = mfilename;
   funhandle = str2func(funname);
   [varargout{1:nargout}] = funhandle(varargin{:});

--- a/src/meg_leadfield1.m
+++ b/src/meg_leadfield1.m
@@ -64,7 +64,7 @@ catch
 end
 
 if success
-  % execute the mex file that was juist created
+  % execute the mex file that was just created
   funname   = mfilename;
   funhandle = str2func(funname);
   [varargout{1:nargout}] = funhandle(varargin{:});

--- a/src/plgndr.m
+++ b/src/plgndr.m
@@ -56,7 +56,7 @@ if ~has_mex_func()
   end
 end
 
-% execute the mex file that was juist created
+% execute the mex file that was just created
 funname   = mfilename;
 funhandle = str2func(funname);
 [varargout{1:nargout}] = funhandle(varargin{:});

--- a/src/plinproj.m
+++ b/src/plinproj.m
@@ -65,7 +65,7 @@ catch
 end
 
 if success
-  % execute the mex file that was juist created
+  % execute the mex file that was just created
   funname   = mfilename;
   funhandle = str2func(funname);
   [varargout{1:nargout}] = funhandle(varargin{:});

--- a/src/ptriproj.m
+++ b/src/ptriproj.m
@@ -65,7 +65,7 @@ catch
 end
 
 if success
-  % execute the mex file that was juist created
+  % execute the mex file that was just created
   funname   = mfilename;
   funhandle = str2func(funname);
   [varargout{1:nargout}] = funhandle(varargin{:});

--- a/src/read_16bit.m
+++ b/src/read_16bit.m
@@ -54,7 +54,7 @@ catch
 end
 
 if success
-  % execute the mex file that was juist created
+  % execute the mex file that was just created
   funname   = mfilename;
   funhandle = str2func(funname);
   [varargout{1:nargout}] = funhandle(varargin{:});

--- a/src/read_24bit.m
+++ b/src/read_24bit.m
@@ -54,7 +54,7 @@ catch
 end
 
 if success
-  % execute the mex file that was juist created
+  % execute the mex file that was just created
   funname   = mfilename;
   funhandle = str2func(funname);
   [varargout{1:nargout}] = funhandle(varargin{:});

--- a/src/read_ctf_shm.m
+++ b/src/read_ctf_shm.m
@@ -57,7 +57,7 @@ catch
 end
 
 if success
-  % execute the mex file that was juist created
+  % execute the mex file that was just created
   funname   = mfilename;
   funhandle = str2func(funname);
   [varargout{1:nargout}] = funhandle(varargin{:});

--- a/src/rfbevent.m
+++ b/src/rfbevent.m
@@ -86,7 +86,7 @@ catch
 end
 
 if success
-  % execute the mex file that was juist created
+  % execute the mex file that was just created
   funname   = mfilename;
   funhandle = str2func(funname);
   [varargout{1:nargout}] = funhandle(varargin{:});

--- a/src/routlm.m
+++ b/src/routlm.m
@@ -68,7 +68,7 @@ catch
 end
 
 if success
-  % execute the mex file that was juist created
+  % execute the mex file that was just created
   funname   = mfilename;
   funhandle = str2func(funname);
   [varargout{1:nargout}] = funhandle(varargin{:});

--- a/src/solid_angle.m
+++ b/src/solid_angle.m
@@ -116,7 +116,7 @@ catch
 end
 
 if success
-  % execute the mex file that was juist created
+  % execute the mex file that was just created
   funname   = mfilename;
   funhandle = str2func(funname);
   [varargout{1:nargout}] = funhandle(varargin{:});

--- a/src/splint_gh.m
+++ b/src/splint_gh.m
@@ -49,7 +49,7 @@ catch
 end
 
 if success
-  % execute the mex file that was juist created
+  % execute the mex file that was just created
   funname   = mfilename;
   funhandle = str2func(funname);
   [varargout{1:nargout}] = funhandle(varargin{:});

--- a/src/write_ctf_shm.m
+++ b/src/write_ctf_shm.m
@@ -54,7 +54,7 @@ catch
 end
 
 if success
-  % execute the mex file that was juist created
+  % execute the mex file that was just created
   funname   = mfilename;
   funhandle = str2func(funname);
   [varargout{1:nargout}] = funhandle(varargin{:});

--- a/utilities/private/lmoutr.m
+++ b/utilities/private/lmoutr.m
@@ -83,7 +83,7 @@ catch
 end
 
 if success
-  % execute the mex file that was juist created
+  % execute the mex file that was just created
   funname   = mfilename;
   funhandle = str2func(funname);
   [varargout{1:nargout}] = funhandle(varargin{:});

--- a/utilities/private/ptriproj.m
+++ b/utilities/private/ptriproj.m
@@ -65,7 +65,7 @@ catch
 end
 
 if success
-  % execute the mex file that was juist created
+  % execute the mex file that was just created
   funname   = mfilename;
   funhandle = str2func(funname);
   [varargout{1:nargout}] = funhandle(varargin{:});


### PR DESCRIPTION
This just fixes a typo that appears in comments in several MEX stub function files.