### PR TITLE
bugfix: fixed 'zscore' baseline correction in ft_freqbaseline

### DIFF
--- a/ft_freqbaseline.m
+++ b/ft_freqbaseline.m
@@ -9,7 +9,7 @@ function [freq] = ft_freqbaseline(cfg, freq)
 %   cfg.baseline     = [begin end] (default = 'no'), alternatively an
 %                      Nfreq x 2 matrix can be specified, that provides
 %                      frequency specific baseline windows.
-%   cfg.baselinetype = 'absolute', 'relative', 'relchange', 'normchange', 'db' or 'zscore' (default = 'absolute')
+%   cfg.baselinetype = 'absolute', 'relative', 'relchange', 'normchange', 'db', 'vssum' or 'zscore' (default = 'absolute')
 %   cfg.parameter    = field for which to apply baseline normalization, or
 %                      cell-array of strings to specify multiple fields to normalize
 %                      (default = 'powspctrm')
@@ -74,7 +74,7 @@ cfg.parameter    =  ft_getopt(cfg, 'parameter', 'powspctrm');
 
 % check validity of input options
 cfg =               ft_checkopt(cfg, 'baseline', {'char', 'doublevector', 'doublematrix'});
-cfg =               ft_checkopt(cfg, 'baselinetype', 'char', {'absolute', 'relative', 'relchange', 'normchange', 'db', 'vssum'});
+cfg =               ft_checkopt(cfg, 'baselinetype', 'char', {'absolute', 'relative', 'relchange', 'normchange', 'db', 'vssum','zscore'});
 cfg =               ft_checkopt(cfg, 'parameter', {'char', 'charcell'});
 
 % make sure cfg.parameter is a cell-array of strings
@@ -206,6 +206,7 @@ elseif (strcmp(baselinetype, 'normchange')) || (strcmp(baselinetype, 'vssum'))
 elseif (strcmp(baselinetype, 'db'))
   data = 10*log10(data ./ meanVals);
 elseif (strcmp(baselinetype,'zscore'))
+    stdVals = repmat(std(data(:,:,baselineTimes),[], 3,'omitnan'), [1 1 size(data, 3)]);
     data=(data-meanVals)./stdVals;
 else
   ft_error('unsupported method for baseline normalization: %s', baselinetype);

--- a/ft_freqbaseline.m
+++ b/ft_freqbaseline.m
@@ -206,7 +206,7 @@ elseif (strcmp(baselinetype, 'normchange')) || (strcmp(baselinetype, 'vssum'))
 elseif (strcmp(baselinetype, 'db'))
   data = 10*log10(data ./ meanVals);
 elseif (strcmp(baselinetype,'zscore'))
-    stdVals = repmat(std(data(:,:,baselineTimes),[], 3,'omitnan'), [1 1 size(data, 3)]);
+    stdVals = repmat(nanstd(data(:,:,baselineTimes),1, 3), [1 1 size(data, 3)]);
     data=(data-meanVals)./stdVals;
 else
   ft_error('unsupported method for baseline normalization: %s', baselinetype);


### PR DESCRIPTION
Fixes:
- 'zscore' was listed as valid baselinetype, but was not listed as valid option in the line of code that checked the validity of the input. => fixed
- The following code was used to perform the zscore-correction: "data=(data-meanVals)./stdVals;" but "stdVals" was not defined. => fixed
- 'vssum' is implemented as baselinetype but is not listed as valid type in the description => fixed