### PR TITLE
ENH - improve handling of call to ft_prepare_neighbours, also for ft_megplanar

### DIFF
--- a/ft_freqstatistics.m
+++ b/ft_freqstatistics.m
@@ -121,9 +121,8 @@ tmpcfg = keepfields(cfg, {'frequency', 'avgoverfreq', 'latency', 'avgovertime', 
 
 % neighbours are required for clustering with multiple channels
 if strcmp(cfg.correctm, 'cluster') && length(varargin{1}.label)>1
-  % the cfg.neighbours field cannot be empty
-  ft_checkconfig(cfg, 'required', 'neighbours');
-  % use ft_prepare_neighbours to load the neighbours from disk and/or select the channels
+  % this is limited to reading neighbours from disk and/or selecting channels
+  % the user should call FT_PREPARE_NEIGHBOURS directly for the actual construction
   tmpcfg = keepfields(cfg, {'neighbours', 'channel', 'showcallinfo'});
   cfg.neighbours = ft_prepare_neighbours(tmpcfg);
 end

--- a/ft_megplanar.m
+++ b/ft_megplanar.m
@@ -114,7 +114,9 @@ cfg.feedback     = ft_getopt(cfg, 'feedback',     'text');
 cfg = ft_checkconfig(cfg, 'renamedval',  {'headshape', 'headmodel', []});
 
 if ~strcmp(cfg.planarmethod, 'sourceproject')
-  tmpcfg = keepfields(cfg, {'neighbours', 'neighbourdist', 'channel', 'elec', 'grad', 'opto', 'showcallinfo'});
+  % this is limited to reading neighbours from disk and/or selecting channels
+  % the user should call FT_PREPARE_NEIGHBOURS directly for the actual construction
+  tmpcfg = keepfields(cfg, {'neighbours', 'channel', 'showcallinfo'});
   cfg.neighbours = ft_prepare_neighbours(tmpcfg);
 end
 

--- a/ft_prepare_neighbours.m
+++ b/ft_prepare_neighbours.m
@@ -99,7 +99,7 @@ if ~isfield(cfg, 'method')
       cfg.neighbours = tmp([]);
     end
     % this is a hack to get past the case-statement
-    cfg.method = 'unspecified_method_but_ok';
+    cfg.method = 'specified';
   end
 end
 
@@ -173,22 +173,9 @@ end % if distance or triangulation
 
 
 switch cfg.method
-  case 'XXfile'
-    % read it from file
-    ft_notice('reading neighbours from file %s', cfg.neighbours);
-    neighbours = loadvar(cfg.neighbours);
-    cfg = rmfield(cfg, 'method'); % FIXME this is a hack
-    
-  case 'XXexisting'
-    ft_notice('using specified neighbours for the channels');
+  case 'specified'
+    % use the neighbours as specified by the user
     neighbours = cfg.neighbours;
-    cfg = rmfield(cfg, 'method'); % FIXME this is a hack
-    
-  case 'XXempty'
-    ft_notice('not using neighbours for the channels');
-    neighbours = struct('label', [], 'neighblabel', []);
-    neighbours = neighbours([]);
-    cfg = rmfield(cfg, 'method'); % FIXME this is a hack
     
   case 'template'
     fprintf('Trying to load sensor neighbours from a template\n');
@@ -261,11 +248,6 @@ switch cfg.method
     tri_y = delaunay(prj(:,1), prj(:,2)./2);
     tri = [tri; tri_x; tri_y];
     neighbours = compneighbstructfromtri(chanpos, label, tri);
-    
-  case 'unspecified_method_but_ok'
-    % this is a hack to get past the case-statement
-    cfg = rmfield(cfg, 'method');
-    neighbours = cfg.neighbours;
     
   otherwise
     ft_error('unsupported method ''%s''', cfg.method);

--- a/ft_timelockstatistics.m
+++ b/ft_timelockstatistics.m
@@ -112,9 +112,8 @@ tmpcfg = keepfields(cfg, {'latency', 'avgovertime', 'channel', 'avgoverchan', 'p
 
 % neighbours are required for clustering with multiple channels
 if strcmp(cfg.correctm, 'cluster') && length(varargin{1}.label)>1
-  % the cfg.neighbours field cannot be empty
-  ft_checkconfig(cfg, 'required', 'neighbours');
-  % use ft_prepare_neighbours to load the neighbours from disk and/or select the channels
+  % this is limited to reading neighbours from disk and/or selecting channels
+  % the user should call FT_PREPARE_NEIGHBOURS directly for the actual construction
   tmpcfg = keepfields(cfg, {'neighbours', 'channel', 'showcallinfo'});
   cfg.neighbours = ft_prepare_neighbours(tmpcfg);
 end

--- a/utilities/dccnpath.m
+++ b/utilities/dccnpath.m
@@ -49,11 +49,11 @@ end
 
 [p, f, x] = fileparts(file);
 
-alternative1 = [f x];
+alternative1 = [f x]; % this should not be used when it is only "test", since that is too generic
 alternative2 = strrep(filename, '/home/common/matlab/fieldtrip', '/Volumes/home/common/matlab/fieldtrip');
 alternative3 = strrep(filename, '/home/common/matlab/fieldtrip', '/Volumes/128GB/data/test');
 
-if ~exist(file, 'file') && exist(alternative1, 'file')
+if ~exist(file, 'file') && exist(alternative1, 'file') && ~strcmp(alternative1, 'test')
   warning('using local copy %s instead of %s', alternative1, file);
   file = alternative1;
 elseif ~exist(file, 'file') && exist(alternative2, 'file')


### PR DESCRIPTION
I realized after fixing #1183 that `ft_megplanar` also uses neighbors in some cases. I checked the code (it still works) and cleaned it up a bit.