### PR TITLE
bugfix when applying calibration to bci2000 data

### DIFF
--- a/fileio/ft_read_data.m
+++ b/fileio/ft_read_data.m
@@ -381,8 +381,9 @@ switch dataformat
     end
     % apply the callibration from AD units to uV
     dat = double(signal(begsample:endsample,chanindx)');
-    for i=chanindx(:)'
-      dat(i,:) = dat(i,:).* parameters.SourceChGain.NumericValue(i) + parameters.SourceChOffset.NumericValue(i);
+    for i=1:length(chanindx)
+      i_chan = chanindx(i);
+      dat(i,:) = dat(i,:).* parameters.SourceChGain.NumericValue(i_chan) + parameters.SourceChOffset.NumericValue(i_chan);
     end
     dimord = 'chans_samples';
     


### PR DESCRIPTION
When reading bci2000 data, `dat` can contain a subset of all the channels in the original data. 

### Current behavior
When applying the calibration, there is only one index for `dat` and for `SourceChGain`/`SourceChOffset`

### Proposed fix
There will be one index `i` for `dat` and one index `i_chan` for `SourceChGain`/`SourceChOffset`. So that `i` tracks the subset of channels which are in `dat`.