### PR TITLE
FIX #1051 - print ft_test results as Markdown table, ...

### DIFF
--- a/utilities/ft_test.m
+++ b/utilities/ft_test.m
@@ -117,17 +117,18 @@ switch (varargin{1})
     result = ft_test_run(varargin{:});
   case 'inventorize'
     result = ft_test_run(varargin{:}); % this uses the same code as 'run'
-  case 'moxunit_run'
-    ft_test_moxunit_run(varargin{:});
   case 'report'
     result = ft_test_report(varargin{:});
   case 'compare'
-    ft_test_compare(varargin{:});
+    result = ft_test_compare(varargin{:});
+  case 'moxunit_run'
+    ft_test_moxunit_run(varargin{:});
   otherwise
     ft_error('unsupported command "%s"', varargin{1})
 end % switch
 
-if ~nargout
-  % do not return 'ans'
+if ~nargout && exist('result', 'var')
+  % show it on screen, do not return 'ans'
+  printstruct_as_table(result);
   clear result
 end

--- a/utilities/private/ft_test_compare.m
+++ b/utilities/private/ft_test_compare.m
@@ -1,4 +1,4 @@
-function ft_test_compare(varargin)
+function [summary] = ft_test_compare(varargin)
 
 % FT_TEST_COMPARE
 
@@ -79,10 +79,6 @@ for i=1:numel(functionname)
     summary(i).(fn) = haspassed(results{j}, sel);
   end % for each functionname
 end % for each of the features
-
-% convert the struct-array to a table
-table = struct2tablestrs(summary);
-fprintf('%s\n', table{:});
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % SUBFUNCTION to convert the boolean result into a string

--- a/utilities/private/ft_test_report.m
+++ b/utilities/private/ft_test_report.m
@@ -1,4 +1,4 @@
-function result = ft_test_report(varargin)
+function [result] = ft_test_report(varargin)
 
 % FT_TEST_REPORT
 
@@ -81,11 +81,4 @@ if ~showdate
   result = removefields(result, 'date');
 end
 
-% convert the struct-array to a table
-if nargout == 0
-  tbl = struct2tablestrs(result);
-  fprintf('%s\n', tbl{:});
-else
-  result = struct2table(result);
-end
 

--- a/utilities/private/printstruct_as_table.m
+++ b/utilities/private/printstruct_as_table.m
@@ -1,17 +1,17 @@
-function table = struct2tablestrs(s)
+function printstruct_as_table(s)
 
-% STRUCT2TABLESTRS converts a struct-array to a cell-array of strings that represents a table
+% PRINTSTRUCT_AS_TABLE prints a struct-array as a table in Markdown format
 %
 % Example
 %   s(1).a = 1
 %   s(1).b = 2
 %   s(2).a = 3
 %   s(2).b = 4
-%   disp(struct2tablestrs(s))
+%   printstruct_as_table(s)
 %
 % See also PRINTSTRUCT, APPENDSTRUCT
 
-% Copyright (C) 2017, Robert Oostenveld
+% Copyright (C) 2017-2019, Robert Oostenveld
 %
 % This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
 % for the documentation and details.
@@ -74,6 +74,7 @@ for i=1:numel(fn)
 end
 
 divider = repmat('-', size(header));
+divider(header=='|') = '|';
 
 % divider = header;
 % divider(divider~='|') = '-';
@@ -87,3 +88,4 @@ for i=1:numel(s)
 end
 
 table = cat(1, header, divider, line);
+fprintf('%s\n', table{:});


### PR DESCRIPTION
... or return them as struct-array. 

I made the output argument handling of the ft_test commands more consistent. they now all return a struct-array (except for moxunit_run) and if no output arg is specified, the array is printed as a Markdown formatted table. 

e.g.

```>> ft_test inventorize maxwalltime 600```


|                                functionname |        mem | walltime |
|---------------------------------------------|------------|----------|
|            test_benchmark_ft_bandpassfilter | 1073741824 |      600 |
|            test_benchmark_ft_bandstopfilter | 1073741824 |      600 |
|           test_benchmark_ft_baselinecorrect | 1073741824 |      600 |
|                test_benchmark_ft_derivative | 1073741824 |      600 |
|                   test_benchmark_ft_detrend | 1073741824 |      600 |
|                 test_benchmark_ft_dftfilter | 1073741824 |      600 |
|            test_benchmark_ft_highpassfilter | 1073741824 |      600 |
...

and  

```>> ft_test report test_bug3219```

| matlabversion | fieldtripversion |       branch |    arch |  hostname |   user | passed | runtime | functionname |
|---------------|------------------|--------------|---------|-----------|--------|--------|---------|--------------|
|         2016b |          cef3396 |       master | glnxa64 | dccn-c038 | roboos |   true |       2 | test_bug3219 |
|         2016b |          cef3396 |       master | glnxa64 | dccn-c021 | roboos |   true |       7 | test_bug3219 |
|         2016b |          cef3396 |       master | glnxa64 | dccn-c034 | roboos |   true |       4 | test_bug3219 |
|         2016b |          cef3396 |       master | glnxa64 | dccn-c042 | roboos |   true |       2 | test_bug3219 |
|         2016b |          7121540 |       master | glnxa64 | dccn-c039 | roboos |   true |       2 | test_bug3219 |
|         2016b |          01281e8 |       master | glnxa64 | dccn-c038 | roboos |   true |       2 | test_bug3219 |
|         2016b |          ae0fe35 |       master | glnxa64 | dccn-c040 | roboos |   true |       2 | test_bug3219 |
...

Pasting the table here on github, I even see that the fieldtripversion is automatically linked. Cool!