### PR TITLE
improve data2bids using cfg.method and by supporting participants/scans

### DIFF
--- a/fileio/ft_write_data.m
+++ b/fileio/ft_write_data.m
@@ -84,6 +84,9 @@ append = istrue(append);
 % determine the data size
 [nchans, nsamples] = size(dat);
 
+% ensure that the directory exists
+isdir_or_mkdir(fileparts(filename));
+
 switch dataformat
   
   case 'empty'

--- a/fileio/ft_write_mri.m
+++ b/fileio/ft_write_mri.m
@@ -64,7 +64,11 @@ if nargout>0
   V = [];
 end
 
+% ensure that the directory exists
+isdir_or_mkdir(fileparts(filename));
+
 switch dataformat
+
   case {'analyze_img' 'analyze_hdr' 'analyze' 'nifti_spm'}
     % analyze data, using SPM
     V = volumewrite_spm(filename, dat, transform, spmversion);

--- a/fileio/ft_write_sens.m
+++ b/fileio/ft_write_sens.m
@@ -13,10 +13,11 @@ function ft_write_sens(filename, sens, varargin)
 %
 % The supported file formats are
 %   bioimage_mgrid
+%   matlab
 %
 % See also FT_READ_SENS, FT_DATATYPE_SENS
 
-% Copyright (C) 2017, Robert Oostenveld
+% Copyright (C) 2017-2019, Robert Oostenveld
 %
 % This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
 % for the documentation and details.
@@ -42,11 +43,19 @@ format = ft_getopt(varargin, 'format');
 % ensure the input is according to the latest standards
 sens = ft_datatype_sens(sens);
 
+% ensure that the directory exists
+isdir_or_mkdir(fileparts(filename));
+
 switch format
   case 'bioimage_mgrid'
     [p, f, x] = fileparts(filename);
     filename = fullfile(p, [f '.mgrid']);
     write_bioimage_mgrid(filename, sens);
+    
+  case 'matlab'
+    [p, f, x] = fileparts(filename);
+    filename = fullfile(p, [f '.mat']);
+    save(filename, sens);
     
   otherwise
     ft_error('unsupported format "%s"', format);

--- a/fileio/private/fopen_or_error.m
+++ b/fileio/private/fopen_or_error.m
@@ -4,6 +4,8 @@ function fid = fopen_or_error(filename, mode, varargin)
 %
 % This keeps you from having to write "if fid < 0; error(...)" everywhere
 % you do an fopen.
+%
+% See also ISDIR_OR_MKDIR
 
 if nargin < 2 || isempty(mode)
   mode = 'r';

--- a/fileio/private/isdir_or_mkdir.m
+++ b/fileio/private/isdir_or_mkdir.m
@@ -1,0 +1,18 @@
+function isdir_or_mkdir(p)
+
+% ISDIR_OR_MKDIR Checks that a directory exists, or if not, creates the directory and
+% all its parent directories.
+%
+% See also FOPEN_OR_ERROR
+
+tok = tokenize(p, filesep);
+if isempty(tok{1})
+  tok{1} = filesep;
+end
+for i=1:numel(tok)
+  d = fullfile(tok{1:i});
+  if ~isfolder(d)
+    ft_notice('creating directory %s', d);
+    mkdir(d);
+  end
+end

--- a/fileio/private/read_eeglabdata.m
+++ b/fileio/private/read_eeglabdata.m
@@ -13,7 +13,7 @@
 %   'header'    - FILEIO structure header
 %
 % Outputs:
-%   dat    - data over the specified range
+%   dat         - data over the specified range
 %
 % Author: Arnaud Delorme, SCCN, INC, UCSD, 2008-
 
@@ -38,9 +38,9 @@
 function dat = read_eeglabdata(filename, varargin)
 
 if nargin < 1
-  help read_eeglabdata;
-  return;
-end;
+  help read_eeglabdata
+  return
+end
 
 header    = ft_getopt(varargin, 'header');
 begsample = ft_getopt(varargin, 'begsample');
@@ -54,43 +54,43 @@ if isempty(header)
 end
 
 if ischar(header.orig.data)
-  if strcmpi(header.orig.data(end-2:end), 'set'),
+  if strcmpi(header.orig.data(end-2:end), 'set')
     header.ori = load('-mat', filename);
   else
-      
-      % assuming that the data file is in the current directory
-      fid = fopen(header.orig.data);
-
-      % assuming the .dat and .set files are located in the same directory
-      if fid == -1
-          pathstr = fileparts(filename);
-          fid = fopen(fullfile(pathstr, header.orig.data));
-      end
-
-      if fid == -1
-          fid = fopen(fullfile(header.orig.filepath, header.orig.data)); %
-      end
-
-if fid == -1, ft_error(['Cannot not find data file: ' header.orig.data]); end;
-
+    
+    % assuming that the data file is in the current directory
+    fid = fopen(header.orig.data);
+    
+    % assuming the .dat and .set files are located in the same directory
+    if fid == -1
+      pathstr = fileparts(filename);
+      fid = fopen(fullfile(pathstr, header.orig.data));
+    end
+    
+    if fid == -1
+      fid = fopen(fullfile(header.orig.filepath, header.orig.data));
+    end
+    
+    if fid == -1, ft_error(['Cannot not find data file: ' header.orig.data]); end
+    
     % only read the desired trials
     if strcmpi(header.orig.data(end-2:end), 'dat')
-        dat = fread(fid,[header.nSamples*header.nTrials header.nChans],'float32')';
+      dat = fread(fid,[header.nSamples*header.nTrials header.nChans],'float32')';
     else
-        dat = fread(fid,[header.nChans header.nSamples*header.nTrials],'float32');
-    end;
+      dat = fread(fid,[header.nChans header.nSamples*header.nTrials],'float32');
+    end
     dat = reshape(dat, header.nChans, header.nSamples, header.nTrials);
     fclose(fid);
-  end;
+  end
 else
   dat = header.orig.data;
   dat = reshape(dat, header.nChans, header.nSamples, header.nTrials);
-end;
+end
 
-if isempty(begtrial), begtrial = 1; end;
-if isempty(endtrial), endtrial = header.nTrials; end;
-if isempty(begsample), begsample = 1; end;
-if isempty(endsample), endsample = header.nSamples; end;
+if isempty(begtrial), begtrial = 1; end
+if isempty(endtrial), endtrial = header.nTrials; end
+if isempty(begsample), begsample = 1; end
+if isempty(endsample), endsample = header.nSamples; end
 dat = dat(:,begsample:endsample,begtrial:endtrial);
 
 if ~isempty(chanindx)

--- a/fileio/private/read_eeglabevent.m
+++ b/fileio/private/read_eeglabevent.m
@@ -35,9 +35,9 @@
 function event = read_eeglabevent(filename, varargin)
 
 if nargin < 1
-  help read_eeglabheader;
-  return;
-end;
+  help read_eeglabheader
+  return
+end
 
 hdr = ft_getopt(varargin, 'header');
 
@@ -49,56 +49,57 @@ event    = [];                % these will be the output in FieldTrip format
 oldevent = hdr.orig.event;    % these are in EEGLAB format
 
 if ~isempty(oldevent)
-    nameList=fieldnames(oldevent);
+  nameList = fieldnames(oldevent);
 else
-    nameList=[];
-end;
-nameList=setdiff(nameList,{'type','value','sample','offset','duration','latency'});
+  nameList = [];
+end
+nameList = setdiff(nameList, {'type','value','sample','offset','duration','latency'});
 
 for index = 1:length(oldevent)
-
+  
   if isfield(oldevent,'code')
     type = oldevent(index).code;
   elseif isfield(oldevent,'value')
     type = oldevent(index).value;
   else
     type = 'trigger';
-  end;
-
+  end
+  
   % events can have a numeric or a string value
   if isfield(oldevent,'type')
     value  = oldevent(index).type;
   else
     value = 'default';
-  end;
-
+  end
+  
   % this is the sample number of the concatenated data to which the event corresponds
   sample = oldevent(index).latency;
-
+  
   % a non-zero offset only applies to trial-events, i.e. in case the data is
   % segmented and each data segment needs to be represented as event. In
   % that case the offset corresponds to the baseline duration (times -1).
   offset = 0;
-
+  
   if isfield(oldevent, 'duration')
     duration = oldevent(index).duration;
   else
     duration = 0;
-  end;
-
+  end
+  
   % add the current event in FieldTrip format
   event(index).type     = type;     % this is usually a string, e.g. 'trigger' or 'trial'
   event(index).value    = value;    % in case of a trigger, this is the value
   event(index).sample   = sample;   % this is the sample in the datafile at which the event happens
   event(index).offset   = offset;   % some events should be represented with a shifted time-axix, e.g. a trial with a baseline period
   event(index).duration = duration; % some events have a duration, such as a trial
-
+  
   %add custom fields
   for iField=1:length(nameList)
-      eval(['event(index).' nameList{iField} '=oldevent(index).' nameList{iField} ';']);
-  end;
+    eval(['event(index).' nameList{iField} '=oldevent(index).' nameList{iField} ';']);
+  end
+  
+end % for oldevent
 
-end;
 
 if hdr.nTrials>1
   % add the trials to the event structure
@@ -106,12 +107,12 @@ if hdr.nTrials>1
     event(end+1).type     = 'trial';
     event(end  ).sample   = (i-1)*hdr.nSamples + 1;
     if isfield(oldevent,'setname') && (length(oldevent) == hdr.nTrials)
-        event(end  ).value    = oldevent(i).setname; %accommodate Widmann's pop_grandaverage function
+      event(end  ).value  = oldevent(i).setname; % accommodate Widmann's pop_grandaverage function
     else
-        event(end  ).value    = [];
-    end;
+      event(end  ).value  = [];
+    end
     event(end  ).offset   = -hdr.nSamplesPre;
     event(end  ).duration =  hdr.nSamples;
   end
-end
+end % if nTrials>1
 

--- a/fileio/private/read_eeglabheader.m
+++ b/fileio/private/read_eeglabheader.m
@@ -32,23 +32,23 @@
 function header = read_eeglabheader(filename)
 
 if nargin < 1
-  help read_eeglabheader;
-  return;
-end;
+  help read_eeglabheader
+  return
+end
 
 if ~isstruct(filename)
-  load('-mat', filename);
+  load('-mat', filename, 'EEG');
 else
   EEG = filename;
-end;
+end
 
-header.Fs          = EEG.srate;
-header.nChans      = EEG.nbchan;
-header.nSamples    = EEG.pnts;
+header.Fs          =  EEG.srate;
+header.nChans      =  EEG.nbchan;
+header.nSamples    =  EEG.pnts;
 header.nSamplesPre = -EEG.xmin*EEG.srate;
-header.nTrials     = EEG.trials;
+header.nTrials     =  EEG.trials;
 try
-  header.label       = { EEG.chanlocs.labels }';
+  header.label     = { EEG.chanlocs.labels }';
 catch
   ft_warning('creating default channel names');
   for i=1:header.nChans
@@ -57,15 +57,15 @@ catch
 end
 ind = 1;
 for i = 1:length( EEG.chanlocs )
-    if isfield(EEG.chanlocs(i), 'X') && ~isempty(EEG.chanlocs(i).X)
-        header.elec.label{ind, 1} = EEG.chanlocs(i).labels;
-        % this channel has a position
-        header.elec.elecpos(ind,1) = EEG.chanlocs(i).X;
-        header.elec.elecpos(ind,2) = EEG.chanlocs(i).Y;
-        header.elec.elecpos(ind,3) = EEG.chanlocs(i).Z;
-        ind = ind+1;
-    end;
-end;
+  if isfield(EEG.chanlocs(i), 'X') && ~isempty(EEG.chanlocs(i).X)
+    header.elec.label{ind, 1} = EEG.chanlocs(i).labels;
+    % this channel has a position
+    header.elec.elecpos(ind,1) = EEG.chanlocs(i).X;
+    header.elec.elecpos(ind,2) = EEG.chanlocs(i).Y;
+    header.elec.elecpos(ind,3) = EEG.chanlocs(i).Z;
+    ind = ind+1;
+  end
+end
 
 % remove data
 % -----------

--- a/private/merge_table.m
+++ b/private/merge_table.m
@@ -1,0 +1,124 @@
+function t3 = merge_table(t1, t2, key)
+
+% MERGE_TABLE merges two tables where the rows and columns can be partially
+% overlapping or different. Values from the 2nd input have precedence in case the
+% same row and column is also present in the 1st.
+%
+% Use as
+%   t3 = merge_table(t1, t2, key)
+%
+% See also TABLE
+
+% Copyright (C) 2018, Robert Oostenveld
+%
+% This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
+% for the documentation and details.
+%
+%    FieldTrip is free software: you can redistribute it and/or modify
+%    it under the terms of the GNU General Public License as published by
+%    the Free Software Foundation, either version 3 of the License, or
+%    (at your option) any later version.
+%
+%    FieldTrip is distributed in the hope that it will be useful,
+%    but WITHOUT ANY WARRANTY; without even the implied warranty of
+%    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%    GNU General Public License for more details.
+%
+%    You should have received a copy of the GNU General Public License
+%    along with FieldTrip. If not, see <http://www.gnu.org/licenses/>.
+%
+% $Id$
+
+assert(nargin==3);
+
+c1 = t1.Properties.VariableNames;
+c2 = t2.Properties.VariableNames;
+
+assert(contains(key, c1));
+assert(contains(key, c2));
+
+[m1, n1] = size(t1);
+[m2, n2] = size(t2);
+
+for i=1:n1
+  if ischar(t1{1,i})
+    t1.(c1{i}) = cellstr(t1{:,i});
+  elseif isnumeric(t1{1,i})
+    t1.(c1{i}) = num2cell(t1{:,i});
+  end
+end
+
+for i=1:n2
+  if ischar(t2{1,i})
+    t2.(c2{i}) = cellstr(t2{:,i});
+  elseif isnumeric(t2{1,i})
+    t2.(c2{i}) = num2cell(t2{:,i});
+  end
+end
+
+t3 = table();
+
+% deal with the columns that are present in both inputs
+col = intersect(c1, c2);
+
+for i=1:numel(col)
+  % copy the existing column from t1 into t3
+  t3.(col{i}) = t1.(col{i});
+end
+
+for j=1:m2
+  row = findkey(t1.(key), t2.(key){j});
+  if ~any(row)
+    % add an empty row to t3
+    row = size(t3,1)+1;
+    t3(row,:) = cell(1, numel(col));
+  end
+  for i=1:numel(col)
+    t3(row, col{i}) = t2(j, col{i});
+  end
+end
+
+n3 = size(t3,1);
+
+% deal with the columns that are only present in the 1st input
+col = setdiff(c1, c2);
+
+for i=1:numel(col)
+  % add an empty column to t3
+  t3.(col{i}) = cell(n3, 1);
+end
+
+for j=1:m1
+  row = findkey(t3.(key), t1.(key){j});
+  for i=1:numel(col)
+    t3(row, col{i}) = t1(j, col{i});
+  end
+end
+
+% deal with the columns that are only present in the 2nd input
+col = setdiff(c2, c1);
+
+for i=1:numel(col)
+  % add an empty column to t3
+  t3.(col{i}) = cell(n3, 1);
+end
+
+for j=1:m2
+  row = findkey(t3.(key), t2.(key){j});
+  for i=1:numel(col)
+    t3(row, col{i}) = t2(j, col{i});
+  end
+end
+
+% reorder the columns to match the input
+c3 = unique(cat(2, c1, c2), 'stable');
+[c3, ia, ib] = intersect(c3, t3.Properties.VariableNames, 'stable');
+t3 = t3(:,ib);
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% SUBFUNCTION this also allows comparisons between different classes
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+function ret = findkey(list, elem)
+match = @(x) isequal(x, elem);
+ret = cellfun(match, list);

--- a/test/test_data2bids.m
+++ b/test/test_data2bids.m
@@ -5,9 +5,8 @@ function test_data2bids
 
 % DEPENDENCY data2bids
 
-cd(dccnpath('/home/common/matlab/fieldtrip/data/test/mous'));
-
 %%
+cd(dccnpath('/home/common/matlab/fieldtrip/data/test/data2bids/mous'));
 
 cfg = [];
 cfg.dataset                     = 'sub-A2002/meg/sub-A2002_task-auditory_meg.ds';
@@ -40,6 +39,8 @@ cfg.meg.SoftwareFilters         = 'n/a';
 data2bids(cfg);
 
 %%
+cd(dccnpath('/home/common/matlab/fieldtrip/data/test/data2bids/mous'));
+
 
 cfg = [];
 cfg.dataset                     = 'sub-A2002/func/sub-A2002_task-auditory_bold.nii';
@@ -58,3 +59,38 @@ cfg.RepetitionTime              = 2;
 
 data2bids(cfg);
 
+%%
+cd(dccnpath('/home/common/matlab/fieldtrip/data/test/data2bids/eeglab'));
+
+% the following uses a dataset that originates from the EEGLAB website
+% wget --no-check-certificate https://sccn.ucsd.edu/mediawiki/images/9/9c/Eeglab_data.set
+
+age = [11  96  23 77  82  87  18 40  26  80];
+sex = ['f' 'f' 'f' 'f' 'f' 'm' 'm' 'm' 'm' 'm'];
+
+sub = {'01', '02', '03', '04', '05', '06', '07', '08', '09', '10'};
+ses = {'pre', 'post'};
+run = {1, 2};
+
+for subindx=1:numel(sub)
+  for sesindx=1:numel(ses)
+    for runindx=1:numel(run)
+      
+      cfg = [];
+      cfg.dataset   = 'sourcedata/Eeglab_data.set';
+      cfg.datatype  = 'eeg';
+      
+      cfg.participants.age = age(subindx);
+      cfg.participants.sex = sex(subindx);
+      
+      cfg.scans.acq_time = datestr(now, 'yyyy-mm-ddThh:MM:SS'); % RFC3339
+      
+      cfg.bidsroot  = 'bids';
+      cfg.sub       = sub{subindx};
+      cfg.ses       = ses{sesindx};
+      cfg.run       = run{runindx};
+      data2bids(cfg);
+      
+    end % for run
+  end % for ses
+end % for sub

--- a/test/test_data2bids.m
+++ b/test/test_data2bids.m
@@ -41,7 +41,6 @@ data2bids(cfg);
 %%
 cd(dccnpath('/home/common/matlab/fieldtrip/data/test/data2bids/mous'));
 
-
 cfg = [];
 cfg.dataset                     = 'sub-A2002/func/sub-A2002_task-auditory_bold.nii';
 cfg.presentationfile            = 'sourcedata/mri_task/A2002-2-fMRI-MOUS-Aud.log';
@@ -65,8 +64,8 @@ cd(dccnpath('/home/common/matlab/fieldtrip/data/test/data2bids/eeglab'));
 % the following uses a dataset that originates from the EEGLAB website
 % wget --no-check-certificate https://sccn.ucsd.edu/mediawiki/images/9/9c/Eeglab_data.set
 
-age = [11  96  23 77  82  87  18 40  26  80];
-sex = ['f' 'f' 'f' 'f' 'f' 'm' 'm' 'm' 'm' 'm'];
+age = [11  96  nan 77  82  87  18 40  26  80];
+sex = {'f' [] 'f' 'f' 'f' 'm' 'm' 'm' 'm' 'm'};
 
 sub = {'01', '02', '03', '04', '05', '06', '07', '08', '09', '10'};
 ses = {'pre', 'post'};
@@ -81,9 +80,12 @@ for subindx=1:numel(sub)
       cfg.datatype  = 'eeg';
       
       cfg.participants.age = age(subindx);
-      cfg.participants.sex = sex(subindx);
+      cfg.participants.sex = sex{subindx};
       
       cfg.scans.acq_time = datestr(now, 'yyyy-mm-ddThh:MM:SS'); % RFC3339
+      
+      cfg.InstitutionName             = 'Radboud University';
+      cfg.InstitutionalDepartmentName = 'Donders Institute for Brain, Cognition and Behaviour';
       
       cfg.bidsroot  = 'bids';
       cfg.sub       = sub{subindx};
@@ -94,3 +96,5 @@ for subindx=1:numel(sub)
     end % for run
   end % for ses
 end % for sub
+
+

--- a/utilities/private/ft_notification.m
+++ b/utilities/private/ft_notification.m
@@ -342,7 +342,7 @@ switch varargin{1}
         if ~isempty(msgId)
           error(state);
         else
-          error(varargin{:});
+          error(rmfield(state, 'identifier'));
         end
         
       elseif strcmp(level, 'warning')


### PR DESCRIPTION
This PR includes two large changes: 

The first is that cfg.bidsroot, cfg.sub, cfg.ses etc are added to allow dynamic construction of the cfg.outputfile and construction of the output directory with the participants.tsv and scans.tsv in the right place. 

The second is that I added cfg.method to explicitly distinguish between decorate/convert/copy, which seem the three major "things" that data2bids does. The old option cfg.keepnative introduces in #966 is now obsolete, but should keep working (using checkconfig). But please be aware....   