### PR TITLE
bugfix - fix ft_defaults detection of utilities toolbox

### DIFF
--- a/ft_defaults.m
+++ b/ft_defaults.m
@@ -149,7 +149,7 @@ end
 
 if ~isdeployed
 
-  if isempty(which('ft_hastoolbox')) || isempty(which('ft_platform_supports'))
+  if isempty(which('ft_test')) || isempty(which('ft_notice'))
     % the fieldtrip/utilities directory contains the ft_hastoolbox and ft_warning
     % functions, which are required for the remainder of this script
     addpath(fullfile(fileparts(which('ft_defaults')), 'utilities'));


### PR DESCRIPTION
Fixes #1058.

Looks like some files have moved around, so ft_defaults is now incorrectly
thinking that utilities is already loaded. This changes it to look for functions
which are currently only present in the utilities toolbox, and not in any
of the private/ directories.