### PR TITLE
New obj reader

### DIFF
--- a/external/wavefront/read_obj_new.m
+++ b/external/wavefront/read_obj_new.m
@@ -1,0 +1,72 @@
+function [vertex, faces, texture, textureIdx] = read_obj_new(filename)
+
+% Faster .obj reader for headshape information acquired using a structure
+% sensor
+
+% from http://boffinblogger.blogspot.com/2015/05/faster-obj-file-reading-in-matlab.html
+% modified output structure and added scan for texture and textureIdx to handle vt
+% Modifications by Robert Oostenveld and Robert Seymour
+
+fid = fopen(filename);
+if fid<0
+    error(['Cannot open ' filename '.']);
+end
+[str, count] = fread(fid, [1,inf], 'uint8=>char'); 
+fprintf('Reading %d characters from %s\n', count, filename);
+fclose(fid);
+
+tic;
+vertex_lines = regexp(str,'v [^\n]*\n', 'match');
+vertex = zeros(length(vertex_lines), 3);
+for i = 1: length(vertex_lines)
+    v = sscanf(vertex_lines{i}, 'v %f %f %f');
+    vertex(i, :) = v';
+end
+
+texture_lines = regexp(str,'vt [^\n]*\n', 'match');
+texture = zeros(length(texture_lines), 2);
+for i = 1: length(texture_lines)
+    vt = sscanf(texture_lines{i}, 'vt %f %f');
+    texture(i, :) = vt';
+end
+
+face_lines = regexp(str,'f [^\n]*\n', 'match');
+faces = zeros(length(face_lines), 3);
+textureIdx = zeros(length(face_lines), 3);
+
+for i = 1: length(face_lines)
+%     f = sscanf(face_lines{i}, 'f %d//%d %d//%d %d//%d');
+%     if (length(f) == 6) % face
+%         faces(i, 1) = f(1);
+%         faces(i, 2) = f(3);
+%         faces(i, 3) = f(5);
+%         continue
+%     end
+%     f = sscanf(face_lines{i}, 'f %d %d %d');
+%     if (length(f) == 3) % face
+%         faces(i, :) = f';
+%         continue
+%     end
+    f = sscanf(face_lines{i}, 'f %d/%d %d/%d %d/%d');
+    if (length(f) == 6) % face
+        faces(i, 1) = f(1);
+        faces(i, 2) = f(3);
+        faces(i, 3) = f(5);
+        textureIdx(i,1) = f(2);
+        textureIdx(i,2) = f(4);
+        textureIdx(i,3) = f(6);
+        continue
+    end
+    f = sscanf(face_lines{i}, 'f %d/%d/%d %d/%d/%d %d/%d/%d');
+    if (length(f) == 9) % face
+        faces(i, 1) = f(1);
+        faces(i, 2) = f(4);
+        faces(i, 3) = f(7);
+        textureIdx(i,1) = f(2);
+        textureIdx(i,2) = f(5);
+        textureIdx(i,3) = f(8);
+        continue
+    end
+end
+fprintf('.obj file took %f seconds to load\n',toc)
+return

--- a/fileio/ft_read_headshape.m
+++ b/fileio/ft_read_headshape.m
@@ -1251,7 +1251,7 @@ end
 shape = fixpos(shape);
 
 % ensure that the numerical arrays are represented in double precision and not as integers
-% except when reading an obj file with color information
-if ~strcmp(fileformat,'obj') && isfield(shape, 'color')
+% except when reading an obj file
+if ~strcmp(fileformat,'obj')
     shape = ft_struct2double(shape);
 end

--- a/fileio/ft_read_headshape.m
+++ b/fileio/ft_read_headshape.m
@@ -59,7 +59,7 @@ function [shape] = ft_read_headshape(filename, varargin)
 %
 % See also FT_READ_HEADMODEL, FT_READ_SENS, FT_READ_ATLAS, FT_WRITE_HEADSHAPE
 
-% Copyright (C) 2008-2017 Robert Oostenveld
+% Copyright (C) 2008-2019 Robert Oostenveld
 %
 % This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
 % for the documentation and details.
@@ -947,25 +947,30 @@ switch fileformat
   case 'obj'
     ft_hastoolbox('wavefront', 1);
     % Only tested for structure.io .obj thus far
-    obj = read_wobj(filename);
-    shape.pos     = obj.vertices(:,1:3);
-    shape.pos     = shape.pos - repmat(sum(shape.pos)/length(shape.pos),[length(shape.pos),1]); %centering vertices
-    shape.tri     = obj.objects(end).data.vertices;
-    if hasimage
-      texture = obj.vertices_texture;
-      
+    [vertex, faces, texture, ~] = read_obj_new(filename);
+    
+    shape.pos   = vertex;
+    shape.pos   = shape.pos - repmat(sum(shape.pos)/length(shape.pos),...
+        [length(shape.pos),1]); %centering vertices
+    shape.tri   = faces(1:end-1,:,:); % remove the last row which is zeros
+    
+    if hasimage      
       % Refines the mesh and textures to increase resolution of the colormapping
-      [shape.pos, shape.tri, texture] = refine(shape.pos, shape.tri, 'banks', texture);
+      [shape.pos, shape.tri, texture] = refine(shape.pos, shape.tri,...
+          'banks', texture);
       
       picture = imread(image);
       color   = uint8(zeros(length(shape.pos),3));
       for i=1:length(shape.pos)
-        color(i,1:3) = picture(floor((1-texture(i,2))*length(picture)),1+floor(texture(i,1)*length(picture)),1:3);
+        color(i,1:3) = picture(floor((1-texture(i,2))*length(picture)),...
+            1+floor(texture(i,1)*length(picture)),1:3);
       end
+      
       shape.color = color;
-    elseif size(obj.vertices,2)==6
+
+    elseif size(vertex,2)==6
       % the vertices also contain RGB colors
-      shape.color = obj.vertices(:,4:6);
+      shape.color = uint8(obj.vertex(:,4:6));
     end
     
   case 'vtk'
@@ -1246,4 +1251,7 @@ end
 shape = fixpos(shape);
 
 % ensure that the numerical arrays are represented in double precision and not as integers
-shape = ft_struct2double(shape);
+% except when reading an obj file with color information
+if ~strcmp(fileformat,'obj') && isfield(shape, 'color')
+    shape = ft_struct2double(shape);
+end

--- a/fileio/ft_read_headshape.m
+++ b/fileio/ft_read_headshape.m
@@ -960,17 +960,31 @@ switch fileformat
           'banks', texture);
       
       picture = imread(image);
-      color   = uint8(zeros(length(shape.pos),3));
+      color   = (zeros(length(shape.pos),3));
       for i=1:length(shape.pos)
         color(i,1:3) = picture(floor((1-texture(i,2))*length(picture)),...
             1+floor(texture(i,1)*length(picture)),1:3);
+      end
+      
+      % If color is specified as 0-255 rather than 0-1 correct by dividing
+      % by 255
+      if range(color(:)) > 1
+          color = color./255;
       end
       
       shape.color = color;
 
     elseif size(vertex,2)==6
       % the vertices also contain RGB colors
-      shape.color = uint8(obj.vertex(:,4:6));
+      
+      color = vertex(:,4:6);
+      % If color is specified as 0-255 rather than 0-1 correct by dividing
+      % by 255
+      if range(color(:)) > 1
+          color = color./255;
+      end
+      
+      shape.color = color;
     end
     
   case 'vtk'
@@ -1251,7 +1265,5 @@ end
 shape = fixpos(shape);
 
 % ensure that the numerical arrays are represented in double precision and not as integers
-% except when reading an obj file
-if ~strcmp(fileformat,'obj')
-    shape = ft_struct2double(shape);
+shape = ft_struct2double(shape);
 end


### PR DESCRIPTION
Following on from discussion on PR
https://github.com/fieldtrip/fieldtrip/commit/d073bb2de8c2aa61a37eeb97b99c177e15985911

This PR implements a new .obj reader from “Boffin Blogger”, which is
much faster than the previous read_wobj function. The function also now
ignores ft_struct2double for .obj files with colour information, in
order to preserve the int8 format. Works well for data acquired from a
structure sensor (@Macquarie-MEG-Research).