### PR TITLE
Update ft_prepare_leadfield.m

### DIFF
--- a/ft_prepare_leadfield.m
+++ b/ft_prepare_leadfield.m
@@ -200,6 +200,9 @@ end
 insideindx = find(sourcemodel.inside);
 
 if ft_headmodeltype(headmodel, 'openmeeg')
+  
+  ft_hastoolbox('openmeeg', 1);  % add to path (if not yet on path)
+  
   % repeated system calls to the openmeeg executable makes it rather slow
   % calling it once is much more efficient
   fprintf('calculating leadfield for all positions at once, this may take a while...\n');


### PR DESCRIPTION
Added openmeeg toolbox to matlab path before calling ft_sensinterp_openmeeg, which otherwise would result in an error if the path to openmeeg was not set by an earlier function in the same matlab session.