### PR TITLE
enh: added disc plotting utility to test battery, and cylinder subfunction to plot_sens and plot_cloud

### DIFF
--- a/test/test_ft_plot_cloud.m
+++ b/test/test_ft_plot_cloud.m
@@ -16,6 +16,7 @@ seg.brain = ones(50, 50, 50);
 cfg = [];
 cfg.tissue = 'brain';
 cfg.numvertices = 100;
+cfg.spmversion = 'spm12';
 mesh1 = ft_prepare_mesh(cfg, seg);
 
 seg.brain = zeros(50, 50, 50);
@@ -74,6 +75,9 @@ figure; ft_plot_cloud(pos, val, 'mesh', {mesh1, mesh2}, 'facealpha', [.5 1], 'fa
 % these two should be the same
 figure; ft_plot_cloud(pos, val, 'mesh', {mesh1, mesh2}, 'facealpha', 0, 'edgealpha', [.5 1], 'edgecolor', {'r', 'b'});
 figure; ft_plot_cloud(pos, val, 'mesh', {mesh1, mesh2}, 'facealpha', 0, 'edgealpha', [.5 1], 'edgecolor', {[1 0 0], [0 0 1]});
+
+% plot electrodes as discs
+figure; ft_plot_cloud(pos, val, 'cloudtype', 'disc', 'mesh', mesh1);
 
 %%
 % slice options

--- a/test/test_ft_plot_sens.m
+++ b/test/test_ft_plot_sens.m
@@ -35,3 +35,15 @@ figure; ft_plot_sens(elec, 'elec', true, 'individual', false, 'orientation', tru
 figure; ft_plot_sens(elec, 'elec', true, 'individual', false, 'orientation', true, 'elecshape', 'square');
 figure; ft_plot_sens(elec, 'elec', true, 'individual', false, 'orientation', true, 'elecshape', 'sphere');
 
+% plot electrodes as discs
+seg.dim = [50 50 50];
+seg.transform = eye(4);
+seg.unit = 'mm';
+seg.brain = ones(50, 50, 50);
+cfg = [];
+cfg.tissue = 'brain';
+cfg.numvertices = 100;
+cfg.spmversion = 'spm12';
+mesh = ft_prepare_mesh(cfg, seg);
+
+figure; ft_plot_sens(elec, 'elecshape', 'disc', 'headshape', mesh);


### PR DESCRIPTION
This fixes an issue introduced by one of my own functions being on the path. To this end, I have included a cylinder generation tool as a subfunction in ft_plot_sens and ft_plot_cloud, which is used to create disc-shaped electrodes that are aligned to the mesh (think of an ECoG grid/strip array).

Second, this PR includes updates to the test functions corresponding to the above functions.