### PR TITLE
Updated IRASA documentation and added test/example script

### DIFF
--- a/ft_freqanalysis.m
+++ b/ft_freqanalysis.m
@@ -286,13 +286,15 @@ switch cfg.method
     end
     
   case 'irasa'
-    ft_warning('the irasa method is under construction')
     cfg.taper       = ft_getopt(cfg, 'taper', 'hanning');
     if ~isequal(cfg.taper, 'hanning')
-      ft_error('only hanning tapers are supported');
+      ft_error('the irasa method supports hanning tapers only');
     end
     if isfield(cfg, 'output') && ~isequal(cfg.output, 'pow')
       ft_error('the irasa method outputs power only');
+    end
+    if ~isequal(cfg.pad, 'nextpow2')
+      ft_warning('consider using cfg.pad=''nextpow2'' for the irasa method');
     end
     % check for foi above Nyquist
     if isfield(cfg, 'foi')

--- a/specest/ft_specest_irasa.m
+++ b/specest/ft_specest_irasa.m
@@ -1,7 +1,7 @@
 function [spectrum,ntaper,freqoi] = ft_specest_irasa(dat, time, varargin)
 
 % FT_SPECEST_IRASA estimates the powerspectral arrythmic component of the 
-% time-domain using Irregular-Resampling Auto-Spectral Analysis. 
+% time-domain using Irregular-Resampling Auto-Spectral Analysis (IRASA)
 %
 % Use as
 %   [spectrum,ntaper,freqoi] = ft_specest_irasa(dat,time...)
@@ -24,6 +24,15 @@ function [spectrum,ntaper,freqoi] = ft_specest_irasa(dat, time, varargin)
 %   verbose    = output progress to console (0 or 1, default 1)
 %
 % This implements: Wen H, Liu Z. Separating fractal and oscillatory components in the power spectrum of neurophysiological signal. Brain Topogr. 2016 Jan;29(1):13-26.
+%   For usage, see Stolk et al., Electrocorticographic dissociation of 
+%   alpha and beta rhythmic activity in the human sensorimotor system.
+%   The algorithm deviates slightly from the original in that no additional
+%   sub-segmentation takes place (step A in Wen & Liu) in order to have
+%   irasa's frequency resolution match that of the mtmfft implementation.
+%   The original sub-segmentation step can, however, be achieved by calling 
+%   ft_redefinetrial with cfg.overlap = 0.9 prior to ft_frequencyanalysis.
+%   Furthermore, it is recommended the user specifies cfg.pad = nextpow2,
+%   which implements the zero-padding of step B in the original article.
 %
 % See also FT_FREQANALYSIS, FT_SPECEST_MTMFFT, FT_SPECEST_MTMCONVOL, FT_SPECEST_TFR, FT_SPECEST_HILBERT, FT_SPECEST_WAVELET
 
@@ -94,7 +103,7 @@ end
 fsample = 1./mean(diff(time));
 dattime = ndatsample / fsample; % total time in seconds of input data
 
-% Zero padding (FIXME: the effect of padding on taking the fft of the resampled signal has not been tested) 
+% Zero padding
 if round(pad * fsample) < ndatsample
   ft_error('the padding that you specified is shorter than the data');
 end

--- a/specest/ft_specest_irasa.m
+++ b/specest/ft_specest_irasa.m
@@ -24,7 +24,7 @@ function [spectrum,ntaper,freqoi] = ft_specest_irasa(dat, time, varargin)
 %   verbose    = output progress to console (0 or 1, default 1)
 %
 % This implements: Wen H, Liu Z. Separating fractal and oscillatory components in the power spectrum of neurophysiological signal. Brain Topogr. 2016 Jan;29(1):13-26.
-%   For usage, see Stolk et al., Electrocorticographic dissociation of 
+%   For application, see Stolk et al., Electrocorticographic dissociation of 
 %   alpha and beta rhythmic activity in the human sensorimotor system. It
 %   is recommended the user first sub-segments the data using ft_redefinetrial 
 %   and specifies cfg.pad = 'nextpow2' when calling ft_frequencyanalysis in 

--- a/specest/ft_specest_irasa.m
+++ b/specest/ft_specest_irasa.m
@@ -25,14 +25,10 @@ function [spectrum,ntaper,freqoi] = ft_specest_irasa(dat, time, varargin)
 %
 % This implements: Wen H, Liu Z. Separating fractal and oscillatory components in the power spectrum of neurophysiological signal. Brain Topogr. 2016 Jan;29(1):13-26.
 %   For usage, see Stolk et al., Electrocorticographic dissociation of 
-%   alpha and beta rhythmic activity in the human sensorimotor system.
-%   The algorithm deviates slightly from the original in that no additional
-%   sub-segmentation takes place (step A in Wen & Liu) in order to have
-%   irasa's frequency resolution match that of the mtmfft implementation.
-%   The original sub-segmentation step can, however, be achieved by calling 
-%   ft_redefinetrial with cfg.overlap = 0.9 prior to ft_frequencyanalysis.
-%   Furthermore, it is recommended the user specifies cfg.pad = nextpow2,
-%   which implements the zero-padding of step B in the original article.
+%   alpha and beta rhythmic activity in the human sensorimotor system. It
+%   is recommended the user first sub-segments the data using ft_redefinetrial 
+%   and specifies cfg.pad = 'nextpow2' when calling ft_frequencyanalysis in 
+%   order to implement steps A and B of the original algorithm in Wen & liu.
 %
 % See also FT_FREQANALYSIS, FT_SPECEST_MTMFFT, FT_SPECEST_MTMCONVOL, FT_SPECEST_TFR, FT_SPECEST_HILBERT, FT_SPECEST_WAVELET
 

--- a/test/test_ft_specest_irasa.m
+++ b/test/test_ft_specest_irasa.m
@@ -6,12 +6,14 @@ function test_ft_specest_irasa
 % DEPENDENCY ft_freqanalysis
 
 % script demonstrating the extraction of rhythmic spectral 
-% features from the electrophysiological signal
+% features from the electrophysiological signal, from Stolk et al., 
+% Electrocorticographic dissociation of alpha and beta rhythmic activity 
+% in the human sensorimotor system
 
 
 % generate trials with a 15 Hz oscillation embedded in pink noise
-t = (1:1:1000)/1000; % time axis
-for rpt = 1:1000
+t = (1:1000)/1000; % time axis
+for rpt = 1:100
   % generate pink noise
   dspobj = dsp.ColoredNoise('Color', 'pink', ...
     'SamplesPerFrame', length(t));
@@ -19,23 +21,53 @@ for rpt = 1:1000
   
   % add a 15 Hz oscillation
   data.trial{1,rpt} = fn + cos(2*pi*15*t); 
-  data.time{1,rpt} = t;
-  data.label{1} = 'chan';
+  data.time{1,rpt}  = t;
+  data.label{1}     = 'chan';
+  data.trialinfo(rpt,1) = rpt;
 end
 
-% perform regular frequency analysis and IRASA
-cfg = [];
-cfg.foilim = [1 50];
-cfg.taper = 'hanning';
-cfg.method = 'irasa';
-frac = ft_freqanalysis(cfg, data);
-cfg.method = 'mtmfft';
-orig = ft_freqanalysis(cfg, data);
+% partition the data into ten overlapping sub-segments
+w = data.time{1}(end)-data.time{1}(1); % window length
+cfg               = [];
+cfg.length        = w*.9;
+cfg.overlap       = 1-((w-cfg.length)/(10-1));
+data_r = ft_redefinetrial(cfg, data);
+
+% perform IRASA and regular spectral analysis
+cfg               = [];
+cfg.foilim        = [1 50];
+cfg.taper         = 'hanning';
+cfg.pad           = 'nextpow2';
+cfg.keeptrials    = 'yes';
+cfg.method        = 'irasa';
+frac_r = ft_freqanalysis(cfg, data_r);
+cfg.method        = 'mtmfft';
+orig_r = ft_freqanalysis(cfg, data_r);
+
+% average across the sub-segments
+frac_s = {}; 
+orig_s = {};
+for rpt = unique(frac_r.trialinfo)'
+  cfg               = [];
+  cfg.trials        = find(frac_r.trialinfo==rpt);
+  cfg.avgoverrpt    = 'yes';
+  frac_s{end+1} = ft_selectdata(cfg, frac_r);
+  orig_s{end+1} = ft_selectdata(cfg, orig_r);
+end
+frac_a = ft_appendfreq([], frac_s{:});
+orig_a = ft_appendfreq([], orig_s{:});
+
+% average across trials
+cfg               = [];
+cfg.trials        = 'all';
+cfg.avgoverrpt    = 'yes';
+frac = ft_selectdata(cfg, frac_a);
+orig = ft_selectdata(cfg, orig_a);
 
 % subtract the fractal component from the power spectrum
-cfg = [];
-cfg.parameter = 'powspctrm';
-cfg.operation = 'x2-x1';
+cfg               = [];
+cfg.parameter     = 'powspctrm';
+cfg.operation     = 'x2-x1';
 osci = ft_math(cfg, frac, orig);
 
 % plot the fractal component and the power spectrum 
@@ -45,12 +77,13 @@ hold on; plot(orig.freq, orig.powspctrm, ...
   'linewidth', 3, 'color', [.6 .6 .6])
 
 % plot the full-width half-maximum of the oscillatory component
-f = fit(osci.freq', osci.powspctrm', 'gauss1');
+f    = fit(osci.freq', osci.powspctrm', 'gauss1');
 mean = f.b1;
-std = f.c1/sqrt(2)*2.3548;
+std  = f.c1/sqrt(2)*2.3548;
 fwhm = [mean-std/2 mean+std/2];
-yl = get(gca, 'YLim');
+yl   = get(gca, 'YLim');
 p = patch([fwhm flip(fwhm)], [yl(1) yl(1) yl(2) yl(2)], [1 1 1]);
 uistack(p, 'bottom');
 legend('FWHM oscillation', 'Fractal component', 'Power spectrum');
 xlabel('Frequency'); ylabel('Power');
+set(gca, 'YLim', yl);


### PR DESCRIPTION
The test script is documented as an example script on the wiki: http://www.fieldtriptoolbox.org/example/irasa/

This example script is important because, as documented in ft_specest_irasa, it implements parts of the original IRASA operation outside ft_freqanalysis