### PR TITLE
load discontinuous Neuralynx data as epochs

### DIFF
--- a/ft_preprocessing.m
+++ b/ft_preprocessing.m
@@ -415,11 +415,15 @@ else
       trl(1,2) = hdr.nSamples*hdr.nTrials;
       trl(1,3) = -hdr.nSamplesPre;
     else
-      trl = zeros(hdr.nTrials, 3);
-      for i=1:hdr.nTrials
-        trl(i,1) = (i-1)*hdr.nSamples + 1;
-        trl(i,2) = (i  )*hdr.nSamples    ;
-        trl(i,3) = -hdr.nSamplesPre;
+      if isfield(hdr, 'trl')
+        trl = hdr.trl;
+      else
+        trl = zeros(hdr.nTrials, 3);
+	    for i=1:hdr.nTrials
+          trl(i,1) = (i-1)*hdr.nSamples+1;
+          trl(i,2) = (i)*hdr.nSamples;
+          trl(i,3) = -hdr.nSamplesPre;
+	    end
       end
     end
     cfg.trl = trl;


### PR DESCRIPTION
Hi there,

As discussed on issue #1128, here's a way to automatically load discontinuous Neuralynx data as epochs (and to avoid getting repeated, artifactual samples in our data due to the pause/stop built-in feature).

Best,
Ludovic