### PR TITLE
 enh: added support for postprocessing with the mars toolbox

### DIFF
--- a/ft_volumenormalise.m
+++ b/ft_volumenormalise.m
@@ -245,7 +245,7 @@ if ~isfield(cfg, 'spmparams')
     %VF         = spm_vol([cfg.intermediatename '_anatomy' ext]);
     flags.nits = 0; % put number of non-linear iterations to zero
     params     = spm_normalise(VG, VF(1), [], [], [], flags);
-  elseif strcmp(cfg.spmversion, 'spm12') && strcmp(cfg.spmmethod, 'new')
+  elseif strcmp(cfg.spmversion, 'spm12') && (strcmp(cfg.spmmethod, 'new') || strcmp(cfg.spmmethod, 'mars'))
     if ~isfield(cfg, 'tpm') || isempty(cfg.tpm)
       cfg.tpm = fullfile(spm('dir'),'tpm','TPM.nii');
     end
@@ -272,8 +272,18 @@ if ~isfield(cfg, 'spmparams')
     
     % this writes the 'deformation field'
     fprintf('writing the deformation field to file\n');
-    bb        = spm_get_bbox(opts.tpm.V(1));
-    spm_preproc_write8(params, zeros(6,4), [0 0], [0 1], 1, 1, bb, cfg.downsample);
+    if strcmp(cfg.spmmethod, 'new')
+      bb        = spm_get_bbox(opts.tpm.V(1));
+      spm_preproc_write8(params, zeros(6,4), [0 0], [0 1], 1, 1, bb, cfg.downsample);
+      %spm_preproc_write8(p, [ones(6,2) zeros(6,2)], [0 0], [0 1], 1, 1, nan(2,3), nan);
+    elseif strcmp(cfg.spmmethod, 'mars')
+      ft_hastoolbox('mars', 1);
+      if ~isfield(cfg, 'mars'), cfg.mars = []; end
+      beta        = ft_getopt(cfg.mars, 'beta', 0.1);
+      convergence = ft_getopt(cfg.mars, 'convergence', 0.1);
+      tcm{1}      = fullfile(fileparts(which('spm_mars_mrf')), 'rTCM_BW20_S1.mat');
+      params = spm_mars_mrf(params, [ones(6,2) zeros(6,2)], [0 0], [0 1], tcm, beta, convergence, 1);
+    end
     
     oldparams = false;
     newparams = true;

--- a/ft_volumenormalise.m
+++ b/ft_volumenormalise.m
@@ -281,7 +281,7 @@ if ~isfield(cfg, 'spmparams')
       beta        = ft_getopt(cfg.mars, 'beta', 0.1);
       convergence = ft_getopt(cfg.mars, 'convergence', 0.1);
       tcm{1}      = fullfile(fileparts(which('spm_mars_mrf')), 'rTCM_BW20_S1.mat');
-      params = spm_mars_mrf(params, [ones(6,2) zeros(6,2)], [0 0], [0 1], tcm, beta, convergence, 1);
+      params = spm_mars_mrf(params, zeros(6,4), [0 0], [0 1], tcm, beta, convergence, 1);
     end
     
     oldparams = false;

--- a/ft_volumenormalise.m
+++ b/ft_volumenormalise.m
@@ -275,7 +275,6 @@ if ~isfield(cfg, 'spmparams')
     if strcmp(cfg.spmmethod, 'new')
       bb        = spm_get_bbox(opts.tpm.V(1));
       spm_preproc_write8(params, zeros(6,4), [0 0], [0 1], 1, 1, bb, cfg.downsample);
-      %spm_preproc_write8(p, [ones(6,2) zeros(6,2)], [0 0], [0 1], 1, 1, nan(2,3), nan);
     elseif strcmp(cfg.spmmethod, 'mars')
       ft_hastoolbox('mars', 1);
       if ~isfield(cfg, 'mars'), cfg.mars = []; end


### PR DESCRIPTION
@schoffelen, I've added the above support to ft_volumenormalise, transferring code from ft_volumesegment. 

One point of difference between the two implementation sites is that in ft_volumenormalise the original code for spmmethod = 'new' is:
spm_preproc_write8(params, zeros(6,4), [0 0], [0 1], 1, 1, bb, cfg.downsample);
.. whereas in ft_volumesegment it is:
spm_preproc_write8(p, [ones(6,2) zeros(6,2)], [0 0], [0 1], 1, 1, nan(2,3), nan);

The vector of ones and zeros determine the 'tc' variable in SPM but there's too little documentation on this variable to easily grasp its consequences. Any thoughts on whether this is important?

