### PR TITLE
read impedances newer versions of vhdr

### DIFF
--- a/fileio/private/read_brainvision_vhdr.m
+++ b/fileio/private/read_brainvision_vhdr.m
@@ -138,7 +138,7 @@ catch err
 end
 while ~feof(fid)
     tline = fgetl(fid);
-    if (length(tline) >= 9) && strcmp(tline(1:9),'Impedance')
+    if (length(tline) >= 11) && strcmp(tline(1:11),'[Impedance []')
         chanCounter=0;
         refCounter=0;
         impCounter=0;
@@ -192,7 +192,7 @@ while ~feof(fid)
                         hdr.impedances.reference(refCounter) = NaN;
                     end
                 end
-                if strcmpi(tline(1:4),'gnd:')
+                if strcmpi(tline(1:4),'gnd:') | strcmpi(tline(1:4),'Gnd:')
                     [chanName,impedances] = strtok(tline,':');
                     hdr.impedances.ground = str2double(impedances(2:end));
                 end
@@ -204,7 +204,7 @@ while ~feof(fid)
                 tline = fgetl(fid);
             end;
             if ~isempty(tline)
-                if strcmpi(tline(1:4),'gnd:')
+                if strcmpi(tline(1:4),'gnd:') | strcmpi(tline(1:4),'Gnd:')
                     [chanName,impedances] = strtok(tline,':');
                     hdr.impedances.ground = str2double(impedances(2:end));
                 end


### PR DESCRIPTION
Current fieldtrip version results in an error when reading the impedance section of Brainvision the header file. In an example vhdr I found:

**Data/Gnd Electrodes Selected Impedance Measurement Range: 0 - 20 kOhm
Impedance [kOhm] at 11:12:44 :**
See the following link to access the file:
https://mfr.osf.io/render?url=https://osf.io/3ym8a/?action=download%26mode=render

In the example above, the "11:12:44" is what is erroneously selected as impedance values. I solved this by searching for  the pattern "Impedance [". I found that other brainvision header files have different impedance info such:

**Test Signal from actiCAP is used.
Impedances Imported from actiCAP Control Software:
Impedance [kOhm] at 16:05:12 :**

https://mfr.osf.io/render?url=https://osf.io/pa647/?action=download%26mode=render (unfortunatelly here you cannot access individual files, you need to download all data)

@robertoostenveld Do you think the pattern "Impedance [" is a robust enough to avoid other problems?
