### PR TITLE
Update crossvalidator.m

### DIFF
--- a/external/dmlt/+dml/crossvalidator.m
+++ b/external/dmlt/+dml/crossvalidator.m
@@ -204,9 +204,7 @@ classdef crossvalidator
       end
       
       if strcmp(obj.type,'split'), obj.folds = 1; end
-      
-      if obj.verbose, fprintf('fixing random number generator for reproducibility\n'); end
-      
+          
       if ~iscell(Y)
         
         test = create_test_folds(Y);

--- a/external/dmlt/+dml/crossvalidator.m
+++ b/external/dmlt/+dml/crossvalidator.m
@@ -240,6 +240,10 @@ classdef crossvalidator
       
         function y = create_test_folds(Y)
           
+          % NOTE: Fixing of the random seed has been removed here in the fieldtrip 
+          % version since the randomseed is dealt with higher up in the code 
+          % hierarchy (i.e. specify cfg.randomseed in ft_timelockstatistics).
+          
           y = cell(obj.folds,1);
           
           % determine indices of labeled (non-nan) datapoints

--- a/external/dmlt/+dml/crossvalidator.m
+++ b/external/dmlt/+dml/crossvalidator.m
@@ -240,13 +240,6 @@ classdef crossvalidator
       
         function y = create_test_folds(Y)
           
-          % use the same ordering for multiple datasets by reinitializing the random number generator
-          try
-            RandStream.setGlobalStream(RandStream('mt19937ar','seed',1));
-          catch
-            rand('twister',1); randn('state',1);
-          end
-          
           y = cell(obj.folds,1);
           
           % determine indices of labeled (non-nan) datapoints


### PR DESCRIPTION
Remove resetting of random seed: it is not optionable in this script, and the option is already available in ft_timelockstatistics.