### PR TITLE
fix an error of sampleinfo update in ft_redefinetrial.m

### DIFF
--- a/ft_redefinetrial.m
+++ b/ft_redefinetrial.m
@@ -225,10 +225,9 @@ elseif ~isempty(cfg.begsample) || ~isempty(cfg.endsample)
   
   % also correct the sampleinfo
   if isfield(data, 'sampleinfo')
-    sampleinfo = data.sampleinfo;
-    data.sampleinfo = [];
+    sampleinfo = data.sampleinfo(:, 1);
     data.sampleinfo(:, 1) = sampleinfo(:, 1) + begsample - 1;
-    data.sampleinfo(:, 2) = sampleinfo(:, 1) + endsample - begsample;
+    data.sampleinfo(:, 2) = sampleinfo(:, 1) + endsample - 1;
   end
   
 elseif ~isempty(cfg.trl)


### PR DESCRIPTION
Hi there,

Here's a quick fix for an error in ft_redefinetrial.m that my RA Dylan Hungate caught, and which led to error messages in further use of the resulting data structure ("Warning: inconsistent sampleinfo", e.g. using ft_resampledata).

The function failed to correctly update the last sampleinfo, because of a mistake in line 231 (should use the update first sampleinfo, not the original one). This could be fixed by replacing "... = sampleinfo(:, 1) + ..." by "... = data.sampleinfo(:, 1) + ...", but we propose here a simpler code.

Best,
Ludovic and Dylan