### PR TITLE
bugfix - Add mex() compatibility shim for Octave

### DIFF
--- a/compat/octave/mex.m
+++ b/compat/octave/mex.m
@@ -1,0 +1,44 @@
+% MEX is a Matlab compatibility shim wrapper for the MEX function. It exists
+% because Octave's mex() function returns a status code instead of raising
+% an error when the compilation fails, unlike Matlab's mex(), which
+% errors on failed compilation. This wrapper smooths over the difference,
+% and makes mex() raise errors on failure in Octave, too.
+%
+%
+%
+% See also: MEX
+
+% Copyright (C) 2019, Andrew Janke
+%
+% This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
+% for the documentation and details.
+%
+%    FieldTrip is free software: you can redistribute it and/or modify
+%    it under the terms of the GNU General Public License as published by
+%    the Free Software Foundation, either version 3 of the License, or
+%    (at your option) any later version.
+%
+%    FieldTrip is distributed in the hope that it will be useful,
+%    but WITHOUT ANY WARRANTY; without even the implied warranty of
+%    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%    GNU General Public License for more details.
+%
+%    You should have received a copy of the GNU General Public License
+%    along with FieldTrip. If not, see <http://www.gnu.org/licenses/>.
+%
+% $Id$
+
+function mex(varargin)
+  real_mex_dir = [matlabroot, '/share/octave/' version '/m/miscellaneous'];
+  %status = builtin('mex', varargin{:});
+  unwind_protect
+    addpath(real_mex_dir, '-begin');
+    status = mex(varargin{:});
+    if status != 0
+      error('mex() invocation failed');
+    endif
+  unwind_protect_cleanup
+    % Shuffle it back to the end of the path
+    addpath(real_mex_dir, '-end');
+  end_unwind_protect
+endfunction


### PR DESCRIPTION
Addresses #1027 (comment). Closes #1031.

Are you interested in Octave compatibility?

One of the compatibility problems with Octave is that its `mex()` function returns a status code instead of raising an error on failure. So the logic in the FT MEX stub functions that build MEX files on the fly doesn't detect compilation failures, and end up going into an infinite loop on Octave.

This PR adds a `mex.m` compatibility shim to `compat/octave`. It uses `addpath()` hackery to get access to Octave's own `mex()` function. (It can't use `builtin`, because `mex.m` is not a builtin.)

This is an alternative approach to https://github.com/fieldtrip/fieldtrip/pull/1031. The upside is that no additional code changes are needed – existing FT code can still just call `mex` instead of a special `ft_mex` wrapper function. The downside is that it uses dynamic path hackery, which is an advanced technique, which you may not be comfortable with.

I'll leave both PRs open and let you decide which approach, if either, you like.

### Testing

With this in place, `mex` errors are correctly recognized.

```
>> addpath ~/local/repos/fieldtrip
>> ft_defaults
warning: strmatch is obsolete; use strncmp or strcmp instead
>> run_trials
Loaded EEGTrial support functions and helpers from /Users/janke/local/repos/oh-oh-thesis
creating sourcemodel based on inward-shifted brain surface from volume conductor model
using electrodes specified in the configuration
warning: trying to compile MEX file from /Users/janke/local/repos/fieldtrip/private/solid_angle.c
 In '/Users/janke/local/repos/fieldtrip/private/solid_angle.m' at line 95
 In '/Users/janke/local/repos/fieldtrip/private/bounding_mesh.m' at line 73
 In '/Users/janke/local/repos/fieldtrip/private/find_outermost_boundary.m' at line 45
 In '/Users/janke/local/repos/fieldtrip/private/headsurface.m' at line 197
 In '/Users/janke/local/repos/fieldtrip/ft_prepare_sourcemodel.m' at line 557

clang: error: no such file or directory: '../../src/geometry.c'
clang: error: no input files
warning: mkoctfile: building exited with failure status
mex() invocation failed
error: could not locate MEX file for solid_angle
error: called from
    ft_notification at line 343 column 11
    ft_error at line 39 column 3
    solid_angle at line 113 column 3
    bounding_mesh at line 73 column 12
    find_outermost_boundary at line 45 column 17
    headsurface at line 197 column 26
    ft_prepare_sourcemodel at line 557 column 23
    create_sourcemodels at line 21 column 17
    prepare_trial_runs at line 14 column 20
    run_trials at line 36 column 18
>>
```

The error that crops up here is due to https://github.com/fieldtrip/fieldtrip/issues/1027. This is an improvement, because now it's recognized as an error and the function aborts, instead of throwing Octave into an infinite loop.