### PR TITLE
enhancement - ft_test: add 'inventorize' mode to just list selected tests

### DIFF
--- a/utilities/ft_test.m
+++ b/utilities/ft_test.m
@@ -1,4 +1,4 @@
-function ft_test(varargin)
+function out = ft_test(varargin)
 
 % FT_TEST performs selected FieldTrip test scripts or reports on previous test
 % results from the dashboard database.
@@ -98,6 +98,12 @@ function ft_test(varargin)
 switch (varargin{1})
   case 'run'
     ft_test_run(varargin{:});
+  case 'inventorize'
+    if nargout == 0
+      ft_test_run('run', varargin{2:end}, 'inventorize', 'yes');
+    else
+      out = ft_test_run('run', varargin{2:end}, 'inventorize', 'yes');
+    end
   case 'moxunit_run'
     ft_test_moxunit_run(varargin{:});
   case 'report'

--- a/utilities/private/ft_test_run.m
+++ b/utilities/private/ft_test_run.m
@@ -1,4 +1,4 @@
-function passed = ft_test_run(varargin)
+function out = ft_test_run(varargin)
 
 % FT_TEST_RUN
 
@@ -27,7 +27,8 @@ command = varargin{1};
 assert(isequal(command, 'run'));
 varargin = varargin(2:end);
 
-optbeg = find(ismember(varargin, {'dependency', 'dccnpath', 'maxmem', 'maxwalltime', 'upload', 'assertclean'}));
+optbeg = find(ismember(varargin, {'dependency', 'dccnpath', 'maxmem', 'maxwalltime', ...
+  'upload', 'assertclean', 'inventorize'}));
 if ~isempty(optbeg)
   optarg   = varargin(optbeg:end);
   varargin = varargin(1:optbeg-1);
@@ -45,6 +46,7 @@ maxmem      = ft_getopt(optarg, 'maxmem', inf);
 maxwalltime = ft_getopt(optarg, 'maxwalltime', inf);
 upload      = ft_getopt(optarg, 'upload', 'yes');
 assertclean = ft_getopt(optarg, 'assertclean', 'yes');
+inventorize = ft_getopt(optarg, 'inventorize', 'no');
 
 if ischar(dependency)
   % this should be a cell-array
@@ -92,6 +94,15 @@ for i=1:numel(functionlist)
   filelist{i} = which(functionlist{i});
 end
 
+if istrue(inventorize)
+  if nargout == 0
+    fprintf('considering %d test functions for execution:\n', numel(filelist));
+    fprintf('%s\n', strjoin(strcat({'  '}, filelist), '\n'));
+  else
+    out.files = filelist;
+  end
+  return
+end
 fprintf('considering %d test functions for execution\n', numel(filelist));
 
 %% make a subselection based on the filters
@@ -196,6 +207,8 @@ for i=1:numel(functionlist)
   result.passed           = passed;
   result.runtime          = runtime;
   result.functionname     = functionlist{i};
+  
+  out = passed;
   
   if istrue(upload)
     try


### PR DESCRIPTION
Addresses https://github.com/fieldtrip/fieldtrip/issues/1024#issuecomment-477356186

Now you can run `ft_test inventorize ...` with all the same options as `ft_test run ...` to see which tests would be selected for running, without having to actually execute them.

```
>> ft_test inventorize test_bug46 test_bug2399
considering 2 test functions for execution:
  /Users/janke/local/repos/fieldtrip/test/test_bug46.m
  /Users/janke/local/repos/fieldtrip/test/test_bug2399.m
>> tests = ft_test('inventorize', 'test_bug46', 'test_bug2399')
tests = 
  struct with fields:

    files: {'/Users/janke/local/repos/fieldtrip/test/test_bug46.m'  '/Users/janke/local/repos/fieldtrip/test/test_bug2399.m'}
>> 
```

I've chosen to return them in a struct holding a cell array of files, instead of just a plain cell array of files, so it could be compatibly extended to include other aspects of the prospective test run, such as detected dependencies, whether the dccn path was found, the wall time and memory limits, and so on.