### PR TITLE
ENH: built in support for IRASA in ft_freqanalysis

### DIFF
--- a/ft_freqanalysis.m
+++ b/ft_freqanalysis.m
@@ -13,7 +13,7 @@ function [freq] = ft_freqanalysis(cfg, data)
 % The configuration should contain:
 %   cfg.method      = different methods of calculating the spectra
 %                     'mtmfft', analyses an entire spectrum for the entire data
-%                       length, implements multitaper frequency transformation
+%                       length, implements multitaper frequency transformation.
 %                     'mtmconvol', implements multitaper time-frequency
 %                       transformation based on multiplication in the
 %                       frequency domain.
@@ -29,6 +29,8 @@ function [freq] = ft_freqanalysis(cfg, data)
 %                       output will contain a spectral transfer matrix,
 %                       the cross-spectral density matrix, and the
 %                       covariance matrix of the innovatio noise.
+%                     'irasa', analyses an entire spectrum for the entire data
+%                       length, returns the fractal/arrhythmic component.
 %   cfg.output      = 'pow'       return the power-spectra
 %                     'powandcsd' return the power and the cross-spectra
 %                     'fourier'   return the complex Fourier-spectra

--- a/ft_freqanalysis.m
+++ b/ft_freqanalysis.m
@@ -292,14 +292,14 @@ switch cfg.method
     if ~isequal(cfg.taper, 'hanning')
       ft_error('only hanning tapers are supported');
     end
+    if isfield(cfg, 'output') && ~isequal(cfg.output, 'pow')
+      ft_error('the output from the irasa method can be power only');
+    end
     % check for foi above Nyquist
     if isfield(cfg, 'foi')
       if any(cfg.foi > (data.fsample/2))
         ft_error('frequencies in cfg.foi are above Nyquist')
       end
-    end
-    if isequal(cfg.taper, 'dpss') && not(isfield(cfg, 'tapsmofrq'))
-      ft_error('you must specify a smoothing parameter with taper = dpss');
     end
     
   case 'wavelet'

--- a/ft_freqanalysis.m
+++ b/ft_freqanalysis.m
@@ -671,7 +671,7 @@ for itrial = 1:ntrials
       
       acttap = logical([ones(ntaper(ifoi),1);zeros(size(spectrum,1)-ntaper(ifoi),1)]);
       if powflg
-        if strcmp(cfg.method, 'irasa')
+        if strcmp(cfg.method, 'irasa') % ft_specest_irasa outputs power and not amplitude
           powdum = spectrum(acttap,:,foiind(ifoi),acttboi);
         else
           powdum = abs(spectrum(acttap,:,foiind(ifoi),acttboi)) .^2;
@@ -761,7 +761,7 @@ for itrial = 1:ntrials
     %rptind = reshape(1:ntrials .* maxtap,[maxtap ntrials]);
     %currrptind = rptind(:,itrial);
     if powflg
-      if strcmp(cfg.method, 'irasa')
+      if strcmp(cfg.method, 'irasa') % ft_specest_irasa outputs power and not amplitude
         powspctrm(currrptind,:,:) = spectrum;
       else
         powspctrm(currrptind,:,:) = abs(spectrum).^2;

--- a/ft_freqanalysis.m
+++ b/ft_freqanalysis.m
@@ -293,7 +293,7 @@ switch cfg.method
       ft_error('only hanning tapers are supported');
     end
     if isfield(cfg, 'output') && ~isequal(cfg.output, 'pow')
-      ft_error('the output from the irasa method can be power only');
+      ft_error('the irasa method outputs power only');
     end
     % check for foi above Nyquist
     if isfield(cfg, 'foi')

--- a/specest/ft_specest_irasa.m
+++ b/specest/ft_specest_irasa.m
@@ -1,0 +1,210 @@
+function [spectrum,ntaper,freqoi] = ft_specest_irasa(dat, time, varargin)
+
+% FT_SPECEST_IRASA performs Irregular-Resampling Auto-Spectral Analysis
+% (Wen et al., 2016) to estimate the powerspectral arrythmic component in the
+% time-domain signal. This arrythmic component can be used to identify
+% individual rhythmic components in the powerspectrum (see Stolk et al., 2019)
+%
+% Use as
+%   [spectrum,ntaper,freqoi] = ft_specest_irasa(dat,time...)
+% where
+%   dat        = matrix of chan*sample
+%   time       = vector, containing time in seconds for each sample
+%   spectrum   = matrix of taper*chan*freqoi of fourier coefficients
+%   ntaper     = vector containing number of tapers per element of freqoi
+%   freqoi     = vector of frequencies in spectrum
+%
+% Optional arguments should be specified in key-value pairs and can include
+%   taper      = 'dpss', 'hanning' or many others, see WINDOW (default = 'dpss')
+%   pad        = number, total length of data after zero padding (in seconds)
+%   padtype    = string, indicating type of padding to be used (see ft_preproc_padding, default: zero)
+%   freqoi     = vector, containing frequencies of interest
+%   tapsmofrq  = the amount of spectral smoothing through multi-tapering. Note: 4 Hz smoothing means plus-minus 4 Hz, i.e. a 8 Hz smoothing box
+%   dimord     = 'tap_chan_freq' (default) or 'chan_time_freqtap' for memory efficiency (only used when variable number slepian tapers)
+%   polyorder  = number, the order of the polynomial to fitted to and removed from the data prior to the fourier transform (default = 0 -> remove DC-component)
+%   taperopt   = additional taper options to be used in the WINDOW function, see WINDOW
+%   verbose    = output progress to console (0 or 1, default 1)
+%
+% See also FT_FREQANALYSIS, FT_SPECEST_MTMFFT, FT_SPECEST_MTMCONVOL, FT_SPECEST_TFR, FT_SPECEST_HILBERT, FT_SPECEST_WAVELET
+
+% Copyright (C) 2019, Arjen Stolk
+%
+% This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
+% for the documentation and details.
+%
+%    FieldTrip is free software: you can redistribute it and/or modify
+%    it under the terms of the GNU General Public License as published by
+%    the Free Software Foundation, either version 3 of the License, or
+%    (at your option) any later version.
+%
+%    FieldTrip is distributed in the hope that it will be useful,
+%    but WITHOUT ANY WARRANTY; without even the implied warranty of
+%    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%    GNU General Public License for more details.
+%
+%    You should have received a copy of the GNU General Public License
+%    along with FieldTrip. If not, see <http://www.gnu.org/licenses/>.
+%
+% $Id$
+
+% these are for speeding up computation of tapers on subsequent calls
+persistent previous_argin previous_tap
+
+% get the optional input arguments
+taper     = ft_getopt(varargin, 'taper'); if isempty(taper), ft_error('You must specify a taper'); end
+pad       = ft_getopt(varargin, 'pad');
+padtype   = ft_getopt(varargin, 'padtype', 'zero');
+freqoi    = ft_getopt(varargin, 'freqoi', 'all');
+tapsmofrq = ft_getopt(varargin, 'tapsmofrq');
+dimord    = ft_getopt(varargin, 'dimord', 'tap_chan_freq');
+fbopt     = ft_getopt(varargin, 'feedback');
+verbose   = ft_getopt(varargin, 'verbose', true);
+polyorder = ft_getopt(varargin, 'polyorder', 0);
+tapopt    = ft_getopt(varargin, 'taperopt');
+
+% Set IRASA resampling factors
+hset = 1.1:0.05:1.9;
+nhset = length(hset);
+
+if isempty(fbopt)
+  fbopt.i = 1;
+  fbopt.n = 1;
+end
+
+% throw errors for required input
+if isempty(tapsmofrq) && (strcmp(taper, 'dpss') || strcmp(taper, 'sine'))
+  ft_error('you need to specify tapsmofrq when using dpss or sine tapers')
+end
+
+% this does not work on integer data
+dat = cast(dat, 'double');
+
+% Set n's
+[nchan,ndatsample] = size(dat);
+
+% This does not work on integer data
+if ~isa(dat, 'double') && ~isa(dat, 'single')
+  dat = cast(dat, 'double');
+end
+
+% Remove polynomial fit from the data -> default is demeaning
+if polyorder >= 0
+  dat = ft_preproc_polyremoval(dat, polyorder, 1, ndatsample);
+end
+
+% Determine fsample and set total time-length of data
+fsample = 1./mean(diff(time));
+dattime = ndatsample / fsample; % total time in seconds of input data
+
+% Zero padding FIXME: needs testing
+if round(pad * fsample) < ndatsample
+  ft_error('the padding that you specified is shorter than the data');
+end
+if isempty(pad) % if no padding is specified padding is equal to current data length
+  pad = dattime;
+end
+postpad    = ceil((pad - dattime) * fsample);
+endnsample = round(pad * fsample);  % total number of samples of padded data
+endtime    = pad;                   % total time in seconds of padded data
+
+% Set freqboi and freqoi
+freqoiinput = freqoi;
+if isnumeric(freqoi) % if input is a vector
+  freqboi   = round(freqoi ./ (fsample ./ endnsample)) + 1; % is equivalent to: round(freqoi .* endtime) + 1;
+  freqboi   = unique(freqboi);
+  freqoi    = (freqboi-1) ./ endtime; % boi - 1 because 0 Hz is included in fourier output
+elseif strcmp(freqoi,'all') % if input was 'all'
+  freqboilim = round([0 fsample/2] ./ (fsample ./ endnsample)) + 1;
+  freqboi    = freqboilim(1):1:freqboilim(2);
+  freqoi     = (freqboi-1) ./ endtime;
+end
+nfreqboi = length(freqboi);
+nfreqoi  = length(freqoi);
+if (strcmp(taper, 'dpss') || strcmp(taper, 'sine')) && numel(tapsmofrq)~=1 && (numel(tapsmofrq)~=nfreqoi)
+  ft_error('tapsmofrq needs to contain a smoothing parameter for every frequency when requesting variable number of slepian tapers')
+end
+
+% throw a warning if input freqoi is different from output freqoi
+if isnumeric(freqoiinput)
+  % check whether padding is appropriate for the requested frequency resolution
+  rayl = 1/endtime;
+  if any(rem(freqoiinput,rayl)) % not always the case when they mismatch
+    ft_warning('padding not sufficient for requested frequency resolution, for more information please see the FAQs on www.ru.nl/neuroimaging/fieldtrip');
+  end
+  if numel(freqoiinput) ~= numel(freqoi) % freqoi will not contain double frequency bins when requested
+    ft_warning('output frequencies are different from input frequencies, multiples of the same bin were requested but not given');
+  else
+    if any(abs(freqoiinput-freqoi) >= eps*1e6)
+      ft_warning('output frequencies are different from input frequencies');
+    end
+  end
+end
+
+% determine whether tapers need to be recomputed
+current_argin = {time, postpad, taper, tapsmofrq, freqoi, tapopt, dimord}; % reasoning: if time and postpad are equal, it's the same length trial, if the rest is equal then the requested output is equal
+if isequal(current_argin, previous_argin)
+  % don't recompute tapers
+  tap = previous_tap;
+else
+  % recompute tapers
+  tap = hanning(ndatsample)';
+  tap = tap./norm(tap, 'fro');
+end
+
+% set ntaper
+if ~((strcmp(taper,'dpss') || strcmp(taper,'sine')) && numel(tapsmofrq)>1) % variable number of slepian tapers not requested
+  ntaper = repmat(size(tap,1),nfreqoi,1);
+else % variable number of slepian tapers requested
+  ntaper = cellfun(@size,tap,repmat({1},[1 nfreqoi]));
+end
+
+% compute fft
+str = sprintf('nfft: %d samples, datalength: %d samples, %d tapers',endnsample,ndatsample,ntaper(1));
+[st, cws] = dbstack;
+if length(st)>1 && strcmp(st(2).name, 'ft_freqanalysis')
+  % specest_mtmfft has been called by ft_freqanalysis, meaning that ft_progress has been initialised
+  ft_progress(fbopt.i./fbopt.n, ['processing trial %d/%d ',str,'\n'], fbopt.i, fbopt.n);
+elseif verbose
+  fprintf([str, '\n']);
+end
+spectrum = cell(ntaper(1),1);
+for itap = 1:ntaper(1) % FIXME: the original implementation additionally loops 15 times across 90% subsegments, and filters
+  %%%% IRASA STARTS %%%%
+  for ih = 1:nhset % loop across resampling factors
+    [n, d] = rat(hset(ih)); % n > d
+    
+    % fft of upsampled data
+    udat = resample(dat', n, d)'; % upsample
+    utap = hanning(size(udat,2))'; % get taper
+    utap = utap./norm(utap, 'fro');
+    ucom = fft(ft_preproc_padding(bsxfun(@times,udat,utap(itap,:)), padtype, 0, postpad),[], 2); % fft
+    ucom = ucom(:,freqboi);
+    ucom = ucom .* sqrt(2 ./ endnsample);
+    %ucom(2:end,:) = ucom(2:end,:)*2; % FIXME inconsistent with mtmfft
+    
+    % fft of downsampled data
+    ddat = resample(dat', d, n)'; % downsample
+    dtap = hanning(size(ddat,2))'; % get taper
+    dtap = dtap./norm(dtap, 'fro');
+    dcom = fft(ft_preproc_padding(bsxfun(@times,ddat,dtap(itap,:)), padtype, 0, postpad),[], 2); % fft
+    dcom = dcom(:,freqboi);
+    dcom = dcom .* sqrt(2 ./ endnsample);
+    %dcom(2:end,:) = dcom(2:end,:)*2;
+    
+    % geometric mean for this resampling factor
+    upow = abs(ucom).^2; % FIXME: ensure the powflag is off in ft_freqanalysis
+    dpow = abs(dcom).^2;
+    spectrum{itap}(:,:,ih) = sqrt(upow.*dpow);
+  end
+  % median across resampling factors
+  spectrum{itap} = median(spectrum{itap},3);
+  %%%% IRASA ENDS %%%%
+end
+
+spectrum = reshape(vertcat(spectrum{:}),[nchan ntaper(1) nfreqboi]); % collecting in a cell-array and later reshaping provides significant speedups
+spectrum = permute(spectrum, [2 1 3]);
+
+% remember the current input arguments, so that they can be
+% reused on a subsequent call in case the same input argument is given
+previous_argin = current_argin;
+previous_tap   = tap;

--- a/specest/ft_specest_irasa.m
+++ b/specest/ft_specest_irasa.m
@@ -1,9 +1,7 @@
 function [spectrum,ntaper,freqoi] = ft_specest_irasa(dat, time, varargin)
 
 % FT_SPECEST_IRASA estimates the powerspectral arrythmic component of the 
-% time-domain using Irregular-Resampling Auto-Spectral Analysis
-% (IRASA, Wen & Liu, 2016). This arrythmic component is instrumental for 
-% extracting rhythmic spectral features (see Stolk et al., 2019)
+% time-domain using Irregular-Resampling Auto-Spectral Analysis. 
 %
 % Use as
 %   [spectrum,ntaper,freqoi] = ft_specest_irasa(dat,time...)
@@ -24,6 +22,8 @@ function [spectrum,ntaper,freqoi] = ft_specest_irasa(dat, time, varargin)
 %   polyorder  = number, the order of the polynomial to fitted to and removed from the data prior to the fourier transform (default = 0 -> remove DC-component)
 %   taperopt   = additional taper options to be used in the WINDOW function, see WINDOW
 %   verbose    = output progress to console (0 or 1, default 1)
+%
+% This implements: Wen H, Liu Z. Separating fractal and oscillatory components in the power spectrum of neurophysiological signal. Brain Topogr. 2016 Jan;29(1):13-26.
 %
 % See also FT_FREQANALYSIS, FT_SPECEST_MTMFFT, FT_SPECEST_MTMCONVOL, FT_SPECEST_TFR, FT_SPECEST_HILBERT, FT_SPECEST_WAVELET
 

--- a/specest/ft_specest_irasa.m
+++ b/specest/ft_specest_irasa.m
@@ -172,10 +172,10 @@ if length(st)>1 && strcmp(st(2).name, 'ft_freqanalysis')
 elseif verbose
   fprintf([str, '\n']);
 end
-pow = cell(ntaper(1),1);
 spectrum = cell(ntaper(1),1);
 for itap = 1:ntaper(1)
   %%%% IRASA STARTS %%%%
+  pow = zeros(nchan,nfreqboi,nhset);
   for ih = 1:nhset % loop across resampling factors
     % resample
     [n, d] = rat(hset(ih)); % n > d
@@ -195,11 +195,11 @@ for itap = 1:ntaper(1)
     % geometric mean for this resampling factor
     upow = abs(ucom).^2;
     dpow = abs(dcom).^2;
-    pow{itap}(:,:,ih) = sqrt(upow.*dpow); 
+    pow(:,:,ih) = sqrt(upow.*dpow); 
   end
   
   % median across resampling factors
-  spectrum{itap} = median(pow{itap},3);
+  spectrum{itap} = median(pow,3);
   %%%% IRASA ENDS %%%%
 end
 

--- a/specest/ft_specest_irasa.m
+++ b/specest/ft_specest_irasa.m
@@ -3,7 +3,7 @@ function [spectrum,ntaper,freqoi] = ft_specest_irasa(dat, time, varargin)
 % FT_SPECEST_IRASA estimates the powerspectral arrythmic component of the 
 % time-domain using Irregular-Resampling Auto-Spectral Analysis
 % (IRASA, Wen & Liu, 2016). This arrythmic component is instrumental for 
-% estimating rhythm frequency bands (see Stolk et al., 2019)
+% extracting rhythmic spectral features (see Stolk et al., 2019)
 %
 % Use as
 %   [spectrum,ntaper,freqoi] = ft_specest_irasa(dat,time...)

--- a/specest/ft_specest_irasa.m
+++ b/specest/ft_specest_irasa.m
@@ -1,10 +1,9 @@
 function [spectrum,ntaper,freqoi] = ft_specest_irasa(dat, time, varargin)
 
-% FT_SPECEST_IRASA performs Irregular-Resampling Auto-Spectral Analysis
-% to estimate the powerspectral arrythmic component in the time-domain
-% signal (see Wen et al., 2016). This arrythmic component can be used to
-% extract individual rhythmic components in the powerspectrum 
-% (see Stolk et al., 2019).
+% FT_SPECEST_IRASA estimates the powerspectral arrythmic component of the 
+% time-domain using Irregular-Resampling Auto-Spectral Analysis
+% (IRASA, Wen & Liu, 2016). This arrythmic component is instrumental for 
+% extracting individual rhythmic components (see Stolk et al., 2019)
 %
 % Use as
 %   [spectrum,ntaper,freqoi] = ft_specest_irasa(dat,time...)
@@ -95,7 +94,7 @@ end
 fsample = 1./mean(diff(time));
 dattime = ndatsample / fsample; % total time in seconds of input data
 
-% Zero padding (FIXME: the effect of padding on taking the fft of the resampled signal has not been tested yet) 
+% Zero padding (FIXME: the effect of padding on taking the fft of the resampled signal has not been tested) 
 if round(pad * fsample) < ndatsample
   ft_error('the padding that you specified is shorter than the data');
 end
@@ -145,7 +144,7 @@ if isequal(current_argin, previous_argin)
   % don't recompute tapers
   tap = previous_tap;
 else
-  % recompute tapers, 1:mid are upsample tapers, mid+1:end are downsample tapers
+  % (re)compute tapers, 1:mid are upsample tapers, mid+1:end are downsample tapers
   for ih = 1:nhset
     [n, d] = rat(hset(ih)); % n > d
     udat = resample(dat', n, d)'; % upsample

--- a/specest/ft_specest_irasa.m
+++ b/specest/ft_specest_irasa.m
@@ -3,7 +3,7 @@ function [spectrum,ntaper,freqoi] = ft_specest_irasa(dat, time, varargin)
 % FT_SPECEST_IRASA estimates the powerspectral arrythmic component of the 
 % time-domain using Irregular-Resampling Auto-Spectral Analysis
 % (IRASA, Wen & Liu, 2016). This arrythmic component is instrumental for 
-% extracting individual rhythmic components (see Stolk et al., 2019)
+% estimating rhythm frequency bands (see Stolk et al., 2019)
 %
 % Use as
 %   [spectrum,ntaper,freqoi] = ft_specest_irasa(dat,time...)

--- a/test/test_ft_specest_irasa.m
+++ b/test/test_ft_specest_irasa.m
@@ -1,0 +1,56 @@
+function test_ft_specest_irasa
+
+% MEM 1500mb
+% WALLTIME 00:10:00
+
+% DEPENDENCY ft_freqanalysis
+
+% script demonstrating the extraction of rhythmic spectral 
+% features from the electrophysiological signal
+
+
+% generate trials with a 15 Hz oscillation embedded in pink noise
+t = (1:1:1000)/1000; % time axis
+for rpt = 1:1000
+  % generate pink noise
+  dspobj = dsp.ColoredNoise('Color', 'pink', ...
+    'SamplesPerFrame', length(t));
+  fn = dspobj()';
+  
+  % add a 15 Hz oscillation
+  data.trial{1,rpt} = fn + cos(2*pi*15*t); 
+  data.time{1,rpt} = t;
+  data.label{1} = 'chan';
+end
+
+% perform regular frequency analysis and IRASA
+cfg = [];
+cfg.foilim = [1 50];
+cfg.taper = 'hanning';
+cfg.method = 'irasa';
+frac = ft_freqanalysis(cfg, data);
+cfg.method = 'mtmfft';
+orig = ft_freqanalysis(cfg, data);
+
+% subtract the fractal component from the power spectrum
+cfg = [];
+cfg.parameter = 'powspctrm';
+cfg.operation = 'x2-x1';
+osci = ft_math(cfg, frac, orig);
+
+% plot the fractal component and the power spectrum 
+figure; plot(frac.freq, frac.powspctrm, ...
+  'linewidth', 3, 'color', [0 0 0])
+hold on; plot(orig.freq, orig.powspctrm, ...
+  'linewidth', 3, 'color', [.6 .6 .6])
+
+% plot the full-width half-maximum of the oscillatory component
+f = fit(osci.freq', osci.powspctrm', 'gauss1');
+mean = f.b1;
+std = f.c1/sqrt(2)*2.3548;
+fwhm = [mean-std/2 mean+std/2];
+yl = get(gca, 'YLim');
+p = patch([fwhm flip(fwhm)], [yl(1) yl(1) yl(2) yl(2)], [1 1 1]);
+uistack(p, 'bottom');
+legend('FWHM oscillation', 'Fractal component', 'Power spectrum');
+xlabel('Frequency'); ylabel('Power');


### PR DESCRIPTION
Irregular-resampling auto-spectral analysis (IRASA, Wen & Liu, 2016) extracts the fractal/arrhythmic component from the time domain signal by stretching and extending it multiple times with irregular amounts prior to taking the FFT. Essentially, this moves rhythmic content up and down the power spectrum with various distances, and the median power spectrum then gives the fractal/arrhythmic component. See below for a simulation.

The code, in ft_specest_irasa, is based on ft_specest_mtmfft, preserving as many functionalities as possible to keep it consistent with the rest of the specest module (e.g., for scaling up to tfr purposes). The tapers, Hannings with variable resampling-based lengths, are computed once for speedup purposes.

I plan to further develop the below script into a wiki example script. This example/test script will also include fitting of Gaussians to estimate (individual) rhythm frequency bands. 

One thing that still puzzles me, however, is the overall offset/downshift of the fractal component relative to the original power spectrum. I am pretty sure this is not because of the irasa vs. mtmfft implementation since I checked and because my previous (all-in-one) implementation occasionally showed the same offset. It's also less obvious with fewer trials, e.g. set rpt = 1 in the below simulation. Any thoughts on this would be _much appreciated_. 


 

% simulate 100 trials of arrhythmic and rhythmic data
for rpt = 1:100
  N = 1000;
  t = 1 : N;
  k = (1 : N/2)';
  kt = k*t;
  theta = unifrnd(0,2*pi,N/2,1);
  Ck = repmat(sqrt(1*k.^(-1)*N),1,N);
  frac_sim = sum(Ck.*cos(2*pi*kt/N - repmat(theta,1,N)));
  
  tim = (1:N)/N;
  osci_sim = cos(2*pi*15*tim)*50;
  mixed_sim = frac_sim+osci_sim;
  
  sim.trial{1,rpt} = mixed_sim;
  sim.time{1,rpt} = tim;
  sim.label{1} = 'sim';
end

% fft
cfg = [];
cfg.foilim = [1 200];
cfg.taper = 'hanning';
cfg.method = 'irasa';
frac = ft_freqanalysis(cfg, sim);
cfg.method = 'mtmfft';
orig = ft_freqanalysis(cfg, sim);

cfg = [];
cfg.parameter = 'powspctrm';
cfg.operation = 'x2-x1';
osci = ft_math(cfg, frac, orig);

% plot
figure; loglog(frac.freq, frac.powspctrm)
hold on; loglog(orig.freq, orig.powspctrm)
legend('fractal', 'original')

figure; plot(osci.freq, osci.powspctrm)
legend('oscillatory')

<img width="999" alt="Screen Shot 2019-04-07 at 8 13 14 PM" src="https://user-images.githubusercontent.com/3984917/55696685-fa2e6880-5972-11e9-8059-bae65039b3b1.png">