### PR TITLE
Update recursesize list in ignorefields.m (add vol, grid, remove dupl…

### DIFF
--- a/utilities/private/ignorefields.m
+++ b/utilities/private/ignorefields.m
@@ -251,8 +251,8 @@ switch purpose
       % these fields should not recursively be checked on their size
       'elec'
       'event'
-      'event'
       'grad'
+      'grid'
       'headmodel'
       'headshape'
       'layout'
@@ -260,6 +260,7 @@ switch purpose
       'neighbours'
       'opto'
       'sourcemodel'
+      'vol'
       };
 
   otherwise


### PR DESCRIPTION
…icate event)

/utilities/private/ignorefields did not have the updated list, /private/ignorefields did. 
It is unclear to my why these two files coexist (since they are the same and can potentially lead to errors, as in this case)