### PR TITLE
Fix synchronize private warnings

### DIFF
--- a/bin/synchronize-private.sh
+++ b/bin/synchronize-private.sh
@@ -9,13 +9,13 @@
 ################################################################################
 
 function sync {
-# find the latest file from the list and copies it to all other files
-latest=`ls -t $* | head -n1`
-for file in $*; do
-if [ $file != $latest ] ; then
-cp $latest $file
-fi
-done
+  # find the latest file from the list and copies it to all other files
+  latest=`ls -t $* | head -n1`
+  for file in $*; do
+    if [ $file != $latest ] ; then
+      cp $latest $file
+    fi
+  done
 }
 
 ################################################################################

--- a/bin/synchronize-private.sh
+++ b/bin/synchronize-private.sh
@@ -12,8 +12,10 @@ function sync {
   # find the latest file from the list and copies it to all other files
   latest=`ls -t $* 2>/dev/null | head -n1`
   for file in $*; do
-    if [ "$file" != "$latest" ] ; then
-      cp "$latest" "$file"
+    if [ -n "$latest" ]; then
+      if [ "$file" != "$latest" ] ; then
+        cp "$latest" "$file"
+      fi
     fi
   done
 }

--- a/bin/synchronize-private.sh
+++ b/bin/synchronize-private.sh
@@ -10,7 +10,7 @@
 
 function sync {
   # find the latest file from the list and copies it to all other files
-  latest=`ls -t $* | head -n1`
+  latest=`ls -t $* 2>/dev/null | head -n1`
   for file in $*; do
     if [ "$file" != "$latest" ] ; then
       cp "$latest" "$file"

--- a/bin/synchronize-private.sh
+++ b/bin/synchronize-private.sh
@@ -12,8 +12,8 @@ function sync {
   # find the latest file from the list and copies it to all other files
   latest=`ls -t $* | head -n1`
   for file in $*; do
-    if [ $file != $latest ] ; then
-      cp $latest $file
+    if [ "$file" != "$latest" ] ; then
+      cp "$latest" "$file"
     fi
   done
 }


### PR DESCRIPTION
Fixes #1037.

Corrects warnings coming from multiple issues:
* The arguments to `ls` may not exist
* The inputs may be empty, and if used unquoted will cause a degenerate `[... != ...]` comparison
* The `cp` is attempted even if the source file does not exist.

This PR fixes all three of them.

Before:

```
$ bin/synchronize-private.sh                                                                                                                                  master
ls: connectivity/private/det3x3.mexglx: No such file or directory
ls: src/det3x3.mexglx: No such file or directory
bin/synchronize-private.sh: line 15: [: connectivity/private/det3x3.mexglx: unary operator expected
bin/synchronize-private.sh: line 15: [: src/det3x3.mexglx: unary operator expected
ls: connectivity/private/det3x3.mexmaci: No such file or directory
ls: src/det3x3.mexmaci: No such file or directory
bin/synchronize-private.sh: line 15: [: connectivity/private/det3x3.mexmaci: unary operator expected
bin/synchronize-private.sh: line 15: [: src/det3x3.mexmaci: unary operator expected
ls: connectivity/private/det3x3.mexmaci64: No such file or directory
ls: private/det3x3.mexmaci64: No such file or directory
ls: src/det3x3.mexmaci64: No such file or directory
bin/synchronize-private.sh: line 15: [: connectivity/private/det3x3.mexmaci64: unary operator expected
bin/synchronize-private.sh: line 15: [: private/det3x3.mexmaci64: unary operator expected
bin/synchronize-private.sh: line 15: [: src/det3x3.mexmaci64: unary operator expected
ls: connectivity/private/det3x3.mexw32: No such file or directory
ls: src/det3x3.mexw32: No such file or directory
bin/synchronize-private.sh: line 15: [: connectivity/private/det3x3.mexw32: unary operator expected
bin/synchronize-private.sh: line 15: [: src/det3x3.mexw32: unary operator expected
ls: connectivity/private/det3x3.mexw64: No such file or directory
ls: src/det3x3.mexw64: No such file or directory
```

After:

```
$ bin/synchronize-private.sh
$
```