### PR TITLE
Issue with preproc.m when using cfg.implicitref

### DIFF
--- a/private/preproc.m
+++ b/private/preproc.m
@@ -257,7 +257,7 @@ end
 % do the rereferencing in case of EEG
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 if ~isempty(cfg.implicitref) && ~any(match_str(cfg.implicitref,label))
-  label = {label{:} cfg.implicitref};
+  label = {label{:} cfg.implicitref}';
   dat(end+1,:) = 0;
 end
 


### PR DESCRIPTION
bugfix - fixed a problem line 260. When calling **cfg.implicitref**, the implicit ref is added to the list of channels **label** - a Nchan x 1  cell array - but the output **label** becomes 1 x Nchan cell array, whereas it should be Nchan x 1 cell array. This can be solved by adding an apostrophe operator to transpose the resulting array. 