### PR TITLE
extend data2bids for more data types

### DIFF
--- a/bin/synchronize-private.sh
+++ b/bin/synchronize-private.sh
@@ -1315,6 +1315,14 @@ ARRAY+=(src/inv3x3.mexw64)
 sync ${ARRAY[*]}
 
 ################################################################################
+# isdir_or_mkdir.m
+
+ARRAY=()
+ARRAY+=(fileiot/private/isdir_or_mkdir.m)
+ARRAY+=(private/isdir_or_mkdir.m)
+sync ${ARRAY[*]}
+
+################################################################################
 # isalmostequal.m
 
 ARRAY=()

--- a/private/copy_brainvision_files.m
+++ b/private/copy_brainvision_files.m
@@ -1,0 +1,170 @@
+function copy_brainvision_files(oldheaderfile, newheaderfile, deleteflag)
+
+% COPY_BRAINVISION_FILES copies a BrainVision EEG dataset, which consists of a vhdr
+% header file, vmrk marker file and a data file with the extension dat, eeg or seg.
+%
+% Use as
+%   copy_brainvision_files(oldname, newname, deleteflag)
+%
+% Both the old and the new filename should be strings corresponding to the header
+% file, i.e. including the vhdr extension. The third "deleteflag" argument is
+% optional, it should be a boolean that specifies whether the original files should
+% be deleted after copying or not (default = false).
+%
+% See also https://gist.github.com/robertoostenveld/e31637a777c514bf1e86272e1092316e
+% and https://gist.github.com/CPernet/e037df46e064ca83a49fb4c595d4566a
+
+% Copyright (C) 2018-2019, Robert Oostenveld
+%
+% This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
+% for the documentation and details.
+%
+%    FieldTrip is free software: you can redistribute it and/or modify
+%    it under the terms of the GNU General Public License as published by
+%    the Free Software Foundation, either version 3 of the License, or
+%    (at your option) any later version.
+%
+%    FieldTrip is distributed in the hope that it will be useful,
+%    but WITHOUT ANY WARRANTY; without even the implied warranty of
+%    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%    GNU General Public License for more details.
+%
+%    You should have received a copy of the GNU General Public License
+%    along with FieldTrip. If not, see <http://www.gnu.org/licenses/>.
+%
+% $Id$
+
+%% deal with inputs
+
+if nargin<3
+  deleteflag = false;
+end
+
+if ~endsWith(oldheaderfile, 'vhdr') && ~endsWith(oldheaderfile, 'VHDR')
+  ft_error('you should specify the old header file');
+end
+
+if ~endsWith(newheaderfile, 'vhdr') && ~endsWith(newheaderfile, 'VHDR')
+  ft_error('you should specify the new header file');
+end
+
+% determine whether the file extensions should be in lower or upper case
+if ~isempty(regexp(newheaderfile, 'VHDR$', 'once'))
+  switchcase = @upper;
+else
+  switchcase = @lower;
+end
+
+% determine the filename without extension
+[~, f, ~] = fileparts(newheaderfile);
+
+%% do the copying
+
+% deal with the header file
+if ~exist(oldheaderfile, 'file')
+  ft_error('the file "%s" does not exists', oldheaderfile);
+end
+
+if exist(newheaderfile, 'file')
+  ft_error('the file "%s" already exists', newheaderfile);
+end
+
+fid1 = fopen(oldheaderfile, 'r'); % read old
+fid2 = fopen(newheaderfile, 'w'); % write new
+
+while ~feof(fid1)
+  line = fgetl(fid1);
+  if ~isempty(regexp(line, '^MarkerFile', 'once'))
+    [~, rem] = strtok(line, '=');
+    oldmarkerfile = rem(2:end);
+    [~, ~, x] = fileparts(oldmarkerfile);
+    newmarkerfile = [f switchcase(x)];
+    line = sprintf('MarkerFile=%s', newmarkerfile);
+  elseif ~isempty(regexp(line, '^DataFile', 'once'))
+    [~, rem] = strtok(line, '=');
+    olddatafile = rem(2:end);
+    [~, ~, x] = fileparts(olddatafile);
+    newdatafile = [f switchcase(x)];
+    line = sprintf('DataFile=%s', newdatafile);
+  end
+  fprintf(fid2, '%s\r\n', line);
+end
+fclose(fid1);
+fclose(fid2);
+
+% deal with the marker file
+if exist(oldmarkerfile, 'file') == 0
+  [~, ~, xx] = fileparts(oldmarkerfile);
+  [~, ff, ~] = fileparts(oldheaderfile); % re-reading as sometimes weird names comes up
+  if exist([ff xx], 'file')
+    oldmarkerfile = [ff xx];
+  else
+    error('the file "%s" does not exists', oldmarkerfile);
+  end
+end
+
+if exist(newmarkerfile, 'file')
+  ft_error('the file "%s" already exists', newmarkerfile);
+end
+
+fid1 = fopen(oldmarkerfile, 'r');
+fid2 = fopen(newmarkerfile, 'w');
+
+while ~feof(fid1)
+  line = fgetl(fid1);
+  if ~isempty(regexp(line, '^HeaderFile', 'once'))
+    [~, rem] = strtok(line, '=');
+    oldheaderfile = rem(2:end);
+    [~, ~, x] = fileparts(oldheaderfile);
+    newheaderfile = [f switchcase(x)];
+    line = sprintf('HeaderFile=%s', newheaderfile);
+  elseif ~isempty(regexp(line, '^DataFile', 'once'))
+    [~, rem] = strtok(line, '=');
+    olddatafile = rem(2:end);
+    [~, ~, x] = fileparts(olddatafile);
+    newdatafile = [f switchcase(x)];
+    line = sprintf('DataFile=%s', newdatafile);
+  end
+  fprintf(fid2, '%s\r\n', line);
+end
+fclose(fid1);
+fclose(fid2);
+
+% deal with the data file
+if exist(olddatafile, 'file') == 0
+  [~, ~, xx] = fileparts(olddatafile);
+  [~, ff, ~] = fileparts(oldheaderfile); % re-reading as sometimes weird names comes up
+  if exist([ff xx], 'file')
+    olddatafile = [ff xx];
+  else
+    error('the file "%s" does not exists', oldmarkerfile);
+  end
+end
+
+if exist(newdatafile, 'file')
+  ft_error('the file "%s" already exists', newdatafile);
+end
+
+status = copyfile(olddatafile, newdatafile);
+if ~status
+  error('failed to copy data from "%s" to "%s"', olddatafile, newdatafile);
+end
+
+%% delete the old files
+if deleteflag
+  try
+    delete(oldheaderfile);
+  catch
+    ft_warning('cannot delete "%s"', oldheaderfile);
+  end
+  try
+    delete(oldmarkerfile);
+  catch
+    ft_warning('cannot delete "%s"', oldmarkerfile);
+  end
+  try
+    delete(olddatafile);
+  catch
+    ft_warning('cannot delete "%s"', olddatafile);
+  end
+end

--- a/private/isdir_or_mkdir.m
+++ b/private/isdir_or_mkdir.m
@@ -1,0 +1,18 @@
+function isdir_or_mkdir(p)
+
+% ISDIR_OR_MKDIR Checks that a directory exists, or if not, creates the directory and
+% all its parent directories.
+%
+% See also FOPEN_OR_ERROR
+
+tok = tokenize(p, filesep);
+if isempty(tok{1})
+  tok{1} = filesep;
+end
+for i=1:numel(tok)
+  d = fullfile(tok{1:i});
+  if ~isfolder(d)
+    ft_notice('creating directory %s', d);
+    mkdir(d);
+  end
+end

--- a/private/merge_table.m
+++ b/private/merge_table.m
@@ -9,7 +9,7 @@ function t3 = merge_table(t1, t2, key)
 %
 % See also TABLE
 
-% Copyright (C) 2018, Robert Oostenveld
+% Copyright (C) 2019, Robert Oostenveld
 %
 % This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
 % for the documentation and details.

--- a/private/mergeconfig.m
+++ b/private/mergeconfig.m
@@ -1,13 +1,30 @@
-function original = mergeconfig(original, default, emptymeaningful)
+function s1 = mergeconfig(s1, s2, emptymeaningful)
 
-% MERGECONFIG merges the fields of a structure with defaults into an original
-% configuration structure. The default is only copied in case the field is absent in
-% the original.
+% MERGECONFIG merges the fields of a structure with another structure. The fields of
+% the 2nd structure are only copied in case they are absent in the 1st structure.
 %
 % Use as
-%   output = mergeconfig(original, default)
+%   s3 = mergeconfig(s1, s2, emptymeaningful)
+%
+% See also MERGE_TABLE
 
-% Copyright (C) 2009-2012, Robert Oostenveld
+% Copyright (C) 2009-2019, Robert Oostenveld
+%
+% This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
+% for the documentation and details.
+%
+%    FieldTrip is free software: you can redistribute it and/or modify
+%    it under the terms of the GNU General Public License as published by
+%    the Free Software Foundation, either version 3 of the License, or
+%    (at your option) any later version.
+%
+%    FieldTrip is distributed in the hope that it will be useful,
+%    but WITHOUT ANY WARRANTY; without even the implied warranty of
+%    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%    GNU General Public License for more details.
+%
+%    You should have received a copy of the GNU General Public License
+%    along with FieldTrip. If not, see <http://www.gnu.org/licenses/>.
 %
 % $Id$
 
@@ -15,68 +32,68 @@ if nargin<3
   emptymeaningful = true;
 end
 
-if isempty(original) && ~isstruct(original)
+if isempty(s1) && ~isstruct(s1)
   % ensure that it is an empty struct, not an empty double
-  original = struct;
+  s1 = struct;
 end
 
-if isempty(default) && ~isstruct(default)
+if isempty(s2) && ~isstruct(s2)
   % ensure that it is an empty struct, not an empty double
-  default = struct;
+  s2 = struct;
 end
 
 if ~emptymeaningful
-  original = remove_empty(original);
-  default = remove_empty(default);
+  s1 = remove_empty(s1);
+  s2 = remove_empty(s2);
 end
 
 % merge the original with the fields from default
-defaultfields = fieldnames(default);
-inputfields = fieldnames(original);
+defaultfields = fieldnames(s2);
+inputfields = fieldnames(s1);
 allfields = union(defaultfields, inputfields);
 
-if numel(default)>1 && numel(default)==numel(original)
+if numel(s2)>1 && numel(s2)==numel(s1)
   % create an empty structure that has all the fields
   tmp = empty_struct(allfields);
-  for i=1:numel(original)
+  for i=1:numel(s1)
     for j=1:numel(allfields)
-      if isfield(original(i), allfields{j})
-        tmp(i).(allfields{j}) = original(i).(allfields{j});
+      if isfield(s1(i), allfields{j})
+        tmp(i).(allfields{j}) = s1(i).(allfields{j});
       else
-        tmp(i).(allfields{j}) = default(i).(allfields{j});
+        tmp(i).(allfields{j}) = s2(i).(allfields{j});
       end
     end
   end
-  original = tmp;
+  s1 = tmp;
   
-elseif numel(default)~=numel(original)
+elseif numel(s2)~=numel(s1)
   for j=1:numel(allfields)
     % ensure that the original has all fields
-    if ~isfield(original, allfields{j})
-      original(1).(allfields{j}) = [];
+    if ~isfield(s1, allfields{j})
+      s1(1).(allfields{j}) = [];
     end
     % ensure that the default has all fields
-    if ~isfield(default, allfields{j})
-      default(1).(allfields{j}) = [];
+    if ~isfield(s2, allfields{j})
+      s2(1).(allfields{j}) = [];
     end
   end
   % simply concatenate them
-  original = cat(1, original(:), default(:));
+  s1 = cat(1, s1(:), s2(:));
   
 else
   for i=1:length(defaultfields)
     fn = defaultfields{i};
-    if  ~isfield(original, fn) && ~isstruct(default.(fn))
+    if  ~isfield(s1, fn) && ~isstruct(s2.(fn))
       % simply copy the value over
-      original.(fn) = default.(fn);
-    elseif ~isfield(original, fn) &&  isstruct(default.(fn))
+      s1.(fn) = s2.(fn);
+    elseif ~isfield(s1, fn) &&  isstruct(s2.(fn))
       % simply copy the substructure over
-      original.(fn) = default.(fn);
-    elseif  isfield(original, fn) && ~isstruct(default.(fn))
+      s1.(fn) = s2.(fn);
+    elseif  isfield(s1, fn) && ~isstruct(s2.(fn))
       % do not copy it over, keep the original value
-    elseif  isfield(original, fn) &&  isstruct(default.(fn))
+    elseif  isfield(s1, fn) &&  isstruct(s2.(fn))
       % merge the two substructures using recursive call
-      original.(fn) = mergeconfig(original.(fn), default.(fn));
+      s1.(fn) = mergeconfig(s1.(fn), s2.(fn));
     end
   end % for all default fields
   

--- a/test/test_data2bids.m
+++ b/test/test_data2bids.m
@@ -72,18 +72,74 @@ cfg.InstitutionalDepartmentName = 'Donders Institute for Brain, Cognition and Be
 cfg.mri.writesidecar            = 'merge';
 data2bids(cfg)
 
-
 %% Example with realigned and resliced anatomical MRI data in memory
 cd(dccnpath('/home/common/matlab/fieldtrip/data/test/data2bids/convert'))
 
 mri = ft_read_mri('dicom/ERIVDBER_030731_R.OOSTERVELD.MR.PAUGAA_ANATOMICAL-3D.2.56.2003.7.31.11.19.16.468000.53834351.IMA');
 
 cfg = [];
-cfg.method                      = 'convert';
 cfg.outputfile                  = 'sub-RO_T1w.nii';
 cfg.InstitutionName             = 'Radboud University';
 cfg.InstitutionalDepartmentName = 'Donders Institute for Brain, Cognition and Behaviour';
 data2bids(cfg, mri)
+
+%% Example where the data is copied
+cd(dccnpath('/home/common/matlab/fieldtrip/data/test/data2bids/copy'));
+
+cfg = [];
+cfg.method                      = 'copy';
+cfg.dataset                     = 'Eeglab_data.set';
+cfg.outputfile                  = 'sub-EEG_task-attention_eeg.set';
+cfg.InstitutionName             = 'Radboud University';
+cfg.InstitutionalDepartmentName = 'Donders Institute for Brain, Cognition and Behaviour';
+data2bids(cfg)
+
+
+cfg = [];
+cfg.method                      = 'copy';
+cfg.dataset                     = 'jg_single_01raw.fif';
+cfg.outputfile                  = 'sub-MEG_task-stimuluation_meg.fif';
+cfg.InstitutionName             = 'Radboud University';
+cfg.InstitutionalDepartmentName = 'Donders Institute for Brain, Cognition and Behaviour';
+data2bids(cfg)
+
+%% try some iEEG data with electrodes
+
+cd(dccnpath('/home/common/matlab/fieldtrip/data/test/data2bids/convert'));
+
+% this loads data, elec_acpc_fr, and mri
+load(dccnpath('/Volumes/home/common/matlab/fieldtrip/data/ftp/tutorial/human_ecog/SubjectUCI29/SubjectUCI29_data.mat'));
+load(dccnpath('/Volumes/home/common/matlab/fieldtrip/data/ftp/tutorial/human_ecog/SubjectUCI29/SubjectUCI29_elec_acpc_fr.mat'));
+mri = ft_read_mri(dccnpath('/Volumes/home/common/matlab/fieldtrip/data/ftp/tutorial/human_ecog/SubjectUCI29/SubjectUCI29_MR_acpc.nii'));
+
+% make the data a bit smaller
+cfg = [];
+cfg.trials = 1;
+data = ft_selectdata(cfg, data);
+
+cfg = [];
+cfg.resamplefs = 500;
+data = ft_resampledata(cfg, data);
+
+% add the electrode definition
+data.elec = elec_acpc_fr;
+
+cfg = [];
+cfg.bidsroot = 'human_ecog';
+cfg.sub = 'UCI29';
+cfg.task = 'attention';
+cfg.datatype = 'ieeg';
+data2bids(cfg, data);
+
+cfg = [];
+cfg.bidsroot = 'human_ecog';
+cfg.sub = 'UCI29';
+cfg.datatype = 'T1w';
+cfg.mri.StationName = 'bay3';
+cfg.mri.MagneticFieldStrength = 3;
+data2bids(cfg, mri);
+
+
 
 %%
 cd(dccnpath('/home/common/matlab/fieldtrip/data/test/data2bids/mous'));

--- a/test/test_data2bids.m
+++ b/test/test_data2bids.m
@@ -5,6 +5,86 @@ function test_data2bids
 
 % DEPENDENCY data2bids
 
+%% Example with a CTF dataset on disk that needs no conversion
+cd(dccnpath('/home/common/matlab/fieldtrip/data/test/data2bids/decorate'))
+
+cfg = [];
+% cfg.method                      = 'decorate';
+% cfg.outputfile                  = 'Subject01.ds';
+cfg.dataset                     = 'Subject01.ds';
+cfg.TaskName                    = 'language';
+cfg.meg.PowerLineFrequency      = 50;
+cfg.InstitutionName             = 'Radboud University';
+cfg.InstitutionalDepartmentName = 'Donders Institute for Brain, Cognition and Behaviour';
+data2bids(cfg)
+
+%% Example with a NeuroScan EEG dataset on disk that needs to be converted
+cd(dccnpath('/home/common/matlab/fieldtrip/data/test/data2bids/convert'))
+
+cfg = [];
+cfg.method                      = 'convert';
+cfg.dataset                     = 'Subject1_MP.cnt';
+cfg.outputfile                  = 'sub-MP_task-visual_eeg.vhdr';
+cfg.eeg.writesidecar            = 'replace';
+cfg.channels.writesidecar       = 'replace';
+cfg.events.writesidecar         = 'replace';
+cfg.TaskName                    = 'visual';
+cfg.TaskDescription             = 'Visual response task';
+cfg.Instructions                = 'Press as fast with your right index finger as you see the target appear on screen.';
+cfg.InstitutionName             = 'Radboud University';
+cfg.InstitutionalDepartmentName = 'Donders Institute for Brain, Cognition and Behaviour';
+cfg.channels.status             = 'good'; % all channels are good
+data2bids(cfg)
+
+%% Example with preprocessed EEG data in memory
+cd(dccnpath('/home/common/matlab/fieldtrip/data/test/data2bids/convert'))
+
+cfg = [];
+cfg.dataset                     = 'Subject1_MP.cnt';
+cfg.bpfilter                    = 'yes';
+cfg.bpfreq                      = [0.1 40];
+data = ft_preprocessing(cfg);
+
+cfg = [];
+cfg.outputfile                  = 'sub-MP_task-visual_eeg.vhdr';
+cfg.eeg.writesidecar            = 'yes';
+cfg.channels.writesidecar       = 'yes';
+cfg.events.writesidecar         = 'yes';
+cfg.TaskName                    = 'visual';
+cfg.TaskDescription             = 'Visual response task';
+cfg.Instructions                = 'Press as fast with your right index finger as you see the target appear on screen.';
+cfg.InstitutionName             = 'Radboud University';
+cfg.InstitutionalDepartmentName = 'Donders Institute for Brain, Cognition and Behaviour';
+data2bids(cfg, data)
+
+%% Example with an anatomical MRI on disk that needs no conversion
+cd(dccnpath('/home/common/matlab/fieldtrip/data/test/data2bids/decorate'))
+
+cfg = [];
+% cfg.method                      = 'decorate';
+% cfg.outputfile                  = 'oostenveld_r.nii';
+cfg.dataset                     = 'oostenveld_r.nii';
+cfg.mri.dicomfile               = 'ERIVDBER_030731_R.OOSTERVELD.MR.PAUGAA_ANATOMICAL-3D.2.142.2003.7.31.11.19.16.140000.53832621.IMA';
+cfg.mri.StationName             = 'Sonata';
+cfg.InstitutionName             = 'Radboud University';
+cfg.InstitutionalDepartmentName = 'Donders Institute for Brain, Cognition and Behaviour';
+
+cfg.mri.writesidecar            = 'merge';
+data2bids(cfg)
+
+
+%% Example with realigned and resliced anatomical MRI data in memory
+cd(dccnpath('/home/common/matlab/fieldtrip/data/test/data2bids/convert'))
+
+mri = ft_read_mri('dicom/ERIVDBER_030731_R.OOSTERVELD.MR.PAUGAA_ANATOMICAL-3D.2.56.2003.7.31.11.19.16.468000.53834351.IMA');
+
+cfg = [];
+cfg.method                      = 'convert';
+cfg.outputfile                  = 'sub-RO_T1w.nii';
+cfg.InstitutionName             = 'Radboud University';
+cfg.InstitutionalDepartmentName = 'Donders Institute for Brain, Cognition and Behaviour';
+data2bids(cfg, mri)
+
 %%
 cd(dccnpath('/home/common/matlab/fieldtrip/data/test/data2bids/mous'));
 

--- a/test/test_data2bids.m
+++ b/test/test_data2bids.m
@@ -5,6 +5,24 @@ function test_data2bids
 
 % DEPENDENCY data2bids
 
+%% Example with only behavioural data
+cd(dccnpath('/home/common/matlab/fieldtrip/data/test/data2bids/behavioral'))
+
+cfg = [];
+cfg.method                      = 'convert';
+cfg.dataset                     = [];
+cfg.presentationfile            = './sourcedata/A2002-2-MEG-MOUS-Aud.log';
+cfg.events.writesidecar         = 'replace';
+cfg.bidsroot                    = './bids';
+cfg.sub                         = 'A2002';
+cfg.ses                         = 'MEG';
+cfg.datatype                    = 'events';
+cfg.TaskName                    = 'language';
+cfg.InstitutionName             = 'Radboud University';
+cfg.InstitutionalDepartmentName = 'Donders Institute for Brain, Cognition and Behaviour';
+data2bids(cfg)
+
+
 %% Example with a CTF dataset on disk that needs no conversion
 cd(dccnpath('/home/common/matlab/fieldtrip/data/test/data2bids/decorate'))
 
@@ -138,8 +156,6 @@ cfg.datatype = 'T1w';
 cfg.mri.StationName = 'bay3';
 cfg.mri.MagneticFieldStrength = 3;
 data2bids(cfg, mri);
-
-
 
 %%
 cd(dccnpath('/home/common/matlab/fieldtrip/data/test/data2bids/mous'));

--- a/utilities/ft_fetch_header.m
+++ b/utilities/ft_fetch_header.m
@@ -63,6 +63,10 @@ if isfield(data, 'hdr')
   end
 end
 
+% try to determine them on the basis of heuristics, when already present they will stay the same
+hdr.chantype = ft_chantype(hdr);
+hdr.chanunit = ft_chanunit(hdr);
+
 % determine hdr.nSamples, hdr.nSamplesPre, hdr.nTrials
 % always pretend that it is continuous data
 hdr.nSamples    = max(trl(:,2));


### PR DESCRIPTION
In the previous coding sprint, I mainly focused on EEG. Now I am specifically looking at all other data types.

Improvements in this PR include writing of electrode positions for eeg/ieeg and pure behavioral data (without biological data) in the `beh` directory  