### PR TITLE
ENH - flip the dipole moment and orientation with +1/-1 

### DIFF
--- a/ft_sourcedescriptives.m
+++ b/ft_sourcedescriptives.m
@@ -22,7 +22,10 @@ function [source] = ft_sourcedescriptives(cfg, source)
 %   cfg.resolutionmatrix = 'yes' or 'no' (default = 'no')
 %   cfg.feedback         = 'no', 'text' (default), 'textbar', 'gui'
 %
-% The following option only applies to LCMV single-trial timecourses.
+% The following option only applies to timecourses.
+%   cfg.flipori          = 'yes' or 'no' (default = 'no')
+%
+% The following option only applies to single-trial timecourses.
 %   cfg.fixedori         = 'within_trials' or 'over_trials' (default = 'over_trials')
 %
 % If repeated trials are present that have undergone some sort of
@@ -112,6 +115,7 @@ cfg.fwhmremovecenter = ft_getopt(cfg, 'fwhmremovecenter', 0);
 cfg.fwhmmethod       = ft_getopt(cfg, 'fwhmmethod',       'barnes');
 cfg.fwhmmaxdist      = ft_getopt(cfg, 'fwhmmaxdist',      []);
 cfg.fixedori         = ft_getopt(cfg, 'fixedori',         'over_trials');
+cfg.flipdori         = ft_getopt(cfg, 'fixedori',         'no');
 
 % only works for minimumnormestimate
 cfg.demean         = ft_getopt(cfg, 'demean',         'yes');
@@ -132,10 +136,9 @@ else
     source.trial = source.trial(cfg.trials);
     if isfield(source, 'cumtapcnt'), source.cumtapcnt = source.cumtapcnt(cfg.trials,:); end
   else
-    ft_error('subselecting trials in ft_sourcedescriptives is currently only possible with a ''trial'' field');   
+    ft_error('subselecting trials in ft_sourcedescriptives is currently only possible with a ''trial'' field');
   end
 end
-
 
 % get desired method from source structure
 source.method = ft_getopt(source,'method',[]);
@@ -188,24 +191,27 @@ if strcmp(cfg.resolutionmatrix, 'yes')
   end
 end
 
-if strcmp(cfg.fwhm, 'yes')
-  if ~isfield(source.avg, 'filter')
-    ft_error('The computation of the fwhm requires keepfilter=''yes'' in sourceanalysis.');
-  end
+if istrue(cfg.fwhm) && ~isfield(source.avg, 'filter')
+  ft_error('computation of the fwhm requires keepfilter=''yes'' in sourceanalysis.');
 end
 
-if strcmp(cfg.eta, 'yes') && strcmp(cfg.cohmethod, 'svdfft')
+if istrue(cfg.eta) && strcmp(cfg.cohmethod, 'svdfft')
   ft_error('eta cannot be computed in combination with the application of svdfft');
 end
 
-if strcmp(cfg.keeptrials, 'yes') && ~strcmp(cfg.supmethod, 'none')
+if istrue(cfg.keeptrials) && ~strcmp(cfg.supmethod, 'none')
   ft_error('you cannot keep trials when you want to partialize something');
+end
+
+if istrue(cfg.flipori) && ~istrue(cfg.projectmom)
+  ft_error('flipori requires projectmom=''yes''');
 end
 
 % set some flags for convenience
 isnoise    = isfield(source, 'avg') && isfield(source.avg, 'noisecsd');
 keeptrials = strcmp(cfg.keeptrials, 'yes');
 projectmom = strcmp(cfg.projectmom, 'yes');
+flipori    = strcmp(cfg.flipori, 'yes');
 
 % determine the subfunction used for computing power
 switch cfg.powmethod
@@ -224,51 +230,52 @@ end
 % represent the selection of sources in the brain as a row-vector with indices
 insideindx = find(source.inside(:)');
 
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 if ispccdata
   % the source reconstruction was computed using the pcc beamformer
-
+  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  
   Ndipole = size(source.pos,1);
-
+  
   if ischar(source.avg.csdlabel{1}), source.avg.csdlabel = {source.avg.csdlabel}; end
   if numel(source.avg.csdlabel)==1
     source.avg.csdlabel = repmat(source.avg.csdlabel, [Ndipole 1]);
   end
-
+  
   dipsel     = find(strcmp(source.avg.csdlabel{1}, 'scandip'));
   refchansel = find(strcmp(source.avg.csdlabel{1}, 'refchan'));
   refdipsel  = find(strcmp(source.avg.csdlabel{1}, 'refdip'));
   supchansel = find(strcmp(source.avg.csdlabel{1}, 'supchan'));
   supdipsel  = find(strcmp(source.avg.csdlabel{1}, 'supdip'));
-
+  
   % cannot handle reference channels and reference dipoles simultaneously
   if numel(refchansel)>0 && numel(refdipsel)>0
     ft_error('cannot simultaneously handle reference channels and reference dipole');
   end
-
+  
   % these are only used to count the number of reference/suppression dipoles and channels
   refsel = [refdipsel refchansel];
   supsel = [supdipsel supchansel];
-
-
+  
   % first do the projection of the moment, if requested
   if projectmom
     source.avg.ori = cell(1, Ndipole);
     ft_progress('init', cfg.feedback, 'projecting dipole moment');
     for i=insideindx
       ft_progress(i/length(insideindx), 'projecting dipole moment %d/%d\n', i, length(insideindx));
-
+      
       if numel(source.avg.csdlabel)>1
         dipsel     = find(strcmp(source.avg.csdlabel{i}, 'scandip'));
         refchansel = find(strcmp(source.avg.csdlabel{i}, 'refchan'));
         refdipsel  = find(strcmp(source.avg.csdlabel{i}, 'refdip'));
         supchansel = find(strcmp(source.avg.csdlabel{i}, 'supchan'));
         supdipsel  = find(strcmp(source.avg.csdlabel{i}, 'supdip'));
-
+        
         % these are only used to count the number of reference/suppression dipoles and channels
         refsel = [refdipsel refchansel];
         supsel = [supdipsel supchansel];
       end
-
+      
       mom     = source.avg.mom{i}(dipsel,     :);
       ref     = source.avg.mom{i}(refdipsel,  :);
       sup     = source.avg.mom{i}(supdipsel,  :);
@@ -281,10 +288,10 @@ if ispccdata
       if length(refdipsel)>1, [ref, rref] = svdfft(ref, 1, source.cumtapcnt); else rref = []; end
       % compute the projection of the supression dipole along the direction of the dominant amplitude
       if length(supdipsel)>1, [sup, rsup] = svdfft(sup, 1, source.cumtapcnt); else rsup = []; end
-
+      
       % compute voxel-level fourier-matrix
       source.avg.mom{i} = cat(1, mom, ref, sup, refchan, supchan);
-
+      
       % create rotation-matrix
       rotmat = zeros(0, length(source.avg.csdlabel{i}));
       if ~isempty(rmom)
@@ -304,7 +311,7 @@ if ispccdata
         rotmat(end+1,:) = 0;
         rotmat(end,numel(dipsel)+numel(refdipsel)+numel(supdipsel)+numel(supchansel)+j) = 1;
       end
-
+      
       % compute voxel-level csd-matrix
       if isfield(source.avg, 'csd'), source.avg.csd{i}           = rotmat * source.avg.csd{i} * rotmat'; end
       % compute voxel-level noisecsd-matrix
@@ -321,11 +328,11 @@ if ispccdata
         % concatenate all the labels
         source.avg.csdlabel{i} = cat(2, scandiplabel, refdiplabel, supdiplabel, refchanlabel, supchanlabel);
       end
-
+      
       % compute rotated leadfield
       % FIXME in the presence of a refdip and/or supdip, this does not work; leadfield is Nx3
       if isfield(source,  'leadfield')
-        %FIXME this is a proposed dirty fix
+        % FIXME this is a proposed dirty fix
         n1 = size(source.leadfield{i},2);
         %n2 = size(rotmat,2) - n1;
         n2 = size(rotmat,2) - n1 +1; %added 1 JM
@@ -333,7 +340,7 @@ if ispccdata
       end
     end % for i=insideindx
     ft_progress('close');
-
+    
     % update the indices
     dipsel     = find(strcmp(source.avg.csdlabel, 'scandip'));
     refchansel = find(strcmp(source.avg.csdlabel, 'refchan'));
@@ -343,17 +350,17 @@ if ispccdata
     refsel     = [refdipsel refchansel];
     supsel     = [supdipsel supchansel];
   end % if projectmom
-
+  
   if keeptrials
     cumtapcnt = source.cumtapcnt(:);
     sumtapcnt = cumsum([0;cumtapcnt]);
     Ntrial = length(cumtapcnt);
-
+    
     ft_progress('init', cfg.feedback, 'computing singletrial voxel-level cross-spectral densities');
     for triallop = 1:Ntrial
       source.trial(triallop).csd = cell(Ndipole, 1);  % allocate memory for this trial
       source.trial(triallop).mom = cell(Ndipole, 1);  % allocate memory for this trial
-
+      
       ft_progress(triallop/Ntrial, 'computing singletrial voxel-level cross-spectral densities %d%d\n', triallop, Ntrial);
       for i=insideindx
         dat = source.avg.mom{i};
@@ -372,38 +379,38 @@ if ispccdata
     fprintf('using average voxel-level cross-spectral densities\n');
     csdlabel = source.avg.csdlabel;
   end % if keeptrials
-
+  
   % process the csdlabel for each of the dipoles
   hasrefdip  = true;
   hasrefchan = true;
   hassupdip  = true;
   hassupchan = true;
-
+  
   dipselcell     = cell(Ndipole,1);
   refdipselcell  = cell(Ndipole,1);
   refchanselcell = cell(Ndipole,1);
   supdipselcell  = cell(Ndipole,1);
   supchanselcell = cell(Ndipole,1);
-
+  
   for i = insideindx
     dipsel     = find(strcmp(csdlabel{i}, 'scandip'));
     refchansel = find(strcmp(csdlabel{i}, 'refchan'));
     refdipsel  = find(strcmp(csdlabel{i}, 'refdip'));
     supchansel = find(strcmp(csdlabel{i}, 'supchan'));
     supdipsel  = find(strcmp(csdlabel{i}, 'supdip'));
-
+    
     hasrefdip  = ~isempty(refdipsel)  && hasrefdip; %NOTE: it has to be true for all dipoles!
     hasrefchan = ~isempty(refchansel) && hasrefchan;
     hassupdip  = ~isempty(supdipsel)  && hassupdip;
     hassupchan = ~isempty(supchansel) && hassupchan;
-
+    
     dipselcell{i}     = dipsel;
     refdipselcell{i}  = refdipsel;
     refchanselcell{i} = refchansel;
     supdipselcell{i}  = supdipsel;
     supchanselcell{i} = supchansel;
   end
-
+  
   if keeptrials
     % do the processing of the CSD matrices for each trial
     if ~strcmp(cfg.supmethod, 'none')
@@ -414,7 +421,7 @@ if ispccdata
     %if hasrefchan, refchanselcell = mat2cell(repmat(refchansel(:)', [Ndipole 1]), ones(Ndipole,1), length(refchansel)); end
     %if hassupdip,  supdipselcell  = mat2cell(repmat(supdipsel(:)',  [Ndipole 1]), ones(Ndipole,1), length(supdipsel));  end
     %if hassupchan, supchanselcell = mat2cell(repmat(supchansel(:)', [Ndipole 1]), ones(Ndipole,1), length(supchansel)); end
-
+    
     ft_progress('init', cfg.feedback, 'computing singletrial voxel-level power');
     for triallop = 1:Ntrial
       %initialize the variables
@@ -423,7 +430,7 @@ if ispccdata
       if hasrefchan, source.trial(triallop).refchanpow    = zeros(Ndipole, 1); end
       if hassupdip,  source.trial(triallop).supdippow     = zeros(Ndipole, 1); end
       if hassupchan, source.trial(triallop).supchanpow    = zeros(Ndipole, 1); end
-
+      
       ft_progress(triallop/Ntrial, 'computing singletrial voxel-level power %d%d\n', triallop, Ntrial);
       source.trial(triallop).pow(source.inside) = cellfun(powmethodfun, source.trial(triallop).csd(source.inside), dipselcell(source.inside));
       if hasrefdip,  source.trial(triallop).refdippow(source.inside)  = cellfun(powmethodfun,source.trial(triallop).csd(source.inside), refdipselcell(source.inside));  end
@@ -441,11 +448,11 @@ if ispccdata
       end % if isnoise
     end % for triallop
     ft_progress('close');
-
+    
     if strcmp(cfg.keepcsd, 'no')
       source.trial = rmfield(source.trial, 'csd');
     end
-
+    
   else
     % do the processing of the average CSD matrix
     for i=insideindx
@@ -466,13 +473,13 @@ if ispccdata
       scnindx = setdiff(1:size(tmpcsd,1), supindx);
       tmpcsd  = tmpcsd(scnindx, scnindx) - tmpcsd(scnindx, supindx)*pinv(tmpcsd(supindx, supindx))*tmpcsd(supindx, scnindx);
       source.avg.csd{i}   = tmpcsd;
-    end % for i=insideindx
-    %     source.avg.csdlabel = source.avg.csdlabel(scnindx);
-
+    end % for insideindx
+    % source.avg.csdlabel = source.avg.csdlabel(scnindx);
+    
     if isnoise && ~strcmp(cfg.supmethod, 'none')
       source.avg = rmfield(source.avg, 'noisecsd');
     end
-
+    
     % initialize the variables
     source.avg.pow           = nan(Ndipole, 1);
     if hasrefdip,  source.avg.refdippow     = nan(Ndipole, 1); end
@@ -498,18 +505,18 @@ if ispccdata
     if strcmp(cfg.fa, 'yes')
       source.avg.fa = nan(Ndipole, 1);
     end
-
+    
     for i=insideindx
       dipsel = dipselcell{i};
-			refsel = [refchanselcell{i} refdipselcell{i}];
-
+      refsel = [refchanselcell{i} refdipselcell{i}];
+      
       % compute the power of each source component
       if strcmp(cfg.projectmom, 'yes') && cfg.numcomp>1
         source.avg.pow(i) = powmethodfun(source.avg.csd{i}(dipselcell{i},dipselcell{i}), 1);
       else
         source.avg.pow(i) = powmethodfun(source.avg.csd{i}(dipselcell{i},dipselcell{i}));
       end
-
+      
       if hasrefdip,  source.avg.refdippow(i)  = powmethodfun(source.avg.csd{i}(refdipsel,refdipsel));   end
       if hassupdip,  source.avg.supdippow(i)  = powmethodfun(source.avg.csd{i}(supdipsel,supdipsel));   end
       if hasrefchan, source.avg.refchanpow(i) = powmethodfun(source.avg.csd{i}(refchansel,refchansel)); end
@@ -526,7 +533,7 @@ if ispccdata
         if hasrefchan, source.avg.refchannoise(i) = powmethodfun(source.avg.noisecsd{i}(refchansel,refchansel)); end
         if hassupchan, source.avg.supchannoise(i) = powmethodfun(source.avg.noisecsd{i}(supchansel,supchansel)); end
       end % if isnoise
-
+      
       if ~isempty(refsel)
         % compute coherence
         csd = source.avg.csd{i};
@@ -551,7 +558,7 @@ if ispccdata
             ft_error('unsupported cohmethod');
         end % cohmethod
       end
-
+      
       % compute eta
       if strcmp(cfg.eta, 'yes')
         [source.avg.eta(i), source.avg.ori{i}] = csd2eta(source.avg.csd{i}(dipselcell{i},dipselcell{i}));
@@ -560,24 +567,27 @@ if ispccdata
           [source.avg.etacsd(i), source.avg.ucsd{i}] = csd2eta(source.avg.csd{i}(dipsel,refsel));
         end
       end
-
+      
       %compute fa
       if strcmp(cfg.fa, 'yes')
         source.avg.fa(i) = csd2fa(source.avg.csd{i}(dipsel,dipsel));
       end
     end % for diplop
-
+    
     if strcmp(cfg.keepcsd, 'no')
       source.avg = rmfield(source.avg, 'csd');
     end
     if strcmp(cfg.keepnoisecsd, 'no') && isnoise
       source.avg = rmfield(source.avg, 'noisecsd');
     end
-
-  end
-
+    
+  end % if keeptrials
+  
+  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 elseif ismneavg
-  %the source reconstruction was computed using the minimumnormestimate and contains an average timecourse
+  % the source reconstruction was computed using the minimumnormestimate and contains an average timecourse
+  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  
   if demean
     begsmp = nearest(source.time, cfg.baselinewindow(1));
     endsmp = nearest(source.time, cfg.baselinewindow(2));
@@ -590,7 +600,7 @@ elseif ismneavg
     end
     ft_progress('close');
   end
-
+  
   if projectmom
     if isfield(source, 'tri')
       nrm = normals(source.pos, source.tri, 'vertex');
@@ -617,8 +627,21 @@ elseif ismneavg
       end
     end
     ft_progress('close');
-  end
-
+  end % if projectmom
+  
+  if flipori
+    tmpmom = cat(1, source.avg.mom{source.inside});
+    [u, ~, ~] = svd(tmpmom, 'econ');
+    flip( source.inside) = sign(u(:,1));
+    flip(~source.inside) = nan;
+    for i=1:numel(source.inside)
+      if source.inside(i)
+        source.avg.mom{i} = flip(i) * source.avg.mom{i};
+        source.avg.ori{i} = flip(i) * source.avg.ori{i};
+      end
+    end
+  end % if flipori
+  
   if zscore
     begsmp = nearest(source.time, cfg.baselinewindow(1));
     endsmp = nearest(source.time, cfg.baselinewindow(2));
@@ -635,7 +658,6 @@ elseif ismneavg
       %source.avg.absmom(source.inside(diplop),:) = sum((mom-mmom)./smom,1);
     end
     ft_progress('close');
-
   else
     % just square for power
     ft_progress('init', cfg.feedback, 'computing power');
@@ -648,10 +670,8 @@ elseif ismneavg
       %source.avg.absmom(insideindx(diplop),:) = sum(mom,1);
     end
     ft_progress('close');
-
-  end
-
-
+  end % if zscore
+  
   if strcmp(cfg.kurtosis, 'yes')
     fprintf('computing kurtosis based on dipole timecourse\n');
     source.avg.k2 = nan(size(source.pos,1),1);
@@ -663,11 +683,13 @@ elseif ismneavg
       source.avg.k2(insideindx(diplop)) = kurtosis(mom);
     end
   end
-
-
+  
+  
+  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 elseif islcmvavg
   % the source reconstruction was computed using the lcmv beamformer and contains an average timecourse
-
+  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  
   if projectmom
     ft_progress('init', cfg.feedback, 'projecting dipole moment');
     for diplop=1:length(insideindx)
@@ -679,7 +701,20 @@ elseif islcmvavg
     end
     ft_progress('close');
   end
-
+  
+  if flipori
+    tmpmom = cat(1, source.avg.mom{source.inside});
+    [u, ~, ~] = svd(tmpmom, 'econ');
+    flip( source.inside) = sign(u(:,1));
+    flip(~source.inside) = nan;
+    for i=1:numel(source.inside)
+      if source.inside(i)
+        source.avg.mom{i} = flip(i) * source.avg.mom{i};
+        source.avg.ori{i} = flip(i) * source.avg.ori{i};
+      end
+    end
+  end
+  
   if ~strcmp(cfg.powmethod, 'none')
     fprintf('recomputing power based on dipole timecourse\n')
     source.avg.pow = nan(size(source.pos,1),1);
@@ -689,7 +724,7 @@ elseif islcmvavg
       source.avg.pow(insideindx(diplop)) = powmethodfun(cov);
     end
   end
-
+  
   if strcmp(cfg.kurtosis, 'yes')
     fprintf('computing kurtosis based on dipole timecourse\n');
     source.avg.k2 = nan(size(source.pos,1),1);
@@ -701,11 +736,14 @@ elseif islcmvavg
       source.avg.k2(insideindx(diplop)) = kurtosis(mom);
     end
   end
-
+  
+  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 elseif islcmvtrl
   % the source reconstruction was computed using the lcmv beamformer and contains a single-trial timecourse
+  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  
   ntrial = length(source.trial);
-
+  
   if projectmom && strcmp(cfg.fixedori, 'within_trials')
     % the dipole orientation is re-determined for each trial
     ft_progress('init', cfg.feedback, 'projecting dipole moment');
@@ -748,7 +786,7 @@ elseif islcmvtrl
     end
     ft_progress('close');
   end
-
+  
   if ~strcmp(cfg.powmethod, 'none')
     fprintf('recomputing power based on dipole timecourse\n')
     for trllop=1:ntrial
@@ -759,7 +797,7 @@ elseif islcmvtrl
       end
     end
   end
-
+  
   if strcmp(cfg.kurtosis, 'yes')
     fprintf('computing kurtosis based on dipole timecourse\n');
     for trllop=1:ntrial
@@ -773,8 +811,10 @@ elseif islcmvtrl
       end
     end
   end
-
-end % dealing with pcc or lcmv input
+  
+  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+end % dealing with pcc, lcmv, dics or mne input
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 if isfield(source, 'avg') && isfield(source.avg, 'pow') && isfield(source.avg, 'noise') && ~ismneavg
   % compute the neural activity index for the average
@@ -863,10 +903,10 @@ end
 if strcmp(source.method, 'jackknife') || strcmp(source.method, 'bootstrap') || strcmp(source.method, 'pseudovalue') || strcmp(source.method, 'singletrial') || strcmp(source.method, 'rawtrial')
   % compute descriptive statistics (mean, var, sem) for multiple trial data
   % compute these for as many source parameters as possible
-
+  
   % for convenience copy the trials out of the source structure
   dip = source.trial;
-
+  
   % determine the (original) number of trials in the data
   if strcmp(source.method, 'bootstrap') %VERANDERD ER ZAT GEEN .RESAMPLE IN SOURCE
     Ntrials = size(source.trial,2); % WAS size(source.resample, 2);
@@ -874,7 +914,7 @@ if strcmp(source.method, 'jackknife') || strcmp(source.method, 'bootstrap') || s
     Ntrials = length(source.trial);
   end
   fprintf('original data contained %d trials\n', Ntrials);
-
+  
   % allocate memory for all elements in the dipole structure
   sumdip = [];
   if isfield(dip(1), 'var'),   sumdip.var    = zeros(size(dip(1).var  )); sumdip.var(~source.inside) = nan; end
@@ -906,7 +946,7 @@ if strcmp(source.method, 'jackknife') || strcmp(source.method, 'bootstrap') || s
       sqrdip.csd{i} = zeros(size(dip(1).csd{i}));
     end
   end
-
+  
   for trial=1:length(dip)
     % compute the sum of all values
     if isfield(dip(trial), 'var'),    sumdip.var   = sumdip.var    + dip(trial).var;    end
@@ -937,7 +977,7 @@ if strcmp(source.method, 'jackknife') || strcmp(source.method, 'bootstrap') || s
       end
     end
   end
-
+  
   % compute the mean over all repetitions
   if isfield(sumdip, 'var'),    dipmean.var    = sumdip.var   / length(dip); end
   if isfield(sumdip, 'pow'),    dipmean.pow    = sumdip.pow   / length(dip); end
@@ -947,7 +987,7 @@ if strcmp(source.method, 'jackknife') || strcmp(source.method, 'bootstrap') || s
   if isfield(sumdip, 'nai'),    dipmean.nai    = sumdip.nai   / length(dip); end
   % for the cell-array with mom, this is done further below
   % for the cell-array with csd, this is done further below
-
+  
   % the estimates for variance and SEM are biased if we are working with the jackknife/bootstrap
   % determine the proper variance scaling that corrects for this bias
   % note that Ntrials is not always the same as the length of dip, especially in case of the bootstrap
@@ -968,7 +1008,7 @@ if strcmp(source.method, 'jackknife') || strcmp(source.method, 'bootstrap') || s
     ft_warning('don''t know how to compute bias for pseudovalue resampling');
     bias = 1;
   end
-
+  
   % compute the variance over all repetitions
   if isfield(sumdip, 'var'),    dipvar.var    = bias*(sqrdip.var    - (sumdip.var   .^2)/length(dip))/(length(dip)-1); end
   if isfield(sumdip, 'pow'),    dipvar.pow    = bias*(sqrdip.pow    - (sumdip.pow   .^2)/length(dip))/(length(dip)-1); end
@@ -976,7 +1016,7 @@ if strcmp(source.method, 'jackknife') || strcmp(source.method, 'bootstrap') || s
   if isfield(sumdip, 'rv' ),    dipvar.rv     = bias*(sqrdip.rv     - (sumdip.rv    .^2)/length(dip))/(length(dip)-1); end
   if isfield(sumdip, 'noise' ), dipvar.noise  = bias*(sqrdip.noise  - (sumdip.noise .^2)/length(dip))/(length(dip)-1); end
   if isfield(sumdip, 'nai' ),   dipvar.nai    = bias*(sqrdip.nai    - (sumdip.nai   .^2)/length(dip))/(length(dip)-1); end
-
+  
   % compute the SEM over all repetitions
   if isfield(sumdip, 'var'),    dipsem.var    = (dipvar.var   /Ntrials).^0.5; end
   if isfield(sumdip, 'pow'),    dipsem.pow    = (dipvar.pow   /Ntrials).^0.5; end
@@ -984,7 +1024,7 @@ if strcmp(source.method, 'jackknife') || strcmp(source.method, 'bootstrap') || s
   if isfield(sumdip, 'rv' ),    dipsem.rv     = (dipvar.rv    /Ntrials).^0.5; end
   if isfield(sumdip, 'noise' ), dipsem.noise  = (dipvar.noise /Ntrials).^0.5; end
   if isfield(sumdip, 'nai' ),   dipsem.nai    = (dipvar.nai   /Ntrials).^0.5; end
-
+  
   % compute the mean and SEM over all repetitions for the cell-array with mom
   if isfield(dip(trial), 'mom')
     for i=1:length(dip(1).mom)
@@ -993,7 +1033,7 @@ if strcmp(source.method, 'jackknife') || strcmp(source.method, 'bootstrap') || s
       dipsem.mom{i} = (dipvar.mom{i}/Ntrials).^0.5;
     end
   end
-
+  
   % compute the mean and SEM over all repetitions for the cell-array with csd
   if isfield(dip(trial), 'csd')
     for i=1:length(dip(1).csd)
@@ -1002,7 +1042,7 @@ if strcmp(source.method, 'jackknife') || strcmp(source.method, 'bootstrap') || s
       dipsem.csd{i} = (dipvar.csd{i}/Ntrials).^0.5;
     end
   end
-
+  
   if strcmp(source.method, 'pseudovalue')
     % keep the trials, since they have been converted to pseudovalues
     % and hence the trials contain the interesting data


### PR DESCRIPTION
to make it more consistent with the overall distribution.

This cane up in discussions with @arnodelorme for https://sccn.ucsd.edu/wiki/A08:_DIPFIT#Advanced_source_reconstruction_using_DIPFIT.2FFieldtrip

I know that @schoffelen has been doing this in other contexts, not only for 3D but also cortical sheets. Jan-Mathijs, could you check whether this makes sense, or whether something similar is already in the code somewhere or in the documentation somewhere? 