### PR TITLE
data written to edf was incorrect 

### DIFF
--- a/fileio/private/read_edf.m
+++ b/fileio/private/read_edf.m
@@ -180,7 +180,9 @@ if needhdr
   fseek(EDF.FILE.FID,32*EDF.NS,0);
 
   EDF.Cal = (EDF.PhysMax-EDF.PhysMin)./(EDF.DigMax-EDF.DigMin);
+  EDF.Cal(isnan(EDF.Cal)) = 0;
   EDF.Off = EDF.PhysMin - EDF.Cal .* EDF.DigMin;
+  
   %tmp = find(EDF.Cal < 0);
   %EDF.Cal(tmp) = ones(size(tmp));
   %EDF.Off(tmp) = zeros(size(tmp));

--- a/fileio/private/write_edf.m
+++ b/fileio/private/write_edf.m
@@ -136,8 +136,8 @@ fwrite(fid, 32*ones(32,nChans), 'uint8'); % reserved (32 spaces / channel)
 % now write data
 begsample = 1;
 endsample = blocksize;
-while endsample<nSamples
-  fwrite(fid, data(:,begsample:endsample), 'int16');
+while endsample<=nSamples
+  fwrite(fid, data(:,begsample:endsample)', 'int16');
   begsample = begsample+blocksize;
   endsample = endsample+blocksize;
 end

--- a/realtime/example/ft_realtime_signalviewer.m
+++ b/realtime/example/ft_realtime_signalviewer.m
@@ -208,7 +208,7 @@ while true
   % shift each of the channels with a given offset
   nchan = size(dat,1);
   for i=1:nchan
-    dat(i,:) = dat(i,:) + (nchan-i-1)*cfg.offset(i);
+    dat(i,:) = dat(i,:) + cfg.offset(i);
   end
   
   % plot the data

--- a/test/test_pull1156.m
+++ b/test/test_pull1156.m
@@ -1,0 +1,41 @@
+function test_pull1156
+
+% WALLTIME 00:20:00
+% MEM 2gb
+% DEPENDENCY write_edf read_edf
+
+%%
+
+filename = {
+  '/home/common/matlab/fieldtrip/data/test/original/eeg/edf/0601_s.edf'
+  '/home/common/matlab/fieldtrip/data/test/original/eeg/edf/shhs1-200001.edf'
+  '/home/common/matlab/fieldtrip/data/test/original/eeg/edf/RecordSession_2017.09.07_20.41.53.edf'
+  '/home/common/matlab/fieldtrip/data/test/original/eeg/edf/RecordSession_2017.09.07_20.41.53.edf'
+  '/home/common/matlab/fieldtrip/data/test/original/eeg/nicolet/Patient59_EEG-OPPTAKER-1_t1-EDF.edf'
+  '/home/common/matlab/fieldtrip/data/test/original/eeg/nicolet/Patient59_EEG-OPPTAKER-1_t1-EDFPLUS.edf'
+  };
+
+headerfields = {
+  'Fs'
+  'nChans'
+  'label'
+  'nSamples'
+  'nSamplesPre'
+  'nTrials'
+  };
+
+%%
+
+for i=1:numel(filename)
+  hdr = ft_read_header(dccnpath(filename{i}));
+  dat = ft_read_data(dccnpath(filename{i}));
+  
+  tempfile = [tempname '.edf'];
+  ft_write_data(tempfile, dat, 'header', hdr);
+  
+  hdr1 = ft_read_header(tempfile);
+  dat1 = ft_read_data(tempfile);
+  
+  assert(isequal(keepfields(hdr, headerfields), keepfields(hdr1, headerfields)));
+  assert(corr(dat(:), dat1(:))>0.99); % isalmostequal does not work well with all the different scales in the test files
+end

--- a/test/test_pull1156.m
+++ b/test/test_pull1156.m
@@ -10,7 +10,6 @@ filename = {
   '/home/common/matlab/fieldtrip/data/test/original/eeg/edf/0601_s.edf'
   '/home/common/matlab/fieldtrip/data/test/original/eeg/edf/shhs1-200001.edf'
   '/home/common/matlab/fieldtrip/data/test/original/eeg/edf/RecordSession_2017.09.07_20.41.53.edf'
-  '/home/common/matlab/fieldtrip/data/test/original/eeg/edf/RecordSession_2017.09.07_20.41.53.edf'
   '/home/common/matlab/fieldtrip/data/test/original/eeg/nicolet/Patient59_EEG-OPPTAKER-1_t1-EDF.edf'
   '/home/common/matlab/fieldtrip/data/test/original/eeg/nicolet/Patient59_EEG-OPPTAKER-1_t1-EDFPLUS.edf'
   };

--- a/trialfun/ft_trialfun_brainvision_segmented.m
+++ b/trialfun/ft_trialfun_brainvision_segmented.m
@@ -5,7 +5,7 @@ function [trl, event] = ft_trialfun_brainvision_segmented(cfg)
 %
 % Use as 
 %   cfg          = [];
-%   cfg.dataset  = '<datasetname>.vhdr';
+%   cfg.dataset  = 'filename.vhdr';
 %   cfg.trialfun = 'ft_trialfun_brainvision_segmented';
 %   cfg  = ft_definetrial(cfg);
 %   data = ft_preprocessing(cfg);


### PR DESCRIPTION
When reading from EDF with a blocksize of 1 sample, and writing it back to EDF with a blocksize of 1 second, I realized that the data is transposed. This would not have mattered with the previous implementation (one sample per block), but now resulted in corrupt data.