### PR TITLE
Update for field selection in ft_freqstatistcs

### DIFF
--- a/ft_freqstatistics.m
+++ b/ft_freqstatistics.m
@@ -114,7 +114,7 @@ if isempty(cfg.parameter)
 end
 
 % ensure that the data in all inputs has the same channels, time-axis, etc.
-tmpcfg = keepfields(cfg, {'frequency', 'avgoverfreq', 'latency', 'avgovertime', 'channel', 'avgoverchan', 'parameter', 'showcallinfo'});
+tmpcfg = keepfields(cfg, {'frequency', 'avgoverfreq', 'latency', 'avgovertime', 'channel', 'avgoverchan', 'parameter', 'showcallinfo', 'select', 'nanmean'});
 [varargin{:}] = ft_selectdata(tmpcfg, varargin{:});
 % restore the provenance information
 [cfg, varargin{:}] = rollback_provenance(cfg, varargin{:});


### PR DESCRIPTION
bugfix -  ft_freqstatistics has the cfg option 'select' and 'nanmean' but line 117 the function keepfields creates a temporary cfg for input to ft_selectdata without those fields. As a consequence ft_selectdata uses  the "default" options ('intersect' instead of 'union' for the field "select" and 'no' instead of 'yes' for the field "nanmean").