### PR TITLE
bugfix - add ft_mex() Octave compatibility shim for mex()

### DIFF
--- a/private/ft_mex.m
+++ b/private/ft_mex.m
@@ -1,0 +1,50 @@
+function ft_mex (varargin)
+
+% FT_MEX is a compatibility shim wrapper for the MEX function. It exists
+% because Octave's mex() function returns a status code instead of raising
+% an error when the compilation fails, unlike Matlab's mex(), which
+% errors on failed compilation. This wrapper smooths over the difference,
+% and always raises an error on failure, regardless of whether you're 
+% running in Matlab or Octave.
+%
+% The signature for FT_MEX is exactly the same as MEX for the system you
+% are running it on. (All its arguments are passed directly on to MEX.)
+% FT_MEX is a drop-in replacement for MEX, and should be used in all places
+% in FieldTrip where MEX would be called.
+%
+% See also: MEX
+
+% Copyright (C) 2019, Andrew Janke
+%
+% This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
+% for the documentation and details.
+%
+%    FieldTrip is free software: you can redistribute it and/or modify
+%    it under the terms of the GNU General Public License as published by
+%    the Free Software Foundation, either version 3 of the License, or
+%    (at your option) any later version.
+%
+%    FieldTrip is distributed in the hope that it will be useful,
+%    but WITHOUT ANY WARRANTY; without even the implied warranty of
+%    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%    GNU General Public License for more details.
+%
+%    You should have received a copy of the GNU General Public License
+%    along with FieldTrip. If not, see <http://www.gnu.org/licenses/>.
+%
+% $Id$
+
+persistent is_octave
+if isempty(is_octave)
+  v = ver;
+  is_octave = ismember('Octave', {v.Name});
+end
+
+if is_octave
+  status = mex(varargin{:});
+  if status != 0
+    ft_error('mex() invocation failed.');
+  end
+else
+  mex(varargin{:});
+end

--- a/private/solid_angle.m
+++ b/private/solid_angle.m
@@ -96,12 +96,12 @@ try
   cd(mexdir);
 
   if ispc
-    mex -I. -c ../../src/geometry.c
-    mex -I. -c solid_angle.c ; mex solid_angle.c solid_angle.obj geometry.obj
+    ft_mex -I. -c ../../src/geometry.c
+    ft_mex -I. -c solid_angle.c ; mex solid_angle.c solid_angle.obj geometry.obj
   else
-    mex -I. -c ../../src/geometry.c
-    mex -I. -c ../../src/solid_angle.c 
-    mex -o solid_angle solid_angle.o geometry.o
+    ft_mex -I. -c ../../src/geometry.c
+    ft_mex -I. -c ../../src/solid_angle.c 
+    ft_mex -o solid_angle solid_angle.o geometry.o
   end
 
   cd(pwdir);


### PR DESCRIPTION
Addresses https://github.com/fieldtrip/fieldtrip/issues/1027#issuecomment-475988296. Closes #1032.

Are you interested in Octave compatibility?

One of the compatibility problems with Octave is that its `mex` function returns a status code instead of raising an error on failure. So the logic in the MEX stub functions that build MEX files on the fly doesn't detect compilation failures, and end up going into an infinite loop on Octave.

This PR illustrates an approach that could be used to fix FT's usage of Octave's MEX. It's just a wrapper function that detects when it's running on Octave and does the error checking.

The downside is that most or all existing `mex` calls would need to be changed to call `ft_mex` instead, and copies made to different `private/` folders.

### Alternative approaches

I also tried the simple way of just putting a compatibility shim at `compat/octave/mex.m`.

```
function mex(varargin)
  status = builtin('mex', varargin{:});
  if status != 0
    error('mex() invocation failed');
  endif
endfunction
```

But that doesn't work. `mex` is not a built-in function, and it just causes Octave to crash.

It's possible this approach could be made to work by dynamically messing with the load path while the `mex` compatibility shim is running, so Octave's own `mex.m` becomes visible again and can be called. Or maybe by constructing a function handle to Octave's own `mex` using the full path to the file.