### PR TITLE
enhancement - add option to return 'ft_test report' results in a table

### DIFF
--- a/utilities/ft_test.m
+++ b/utilities/ft_test.m
@@ -1,4 +1,4 @@
-function ft_test(varargin)
+function out = ft_test(varargin)
 
 % FT_TEST performs selected FieldTrip test scripts or reports on previous test
 % results from the dashboard database.
@@ -58,6 +58,11 @@ function ft_test(varargin)
 %   hostname         = string
 %   user             = string
 %
+% Optionally, you may capture the output to get the results as a Matlab table
+% array, in which case they are not automatically displayed.
+%   rslt = ft_test('report', 'fieldtripversion', 'cef3396');
+%
+%
 % ========= Comparing tests =========
 %
 % To print a table comparing different test results, you would do
@@ -101,11 +106,17 @@ switch (varargin{1})
   case 'moxunit_run'
     ft_test_moxunit_run(varargin{:});
   case 'report'
-    ft_test_report(varargin{:});
+    if nargout == 0
+      ft_test_report(varargin{:});
+    else
+      out = ft_test_report(varargin{:});
+    end
   case 'compare'
     ft_test_compare(varargin{:});
   otherwise
     ft_error('unsupported command "%s"', varargin{1})
 end % switch
 
-
+if nargin == 0
+  clear out
+end

--- a/utilities/private/ft_test_compare.m
+++ b/utilities/private/ft_test_compare.m
@@ -81,7 +81,7 @@ for i=1:numel(functionname)
 end % for each of the features
 
 % convert the struct-array to a table
-table = struct2table(summary);
+table = struct2tablestrs(summary);
 fprintf('%s\n', table{:});
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/utilities/private/ft_test_report.m
+++ b/utilities/private/ft_test_report.m
@@ -82,6 +82,10 @@ if ~showdate
 end
 
 % convert the struct-array to a table
-table = struct2table(result);
-fprintf('%s\n', table{:});
+if nargout == 0
+  tbl = struct2tablestrs(result);
+  fprintf('%s\n', tbl{:});
+else
+  result = struct2table(result);
+end
 

--- a/utilities/private/struct2tablestrs.m
+++ b/utilities/private/struct2tablestrs.m
@@ -1,13 +1,13 @@
-function table = struct2table(s)
+function table = struct2tablestrs(s)
 
-% STRUCT2TABLE converts a struct-array to a cell-array of strings that represents a table
+% STRUCT2TABLESTRS converts a struct-array to a cell-array of strings that represents a table
 %
 % Example
 %   s(1).a = 1
 %   s(1).b = 2
 %   s(2).a = 3
 %   s(2).b = 4
-%   disp(struct2table(s))
+%   disp(struct2tablestrs(s))
 %
 % See also PRINTSTRUCT, APPENDSTRUCT
 


### PR DESCRIPTION
Addresses https://github.com/fieldtrip/fieldtrip/issues/1024#issuecomment-477354678.

After:

```
>> rslt = ft_test('report', 'fieldtripversion', 'cef3396');
>> class(rslt)
ans =
    'table'
>> summary(rslt)
Variables:
    matlabversion: 2480×1 cell array of character vectors
    fieldtripversion: 2480×1 cell array of character vectors
    branch: 2480×1 cell array of character vectors
    arch: 2480×1 cell array of character vectors
    hostname: 2480×1 cell array of character vectors
    user: 2480×1 cell array of character vectors
    passed: 2480×1 logical
        Values:
            True       2448  
            False        32  
    runtime: 2480×1 double
        Values:
            Min             0  
            Median         10  
            Max         11893  
    functionname: 2480×1 cell array of character vectors
>> 
```

If you do not capture the output, behavior does not change.