### PR TITLE
allows setting a colorbar text

### DIFF
--- a/ft_movieplotER.m
+++ b/ft_movieplotER.m
@@ -18,6 +18,7 @@ function [cfg] = ft_movieplotER(cfg, data)
 %   cfg.baseline     = 'yes','no' or [time1 time2] (default = 'no'), see FT_TIMELOCKBASELINE
 %   cfg.baselinetype = 'absolute' or 'relative' (default = 'absolute')
 %   cfg.colorbar     = 'yes', 'no' (default = 'no')
+%   cfg.colorbartext =  string indicating the text next to colorbar
 %
 % The layout defines how the channels are arranged. You can specify the
 % layout in a variety of ways:

--- a/ft_movieplotTFR.m
+++ b/ft_movieplotTFR.m
@@ -24,6 +24,7 @@ function [cfg] = ft_movieplotTFR(cfg, data)
 %   cfg.baseline     = 'yes','no' or [time1 time2] (default = 'no'), see FT_TIMELOCKBASELINE or FT_FREQBASELINE
 %   cfg.baselinetype = 'absolute', 'relative', 'relchange', 'normchange', 'db' or 'zscore' (default = 'absolute')
 %   cfg.colorbar     = 'yes', 'no' (default = 'no')
+%   cfg.colorbartext =  string indicating the text next to colorbar
 %
 % the layout defines how the channels are arranged. you can specify the
 % layout in a variety of ways:
@@ -107,6 +108,7 @@ cfg.movietime     = ft_getopt(cfg, 'movietime',     []);
 cfg.movierpt      = ft_getopt(cfg, 'movierpt',      1);
 cfg.baseline      = ft_getopt(cfg, 'baseline',      'no');
 cfg.colorbar      = ft_getopt(cfg, 'colorbar',      'no');
+cfg.colorbartext  = ft_getopt(cfg, 'colorbartext',  '');
 cfg.renderer      = ft_getopt(cfg, 'renderer',      []); % let MATLAB decide on the default
 cfg.interactive   = ft_getopt(cfg, 'interactive',   'yes');
 dointeractive     = istrue(cfg.interactive);
@@ -317,7 +319,8 @@ if dointeractive
   caxis(cfg.zlim);
   axis off;
   if opt.colorbar
-    colorbar
+    c = colorbar;
+    c.Label.String = cfg.colorbartext;
   end
 
   % add sum stuff at a higher level for quicker access in the callback

--- a/ft_movieplotTFR.m
+++ b/ft_movieplotTFR.m
@@ -320,7 +320,7 @@ if dointeractive
   axis off;
   if opt.colorbar
     c = colorbar;
-    c.Label.String = cfg.colorbartext;
+    ylabel(c, cfg.colorbartext);
   end
 
   % add sum stuff at a higher level for quicker access in the callback

--- a/ft_multiplotTFR.m
+++ b/ft_multiplotTFR.m
@@ -542,7 +542,7 @@ end % show scale
 % show colorbar
 if isfield(cfg, 'colorbar') && (strcmp(cfg.colorbar, 'yes'))
   c = colorbar;
-  c.Label.String = cfg.colorbartext;
+  ylabel(c, cfg.colorbartext);
 end
 
 % Set colour axis

--- a/ft_multiplotTFR.m
+++ b/ft_multiplotTFR.m
@@ -37,6 +37,7 @@ function [cfg] = ft_multiplotTFR(cfg, data)
 %                          Draw a box around each graph
 %   cfg.hotkeys          = enables hotkeys (up/down arrows) for dynamic colorbar adjustment
 %   cfg.colorbar         = 'yes', 'no' (default = 'no')
+%   cfg.colorbartext     =  string indicating the text next to colorbar
 %   cfg.colormap         = any sized colormap, see COLORMAP
 %   cfg.showlabels       = 'yes', 'no' (default = 'no')
 %   cfg.showoutline      = 'yes', 'no' (default = 'no')
@@ -179,6 +180,7 @@ cfg.xlim           = ft_getopt(cfg, 'xlim', 'maxmin');
 cfg.ylim           = ft_getopt(cfg, 'ylim', 'maxmin');
 cfg.zlim           = ft_getopt(cfg, 'zlim', 'maxmin');
 cfg.colorbar       = ft_getopt(cfg, 'colorbar', 'no');
+cfg.colorbartext   = ft_getopt(cfg, 'colorbartext', '');
 cfg.comment        = ft_getopt(cfg, 'comment', date);
 cfg.limittext      = ft_getopt(cfg, 'limittext', 'default');
 cfg.showlabels     = ft_getopt(cfg, 'showlabels', 'no');
@@ -539,7 +541,8 @@ end % show scale
 
 % show colorbar
 if isfield(cfg, 'colorbar') && (strcmp(cfg.colorbar, 'yes'))
-  colorbar;
+  c = colorbar;
+  c.Label.String = cfg.colorbartext;
 end
 
 % Set colour axis

--- a/ft_singleplotTFR.m
+++ b/ft_singleplotTFR.m
@@ -411,7 +411,7 @@ axis xy
 
 if isequal(cfg.colorbar, 'yes')
   c = colorbar;
-  c.Label.String = cfg.colorbartext;
+  ylabel(c, cfg.colorbartext);
 end
 
 % Set callback to adjust color axis

--- a/ft_singleplotTFR.m
+++ b/ft_singleplotTFR.m
@@ -34,6 +34,7 @@ function [cfg] = ft_singleplotTFR(cfg, data)
 %   cfg.hotkeys        = enables hotkeys (leftarrow/rightarrow/uparrow/downarrow/pageup/pagedown/m) for dynamic zoom and translation (ctrl+) of the axes and color limits
 %   cfg.colormap       = any sized colormap, see COLORMAP
 %   cfg.colorbar       = 'yes', 'no' (default = 'yes')
+%   cfg.colorbartext   =  string indicating the text next to colorbar
 %   cfg.interactive    = Interactive plot 'yes' or 'no' (default = 'yes')
 %                        In a interactive plot you can select areas and produce a new
 %                        interactive plot when a selected area is clicked. Multiple areas
@@ -137,6 +138,7 @@ cfg.ylim           = ft_getopt(cfg, 'ylim',          'maxmin');
 cfg.zlim           = ft_getopt(cfg, 'zlim',          'maxmin');
 cfg.fontsize       = ft_getopt(cfg, 'fontsize',       8);
 cfg.colorbar       = ft_getopt(cfg, 'colorbar',      'yes');
+cfg.colorbartext   = ft_getopt(cfg, 'colorbartext',   '');
 cfg.interactive    = ft_getopt(cfg, 'interactive',   'yes');
 cfg.hotkeys        = ft_getopt(cfg, 'hotkeys',       'yes');
 cfg.renderer       = ft_getopt(cfg, 'renderer',       []); % let MATLAB decide on the default
@@ -408,7 +410,8 @@ end
 axis xy
 
 if isequal(cfg.colorbar, 'yes')
-  colorbar;
+  c = colorbar;
+  c.Label.String = cfg.colorbartext;
 end
 
 % Set callback to adjust color axis

--- a/ft_sourceplot.m
+++ b/ft_sourceplot.m
@@ -1685,14 +1685,14 @@ elseif strcmp(opt.colorbar,  'yes') && ~isfield(opt, 'hc')
     try
       caxis([opt.fcolmin opt.fcolmax]);
     end
+
     opt.hc = colorbar;
     set(opt.hc, 'location', 'southoutside');
     set(opt.hc, 'position',[0.06+0.06+opt.h1size(1) 0.06-0.06+opt.h3size(2) opt.h2size(1) 0.06]);
-
+    ylabel(opt.hc, opt.colorbartext);
     try
       set(opt.hc, 'XLim', [opt.fcolmin opt.fcolmax]);
     end
-    opt.hc.Label.String = opt.colorbartext;
   else
     ft_warning('no colorbar possible without functional data');
   end

--- a/ft_sourceplot.m
+++ b/ft_sourceplot.m
@@ -910,7 +910,7 @@ switch cfg.method
         % use a normal MATLAB coorbar
         hc = colorbar;
         set(hc, 'YLim', [fcolmin fcolmax]);
-        hc.Label.String = cfg.colorbartext;
+        ylabel(hc, cfg.colorbartext);
       else
         ft_warning('no colorbar possible without functional data')
       end
@@ -1279,7 +1279,7 @@ switch cfg.method
         if strcmp(cfg.maskstyle, 'opacity')
           % functional values are according to original input values
           set(hc, 'YLim', [fcolmin fcolmax]);
-          hc.Label.String = cfg.colorbartext;
+          ylabel(hc, cfg.colorbartext);
         else
           % functional values have been transformed to be scaled
         end
@@ -1424,7 +1424,7 @@ switch cfg.method
         subplotpos = get(subplot(cfg.nslices,1,cfg.nslices), 'Position'); % position of the bottom or rightmost subplot
         c = colorbar('Position', [subplotpos(1)+subplotpos(3)+0.01 subplotpos(2) .03 subplotpos(2)+subplotpos(4)*(cfg.nslices+.1)]);
       end
-      c.Label.String = cfg.colorbartext;
+      ylabel(c, cfg.colorbartext);
     end
 
 

--- a/ft_sourceplot.m
+++ b/ft_sourceplot.m
@@ -67,6 +67,7 @@ function ft_sourceplot(cfg, functional, anatomical)
 %                        'auto', if funparameter values are all positive: 'zeromax',
 %                          all negative: 'minzero', both possitive and negative: 'maxabs'
 %   cfg.colorbar      = 'yes' or 'no' (default = 'yes')
+%   cfg.colorbartext  =  string indicating the text next to colorbar
 %
 % The 'ortho' method can also plot time and/or frequency, the other methods can not.
 % If your functional data has a time and/or frequency dimension, you can use
@@ -289,6 +290,7 @@ cfg.markersize    = ft_getopt(cfg, 'markersize',    5);
 cfg.markercolor   = ft_getopt(cfg, 'markercolor',   [1 1 1]);
 cfg.renderer      = ft_getopt(cfg, 'renderer',      'opengl');
 cfg.colorbar      = ft_getopt(cfg, 'colorbar',      'yes');
+cfg.colorbartext  = ft_getopt(cfg, 'colorbartext',  '');
 cfg.voxelratio    = ft_getopt(cfg, 'voxelratio',    'data'); % display size of the voxel, 'data' or 'square'
 cfg.axisratio     = ft_getopt(cfg, 'axisratio',     'data'); % size of the axes of the three orthoplots, 'square', 'voxel', or 'data'
 cfg.visible       = ft_getopt(cfg, 'visible',       'on');
@@ -908,6 +910,7 @@ switch cfg.method
         % use a normal MATLAB coorbar
         hc = colorbar;
         set(hc, 'YLim', [fcolmin fcolmax]);
+        hc.Label.String = cfg.colorbartext;
       else
         ft_warning('no colorbar possible without functional data')
       end
@@ -1084,6 +1087,7 @@ switch cfg.method
     opt.opacmax       = opacmax;
     opt.clim          = cfg.clim; % contrast limits for the anatomy, see ft_volumenormalise
     opt.colorbar      = cfg.colorbar;
+    opt.colorbartext  = cfg.colorbartext;
     opt.queryrange    = cfg.queryrange;
     opt.funcolormap   = cfg.funcolormap;
     opt.crosshair     = istrue(cfg.crosshair);
@@ -1275,6 +1279,7 @@ switch cfg.method
         if strcmp(cfg.maskstyle, 'opacity')
           % functional values are according to original input values
           set(hc, 'YLim', [fcolmin fcolmax]);
+          hc.Label.String = cfg.colorbartext;
         else
           % functional values have been transformed to be scaled
         end
@@ -1414,11 +1419,12 @@ switch cfg.method
 
     if istrue(cfg.colorbar)
       if ~strcmp(cfg.slice, '2d')
-        colorbar;
+        c = colorbar;
       else % position the colorbar so that it does not change the axis of the last subplot
         subplotpos = get(subplot(cfg.nslices,1,cfg.nslices), 'Position'); % position of the bottom or rightmost subplot
-        colorbar('Position', [subplotpos(1)+subplotpos(3)+0.01 subplotpos(2) .03 subplotpos(2)+subplotpos(4)*(cfg.nslices+.1)]);
+        c = colorbar('Position', [subplotpos(1)+subplotpos(3)+0.01 subplotpos(2) .03 subplotpos(2)+subplotpos(4)*(cfg.nslices+.1)]);
       end
+      c.Label.String = cfg.colorbartext;
     end
 
 
@@ -1686,6 +1692,7 @@ elseif strcmp(opt.colorbar,  'yes') && ~isfield(opt, 'hc')
     try
       set(opt.hc, 'XLim', [opt.fcolmin opt.fcolmax]);
     end
+    opt.hc.Label.String = opt.colorbartext;
   else
     ft_warning('no colorbar possible without functional data');
   end

--- a/ft_topoplotER.m
+++ b/ft_topoplotER.m
@@ -47,6 +47,7 @@ function [cfg] = ft_topoplotER(cfg, varargin)
 %                            'SouthOutside'       outside bottom
 %                            'EastOutside'        outside right
 %                            'WestOutside'        outside left
+%   cfg.colorbartext       =  string indicating the text next to colorbar
 %   cfg.interplimits       = limits for interpolation (default = 'head')
 %                            'electrodes' to furthest electrode
 %                            'head' to edge of head

--- a/ft_topoplotIC.m
+++ b/ft_topoplotIC.m
@@ -36,6 +36,7 @@ function [cfg] = ft_topoplotIC(cfg, comp)
 %                            'SouthOutside'       outside bottom
 %                            'EastOutside'        outside right
 %                            'WestOutside'        outside left
+%   cfg.colorbartext       =  string indicating the text next to colorbar
 %   cfg.interplimits       = limits for interpolation (default = 'head')
 %                            'electrodes' to furthest electrode
 %                            'head' to edge of head

--- a/ft_topoplotTFR.m
+++ b/ft_topoplotTFR.m
@@ -44,6 +44,7 @@ function [cfg] = ft_topoplotTFR(cfg, varargin)
 %                            'SouthOutside'       outside bottom
 %                            'EastOutside'        outside right
 %                            'WestOutside'        outside left
+%   cfg.colorbartext       =  string indicating the text next to colorbar
 %   cfg.interplimits       = limits for interpolation (default = 'head')
 %                            'electrodes' to furthest electrode
 %                            'head' to edge of head

--- a/private/topoplot_common.m
+++ b/private/topoplot_common.m
@@ -753,7 +753,7 @@ if isfield(cfg, 'colorbar')
   elseif ~strcmp(cfg.colorbar, 'no')
     c = colorbar('location', cfg.colorbar);
   end
-  c.Label.String = cfg.colorbartext;
+  ylabel(c, cfg.colorbartext);
 end
 
 % Set renderer if specified

--- a/private/topoplot_common.m
+++ b/private/topoplot_common.m
@@ -149,6 +149,7 @@ cfg.interplimits      = ft_getopt(cfg, 'interplimits',     'head');
 cfg.interpolation     = ft_getopt(cfg, 'interpolation',     default_interpmethod);
 cfg.contournum        = ft_getopt(cfg, 'contournum',        6);
 cfg.colorbar          = ft_getopt(cfg, 'colorbar',         'no');
+cfg.colorbartext      = ft_getopt(cfg, 'colorbartext',    '');
 cfg.shading           = ft_getopt(cfg, 'shading',          'flat');
 cfg.comment           = ft_getopt(cfg, 'comment',          'auto');
 cfg.fontsize          = ft_getopt(cfg, 'fontsize',          8);
@@ -748,10 +749,11 @@ end
 % Plot colorbar
 if isfield(cfg, 'colorbar')
   if strcmp(cfg.colorbar, 'yes')
-    colorbar;
+    c = colorbar;
   elseif ~strcmp(cfg.colorbar, 'no')
-    colorbar('location', cfg.colorbar);
+    c = colorbar('location', cfg.colorbar);
   end
+  c.Label.String = cfg.colorbartext;
 end
 
 % Set renderer if specified


### PR DESCRIPTION
Allowing for setting a colorbar text next to the colorbar.
Documentation has been added for IC, ER and TFR top functions and the functionality has been added in topoplot_common. The result is seen below where the string has been set with cfg.colorbartext

```
cfg = [];
cfg.layout = 'CTF275.lay';
cfg.xlim = [0.100 0.100];
cfg.colorbar = 'yes';
cfg.colorbartext = 'Magnetic Field (T)';

ft_topoplotER(cfg, ERFs{1});
```

![bild](https://user-images.githubusercontent.com/17312936/56722768-03c41880-6748-11e9-8593-a9bb409dc4fc.png)
