### PR TITLE
Octave compatibility for `ft_compile_mex`

### DIFF
--- a/src/mxDeserialize_cpp.cpp
+++ b/src/mxDeserialize_cpp.cpp
@@ -5,6 +5,8 @@
 #if defined(__cplusplus) && defined(MATRIX_DLL_EXPORT_SYM)
     #define EXTERN_C extern
     namespace matrix{ namespace detail{ namespace noninlined{ namespace mx_array_api{
+#else
+    #define EXTERN_C
 #endif
  
 EXTERN_C mxArray* mxSerialize(mxArray const *);

--- a/src/mxSerialize_cpp.cpp
+++ b/src/mxSerialize_cpp.cpp
@@ -5,6 +5,8 @@
 #if defined(__cplusplus) && defined(MATRIX_DLL_EXPORT_SYM)
     #define EXTERN_C extern
     namespace matrix{ namespace detail{ namespace noninlined{ namespace mx_array_api{
+#else
+    #define EXTERN_C
 #endif
  
 EXTERN_C mxArray* mxSerialize(mxArray const *);


### PR DESCRIPTION
This PR modifies `ft_compile_mex` for Octave compatibility.

Addresses https://github.com/fieldtrip/fieldtrip/issues/1027#issuecomment-476180568.

The big issue with Octave compatibility is that it picks up files inside `@class` directories when you `cd` in to them and sees them as global functions. This PR restructures `ft_compile_mex` to not change into the individual source directories when it's doing compiling. Also addresses differences in Octave `mex()`'s signature from Matlab's `mex()`.

With this change, everything is compiling on Octave 4.4.1 on macOS for me, except `mxSerialize` and `mxDeserialize`.

```
Compiling MEX file src/mxSerialize_cpp ...
  mex -v /Users/janke/local/repos/fieldtrip/src/mxSerialize_cpp.cpp -I/Users/janke/local/repos/fieldtrip/src --output /Users/janke/local/repos/fieldtrip/src/mxSerialize_cpp
Undefined symbols for architecture x86_64:
  "mxSerialize(void const*)", referenced from:
      _mexFunction in mxSerialize_cpp.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
warning: mkoctfile: building exited with failure status
clang++ -std=gnu++11 -c  -fPIC -I/usr/local/Cellar/octave/4.4.1_6/include/octave-4.4.1/octave/.. -I/usr/local/Cellar/octave/4.4.1_6/include/octave-4.4.1/octave -I/usr/local/Cellar/octave/4.4.1_6/include  -D_THREAD_SAFE -pthread -I/Library/Java/JavaVirtualMachines/openjdk-11.0.2.jdk/Contents/Home/include -I/Library/Java/JavaVirtualMachines/openjdk-11.0.2.jdk/Contents/Home/include/darwin   -I. -I/Users/janke/local/repos/fieldtrip/src  /Users/janke/local/repos/fieldtrip/src/mxSerialize_cpp.cpp -o mxSerialize_cpp.o
clang++ -std=gnu++11 -I/usr/local/Cellar/octave/4.4.1_6/include/octave-4.4.1/octave/.. -I/usr/local/Cellar/octave/4.4.1_6/include/octave-4.4.1/octave -I/usr/local/Cellar/octave/4.4.1_6/include  -D_THREAD_SAFE -pthread -I/Library/Java/JavaVirtualMachines/openjdk-11.0.2.jdk/Contents/Home/include -I/Library/Java/JavaVirtualMachines/openjdk-11.0.2.jdk/Contents/Home/include/darwin -bundle -bundle_loader /usr/local/Cellar/octave/4.4.1_6/bin/octave-4.4.1  -o /Users/janke/local/repos/fieldtrip/src/mxSerialize_cpp.mex  mxSerialize_cpp.o   -L/usr/local/Cellar/octave/4.4.1_6/lib/octave/4.4.1 -L/usr/local/Cellar/octave/4.4.1_6/lib -loctinterp -loctave
mex compilation failed: -v /Users/janke/local/repos/fieldtrip/src/mxSerialize_cpp.cpp -I/Users/janke/local/repos/fieldtrip/src --output /Users/janke/local/repos/fieldtrip/src/mxSerialize_cpp
error: called from
    ft_compile_mex>my_mex at line 242 column 5
    ft_compile_mex>compile_mex_list at line 234 column 3
    ft_compile_mex at line 121 column 3
octave:11> ver
----------------------------------------------------------------------
GNU Octave Version: 4.4.1 (hg id: 1f46d371968c)
GNU Octave License: GNU General Public License
Operating System: Darwin 18.2.0 Darwin Kernel Version 18.2.0: Thu Dec 20 20:46:53 PST 2018; root:xnu-4903.241.1~1/RELEASE_X86_64 x86_64
----------------------------------------------------------------------
```

Looks like a problem with the MX API thing they're setting up in the defines.

```
// MX_API_VER has unfortunately not changed between R2013b and R2014a,
// so we use the new MATRIX_DLL_EXPORT_SYM as an ugly hack instead
#if defined(__cplusplus) && defined(MATRIX_DLL_EXPORT_SYM)
    #define EXTERN_C extern
    namespace matrix{ namespace detail{ namespace noninlined{ namespace mx_array_api{
#endif
```

It's not working on macOS for me under R2017b or R2018b because `mex` doesn't like the `'CFLAGS=''-std=c99 -fPIC'''` argument.

```
Compiling MEX file external/fileexchange/CalcMD5 ...
Building with 'Xcode with Clang'.
Error using mex
error: invalid value 'c99 -fPIC' in '-std=c99 -fPIC'
note: use 'c89', 'c90', or 'iso9899:1990' for 'ISO C 1990' standard
note: use 'iso9899:199409' for 'ISO C 1990 with amendment 1' standard
note: use 'gnu89' or 'gnu90' for 'ISO C 1990 with GNU extensions' standard
note: use 'c99' or 'iso9899:1999' for 'ISO C 1999' standard
note: use 'gnu99' for 'ISO C 1999 with GNU extensions' standard
note: use 'c11' or 'iso9899:2011' for 'ISO C 2011' standard
note: use 'gnu11' for 'ISO C 2011 with GNU extensions' standard
note: use 'c17' or 'iso9899:2017' for 'ISO C 2017' standard
note: use 'gnu17' for 'ISO C 2017 with GNU extensions' standard

Error in ft_compile_mex>my_mex (line 244)
  mex(varargin{:});
Error in ft_compile_mex>compile_mex_list (line 233)
  my_mex(mex_args{:});
Error in ft_compile_mex (line 121)
  compile_mex_list(L, ftpath, force); 
```

### References

* https://undocumentedmatlab.com/blog/serializing-deserializing-matlab-data