### PR TITLE
print filfter settings only once.

### DIFF
--- a/preproc/ft_preproc_bandpassfilter.m
+++ b/preproc/ft_preproc_bandpassfilter.m
@@ -215,6 +215,7 @@ switch type
     end
 
     % Reporting
+    ft_info once
     ft_info('Bandpass filtering data: %s, order %d, %s-windowed sinc FIR\n', dir, order, wintype);
     if ~isTwopass && ~isOrderLow % Do not report shifted cutoffs
       ft_info('  cutoff (-6 dB) %g Hz and %g Hz\n', Fbp(1), Fbp(2));

--- a/preproc/ft_preproc_bandstopfilter.m
+++ b/preproc/ft_preproc_bandstopfilter.m
@@ -214,6 +214,7 @@ switch type
     end
 
     % Reporting
+    ft_info once
     ft_info('Bandstop filtering data: %s, order %d, %s-windowed sinc FIR\n', dir, order, wintype);
     if ~isTwopass && ~isOrderLow % Do not report shifted cutoffs
       ft_info('  cutoff (-6 dB) %g Hz and %g Hz\n', Fbp(1), Fbp(2));

--- a/preproc/ft_preproc_highpassfilter.m
+++ b/preproc/ft_preproc_highpassfilter.m
@@ -213,6 +213,7 @@ switch type
     end
     
     % Reporting
+    ft_info once
     ft_info('Highpass filtering data: %s, order %d, %s-windowed sinc FIR\n', dir, order, wintype);
     if ~isTwopass && ~isOrderLow % Do not report shifted cutoffs
       ft_info('  cutoff (-6 dB) %g Hz\n', Fhp);

--- a/preproc/ft_preproc_lowpassfilter.m
+++ b/preproc/ft_preproc_lowpassfilter.m
@@ -217,6 +217,7 @@ switch type
     end
 
     % Reporting
+    ft_info once
     ft_info('Lowpass filtering data: %s, order %d, %s-windowed sinc FIR\n', dir, order, wintype);
     if ~isTwopass && ~isOrderLow % Do not report shifted cutoffs
       ft_info('  cutoff (-6 dB) %g Hz\n', Flp);


### PR DESCRIPTION
Instead of printing filter settings for every trial, only do it for the first trial.