### PR TITLE
ENH #1196 - extend data2bids with EMG data type

### DIFF
--- a/data2bids.m
+++ b/data2bids.m
@@ -43,7 +43,7 @@ function cfg = data2bids(cfg, varargin)
 % obtain the sidecar files for a dataset that already has the correct BIDS name.
 %
 % CONVERT - data2bids will read the input data (or use the specified input data) and
-% write it to a new output file that is BIDS compliant. The output format is NIFTI
+% write it to a new output file that is BIDS compliant. The output format is NIfTI
 % for MRI data, and BrainVision for EEG and iEEG. Note that MEG data files are stored
 % in BIDS in their native format and this function will NOT convert them for you.
 %
@@ -80,7 +80,7 @@ function cfg = data2bids(cfg, varargin)
 % In case any of these values is specified as empty (i.e. []) or as nan, it will be
 % written to the tsv file as 'n/a'.
 %
-% In case cfg.dataset points to a NIFTI file, or in case you pass a preprocessed MRI
+% In case cfg.dataset points to a NIfTI file, or in case you pass a preprocessed MRI
 % as input data structure, you can specify cfg.mri.dicomfile to read the detailed MR
 % scanner and sequence details from the DICOM file. This will be used to fill in the
 % details of the corresponding JSON file.
@@ -248,6 +248,9 @@ cfg.eeg.writesidecar        = ft_getopt(cfg.eeg, 'writesidecar', 'yes');      % 
 cfg.ieeg                    = ft_getopt(cfg, 'ieeg');
 cfg.ieeg.writesidecar       = ft_getopt(cfg.ieeg, 'writesidecar', 'yes');     % whether to write the sidecar file
 
+cfg.emg                     = ft_getopt(cfg, 'emg');
+cfg.emg.writesidecar        = ft_getopt(cfg.emg, 'writesidecar', 'yes');      % whether to write the sidecar file
+
 cfg.channels                = ft_getopt(cfg, 'channels');
 cfg.channels.writesidecar   = ft_getopt(cfg.channels, 'writesidecar', 'yes'); % whether to write the sidecar file
 
@@ -281,8 +284,8 @@ cfg.TaskDescription                   = ft_getopt(cfg, 'TaskDescription'        
 cfg.Instructions                      = ft_getopt(cfg, 'Instructions'                ); % OPTIONAL. Text of the instructions given to participants before the scan. This is not only important for behavioral or cognitive tasks but also in resting state paradigms (e.g. to distinguish between eyes open and eyes closed).
 cfg.CogAtlasID                        = ft_getopt(cfg, 'CogAtlasID'                  ); % OPTIONAL. URL of the corresponding "Cognitive Atlas term that describes the task (e.g. Resting State with eyes closed ""http://www.cognitiveatlas.org/term/id/trm_54e69c642d89b""")
 cfg.CogPOID                           = ft_getopt(cfg, 'CogPOID'                     ); % OPTIONAL. URL of the corresponding "CogPO term that describes the task (e.g. Rest "http://wiki.cogpo.org/index.php?title=Rest")
-cfg.Manufacturer                      = ft_getopt(cfg, 'Manufacturer'                ); % OPTIONAL. Manufacturer of the MEG system ("CTF", ""Neuromag/Elekta"", ""4D/BTi"", ""KIT/Yokogawa"", ""ITAB"", "KRISS", "Other")
-cfg.ManufacturersModelName            = ft_getopt(cfg, 'ManufacturersModelName'      ); % OPTIONAL. Manufacturer's designation of the MEG scanner model (e.g. "CTF-275"). See "Appendix VII" with preferred names
+cfg.Manufacturer                      = ft_getopt(cfg, 'Manufacturer'                ); % OPTIONAL. Manufacturer of the recording system ("CTF", ""Neuromag/Elekta"", ""4D/BTi"", ""KIT/Yokogawa"", ""ITAB"", "KRISS", "Other")
+cfg.ManufacturersModelName            = ft_getopt(cfg, 'ManufacturersModelName'      ); % OPTIONAL. Manufacturer's designation of the model (e.g. "CTF-275"). See "Appendix VII" with preferred names
 cfg.DeviceSerialNumber                = ft_getopt(cfg, 'DeviceSerialNumber'          ); % OPTIONAL. The serial number of the equipment that produced the composite instances. A pseudonym can also be used to prevent the equipment from being identifiable, as long as each pseudonym is unique within the dataset.
 cfg.SoftwareVersions                  = ft_getopt(cfg, 'SoftwareVersions'            ); % OPTIONAL. Manufacturer's designation of the acquisition software.
 cfg.InstitutionName                   = ft_getopt(cfg, 'InstitutionName'             ); % OPTIONAL. The name of the institution in charge of the equipment that produced the composite instances.
@@ -315,7 +318,7 @@ cfg.mri.ParallelReductionFactorInPlan = ft_getopt(cfg.mri, 'ParallelReductionFac
 cfg.mri.ParallelAcquisitionTechnique  = ft_getopt(cfg.mri, 'ParallelAcquisitionTechnique'   ); % The type of parallel imaging used (e.g. GRAPPA, SENSE). Corresponds to DICOM Tag 0018, 9078 "Parallel Acquisition Technique".
 cfg.mri.PartialFourier                = ft_getopt(cfg.mri, 'PartialFourier'                 ); % The fraction of partial Fourier information collected. Corresponds to DICOM Tag 0018, 9081 "Partial Fourier".
 cfg.mri.PartialFourierDirection       = ft_getopt(cfg.mri, 'PartialFourierDirection'        ); % The direction where only partial Fourier information was collected. Corresponds to DICOM Tag 0018, 9036 "Partial Fourier Direction".
-cfg.mri.PhaseEncodingDirection        = ft_getopt(cfg.mri, 'PhaseEncodingDirection'         ); % Possible values = [];                     % "i", "j", "k", "i-", "j-", "k-". The letters "i", "j", "k" correspond to the first, second and third axis of the data in the NIFTI file. The polarity of the phase encoding is assumed to go from zero index to maximum index unless "-" sign is present (then the order is reversed - starting from the highest index instead of zero). PhaseEncodingDirection is defined as the direction along which phase is was modulated which may result in visible distortions. Note that this is not the same as the DICOM term InPlanePhaseEncodingDirection which can have "ROW" or "COL" values. This parameter is REQUIRED if corresponding fieldmap data is present or when using multiple runs with different phase encoding directions (which can be later used for field inhomogeneity correction).
+cfg.mri.PhaseEncodingDirection        = ft_getopt(cfg.mri, 'PhaseEncodingDirection'         ); % Possible values = [];                     % "i", "j", "k", "i-", "j-", "k-". The letters "i", "j", "k" correspond to the first, second and third axis of the data in the NIfTI file. The polarity of the phase encoding is assumed to go from zero index to maximum index unless "-" sign is present (then the order is reversed - starting from the highest index instead of zero). PhaseEncodingDirection is defined as the direction along which phase is was modulated which may result in visible distortions. Note that this is not the same as the DICOM term InPlanePhaseEncodingDirection which can have "ROW" or "COL" values. This parameter is REQUIRED if corresponding fieldmap data is present or when using multiple runs with different phase encoding directions (which can be later used for field inhomogeneity correction).
 cfg.mri.EffectiveEchoSpacing          = ft_getopt(cfg.mri, 'EffectiveEchoSpacing'           ); % The "effective" sampling interval, specified in seconds, between lines in the phase-encoding direction, defined based on the size of the reconstructed image in the phase direction.  It is frequently, but incorrectly, referred to as  "dwell time" (see DwellTime parameter below for actual dwell time).  It is  required for unwarping distortions using field maps. Note that beyond just in-plane acceleration, a variety of other manipulations to the phase encoding need to be accounted for properly, including partial fourier, phase oversampling, phase resolution, phase field-of-view and interpolation. This parameter is REQUIRED if corresponding fieldmap data is present.
 cfg.mri.TotalReadoutTime              = ft_getopt(cfg.mri, 'TotalReadoutTime'               ); % This is actually the "effective" total readout time , defined as the readout duration, specified in seconds, that would have generated data with the given level of distortion.  It is NOT the actual, physical duration of the readout train.  If EffectiveEchoSpacing has been properly computed, it is just EffectiveEchoSpacing * (ReconMatrixPE - 1). . This parameter is REQUIRED if corresponding "field/distortion" maps acquired with opposing phase encoding directions are present  (see 8.9.4).
 
@@ -345,6 +348,7 @@ cfg.mri.RepetitionTime                = ft_getopt(cfg.mri, 'RepetitionTime'     
 cfg.mri.VolumeTiming                  = ft_getopt(cfg.mri, 'VolumeTiming'                   ); % REQUIRED. The time at which each volume was acquired during the acquisition. It is described using a list of times (in JSON format) referring to the onset of each volume in the BOLD series. The list must have the same length as the BOLD series, and the values must be non-negative and monotonically increasing. This field is mutually exclusive with RepetitionTime and DelayTime. If defined, this requires acquisition time (TA) be defined via either SliceTiming or AcquisitionDuration be defined.
 
 %% MEG specific fields
+% Manufacturer and ManufacturersModelName are general
 cfg.meg.SamplingFrequency             = ft_getopt(cfg.meg, 'SamplingFrequency'           ); % REQUIRED. Sampling frequency (in Hz) of all the data in the recording, regardless of their type (e.g., 2400)
 cfg.meg.PowerLineFrequency            = ft_getopt(cfg.meg, 'PowerLineFrequency'          ); % REQUIRED. Frequency (in Hz) of the power grid at the geographical location of the MEG instrument (i.e. 50 or 60)
 cfg.meg.DewarPosition                 = ft_getopt(cfg.meg, 'DewarPosition'               ); % REQUIRED. Position of the dewar during the MEG scan: "upright", "supine" or "degrees" of angle from vertical: for example on CTF systems, upright=15??, supine = 90??.
@@ -384,6 +388,7 @@ cfg.eeg.PowerLineFrequency            = ft_getopt(cfg.eeg, 'PowerLineFrequency' 
 cfg.eeg.SoftwareFilters               = ft_getopt(cfg.eeg, 'SoftwareFilters'             ); % List of temporal software filters applied or ideally  key:value pairs of pre-applied filters and their parameter values
 cfg.eeg.CapManufacturer               = ft_getopt(cfg.eeg, 'CapManufacturer'             ); % name of the cap manufacturer
 cfg.eeg.CapModelName                  = ft_getopt(cfg.eeg, 'CapModelName'                ); % Manufacturer's designation of the EEG cap model (e.g. "CAPML128", "actiCAP 64Ch Standard-2")
+% Manufacturer and ManufacturersModelName are general
 cfg.eeg.EEGChannelCount               = ft_getopt(cfg.eeg, 'EEGChannelCount'             ); % Number of EEG channels included in the recording (e.g. 128).
 cfg.eeg.ECGChannelCount               = ft_getopt(cfg.eeg, 'ECGChannelCount'             ); % Number of ECG channels included in the recording (e.g. 1).
 cfg.eeg.EMGChannelCount               = ft_getopt(cfg.eeg, 'EMGChannelCount'             ); % Number of EMG channels included in the recording (e.g. 2).
@@ -400,7 +405,6 @@ cfg.eeg.HardwareFilters               = ft_getopt(cfg.eeg, 'HardwareFilters'    
 cfg.eeg.SubjectArtefactDescription    = ft_getopt(cfg.eeg, 'SubjectArtefactDescription'  ); % Freeform description of the observed subject artefact and its possible cause (e.g. "Vagus Nerve Stimulator", "non-removable implant"). If this field is left empty, it will be interpreted as absence of  a source of (constantly present) artifacts.
 
 %% iEEG specific fields
-
 cfg.ieeg.iEEGReference                   = ft_getopt(cfg, 'iEEGReference'                  ); % REQUIRED. General description of the reference scheme used and (when applicable) of location of the reference electrode in the raw recordings (e.g. "left mastoid”, “bipolar”, “T01” for electrode with name T01, “intracranial electrode on top of a grid, not included with data”, “upside down electrode”). If different channels have a different reference, this field should have a general description and the channel specific reference should be defined in the _channels.tsv file.
 cfg.ieeg.SamplingFrequency               = ft_getopt(cfg, 'SamplingFrequency'              ); % REQUIRED. Sampling frequency (in Hz) of all the iEEG channels in the recording (e.g., 2400). All other channels should have frequency specified as well in the channels.tsv file.
 cfg.ieeg.PowerLineFrequency              = ft_getopt(cfg, 'PowerLineFrequency'             ); % REQUIRED. Frequency (in Hz) of the power grid where the iEEG recording was done (i.e. 50 or 60)
@@ -409,8 +413,7 @@ cfg.ieeg.SoftwareFilters                 = ft_getopt(cfg, 'SoftwareFilters'     
 cfg.ieeg.HardwareFilters                 = ft_getopt(cfg, 'HardwareFilters'                ); % REQUIRED. List of hardware (amplifier) filters applied with  key:value pairs of filter parameters and their values.
 cfg.ieeg.ElectrodeManufacturer           = ft_getopt(cfg, 'ElectrodeManufacturer'          ); % RECOMMENDED. can be used if all electrodes are of the same manufacturer (e.g. AD-TECH, DIXI). If electrodes of different manufacturers are used, please use the corresponding table in the _electrodes.tsv file.
 cfg.ieeg.ElectrodeManufacturersModelName = ft_getopt(cfg, 'ElectrodeManufacturersModelName'); % RECOMMENDED. If different electrode types are used, please use the corresponding table in the _electrodes.tsv file.
-cfg.ieeg.Manufacturer                    = ft_getopt(cfg, 'Manufacturer'                   ); % RECOMMENDED. Manufacturer of the amplifier system  (e.g. "TDT, Blackrock")
-cfg.ieeg.ManufacturersModelName          = ft_getopt(cfg, 'ManufacturersModelName'         ); % RECOMMENDED. Manufacturer’s designation of the iEEG amplifier model.
+% Manufacturer and ManufacturersModelName are general
 cfg.ieeg.ECOGChannelCount                = ft_getopt(cfg, 'ECOGChannelCount'               ); % RECOMMENDED. Number of iEEG surface channels included in the recording (e.g. 120)
 cfg.ieeg.SEEGChannelCount                = ft_getopt(cfg, 'SEEGChannelCount'               ); % RECOMMENDED. Number of iEEG depth channels included in the recording (e.g. 8)
 cfg.ieeg.EEGChannelCount                 = ft_getopt(cfg, 'EEGChannelCount'                ); % RECOMMENDED. Number of scalp EEG channels recorded simultaneously (e.g. 21)
@@ -428,6 +431,22 @@ cfg.ieeg.iEEGElectrodeGroups             = ft_getopt(cfg, 'iEEGElectrodeGroups' 
 cfg.ieeg.SubjectArtefactDescription      = ft_getopt(cfg, 'SubjectArtefactDescription'     ); % RECOMMENDED. Freeform description of the observed subject artefact and its possible cause (e.g. “door open”, ”nurse walked into room at 2 min”, ”seizure at 10 min”). If this field is left empty, it will be interpreted as absence of artifacts.
 cfg.ieeg.ElectricalStimulation           = ft_getopt(cfg, 'ElectricalStimulation'          ); % OPTIONAL. Boolean field to specify if electrical stimulation was done during the recording (options are “true” or “false”). Parameters for event-like stimulation should be specified in the _events.tsv file (see example underneath).
 cfg.ieeg.ElectricalStimulationParameters = ft_getopt(cfg, 'ElectricalStimulationParameters'); % OPTIONAL. Free form description of stimulation parameters, such as frequency, shape etc. Specific onsets can be specified in the _events.tsv file. Specific shapes can be described here in freeform text.
+
+%% EMG is not part of the official BIDS specification
+cfg.emg.SamplingFrequency                 = ft_getopt(cfg.emg, 'SamplingFrequency'                 );
+cfg.emg.RecordingDuration                 = ft_getopt(cfg.emg, 'RecordingDuration'                 );
+cfg.emg.RecordingType                     = ft_getopt(cfg.emg, 'RecordingType'                     );
+cfg.emg.PowerLineFrequency                = ft_getopt(cfg.emg, 'PowerLineFrequency'                );
+cfg.emg.HardwareFilters                   = ft_getopt(cfg.emg, 'HardwareFilters'                   );
+cfg.emg.SoftwareFilters                   = ft_getopt(cfg.emg, 'SoftwareFilters'                   );
+cfg.emg.EMGChannelCount                   = ft_getopt(cfg.emg, 'EMGChannelCount'                   );
+cfg.emg.EOGChannelCount                   = ft_getopt(cfg.emg, 'EOGChannelCount'                   );
+cfg.emg.ECGChannelCount                   = ft_getopt(cfg.emg, 'ECGChannelCount'                   );
+cfg.emg.ElectrodeManufacturer             = ft_getopt(cfg.emg, 'ElectrodeManufacturer'             );
+cfg.emg.ElectrodeManufacturersModelName   = ft_getopt(cfg.emg, 'ElectrodeManufacturersModelName'   );
+cfg.emg.EMGPlacementScheme                = ft_getopt(cfg.emg, 'EMGPlacementScheme'                );
+cfg.emg.EMGReference                      = ft_getopt(cfg.emg, 'EMGReference'                      );
+cfg.emg.EMGGround                         = ft_getopt(cfg.emg, 'EMGGround'                         );
 
 %% information for the coordsystem.json file for MEG, EEG and iEEG
 cfg.coordsystem.MEGCoordinateSystem                             = ft_getopt(cfg.coordsystem, 'MEGCoordinateSystem'                            ); % REQUIRED. Defines the coordinate system for the MEG sensors. See Appendix VIII: preferred names of Coordinate systems. If "Other", provide definition of the coordinate system in [MEGCoordinateSystemDescription].
@@ -594,6 +613,7 @@ need_mri_json         = false;
 need_meg_json         = false;
 need_eeg_json         = false;
 need_ieeg_json        = false;
+need_emg_json         = false;
 need_events_tsv       = false; % for behavioral experiments
 need_electrodes_tsv   = false; % only needed when actually present as data.cfg or as cfg.elec
 
@@ -607,12 +627,12 @@ switch typ
       dcm = [];
     end
     need_mri_json = true;
-
+    
   case 'dicom'
     mri = ft_read_mri(cfg.dataset);
     dcm = dicominfo(cfg.dataset);
     need_mri_json = true;
-
+    
   case 'volume'
     % the input data structure represents imaging data
     mri = varargin{1};
@@ -627,7 +647,7 @@ switch typ
       dcm = [];
     end
     need_mri_json = true;
-
+    
   case {'ctf_ds', 'ctf_meg4', 'ctf_res4', 'ctf151', 'ctf275', 'neuromag_fif', 'neuromag122', 'neuromag306'}
     % it is MEG data from disk and in a supported format
     hdr = ft_read_header(cfg.headerfile, 'checkmaxfilter', false);
@@ -642,9 +662,9 @@ switch typ
       trigger = cfg.trigger.event;
     end
     need_meg_json = true;
-
+    
   case {'brainvision_vhdr', 'edf', 'eeglab_set'}
-    % it is EEG data from disk and in a supported format
+    % it is ExG data from disk in a supported format
     hdr = ft_read_header(cfg.headerfile, 'checkmaxfilter', false);
     if strcmp(cfg.method, 'convert')
       % the data should be converted and written to disk
@@ -656,8 +676,17 @@ switch typ
       % use the triggers as specified in the cfg
       trigger = cfg.trigger.event;
     end
-    need_eeg_json = true;
-
+    if isequal(cfg.datatype, 'eeg')
+      need_eeg_json = true;
+    elseif isequal(cfg.datatype, 'ieeg')
+      need_ieeg_json = true;
+    elseif isequal(cfg.datatype, 'emg')
+      need_emg_json = true;
+    else
+      ft_warning('assuming that the dataset represents EEG');
+      need_eeg_json = true;
+    end
+    
   case 'raw'
     % the input data structure contains raw electrophysiology data
     if isequal(cfg.datatype, 'meg')
@@ -666,11 +695,13 @@ switch typ
       need_eeg_json = true;
     elseif isequal(cfg.datatype, 'ieeg')
       need_ieeg_json = true;
+    elseif isequal(cfg.datatype, 'emg')
+      need_emg_json = true;
     else
       ft_warning('assuming that the dataset represents EEG');
       need_eeg_json = true;
     end
-
+    
     hdr = ft_fetch_header(varargin{1});
     if strcmp(cfg.method, 'convert')
       % the data should be written to disk
@@ -691,15 +722,15 @@ switch typ
     catch
       need_electrodes_tsv = false;
     end
-
+    
     if ft_senstype(varargin{1}, 'ctf') || ft_senstype(varargin{1}, 'neuromag')
       % use the subsequent MEG-specific metadata handling for the JSON and TSV sidecar files
       typ = ft_senstype(varargin{1});
     end
-
+    
   case 'presentation_log'
     need_events_tsv = true;
-
+    
   otherwise
     % the file on disk contains raw electrophysiology data
     if isequal(cfg.datatype, 'meg')
@@ -708,11 +739,13 @@ switch typ
       need_eeg_json = true;
     elseif isequal(cfg.datatype, 'ieeg')
       need_ieeg_json = true;
+    elseif isequal(cfg.datatype, 'emg')
+      need_emg_json = true;
     else
       ft_warning('assuming that the dataset represents EEG');
       need_eeg_json = true;
     end
-
+    
     hdr = ft_read_header(cfg.headerfile, 'checkmaxfilter', false);
     if strcmp(cfg.method, 'convert')
       % the data should be converted and written to disk
@@ -724,12 +757,16 @@ switch typ
       % use the triggers as specified in the cfg
       trigger = cfg.trigger.event;
     end
-
+    
 end % switch typ
 
-need_events_tsv       = need_events_tsv || need_meg_json || need_eeg_json || need_ieeg_json || (need_mri_json && (contains(cfg.outputfile, 'task') || ~isempty(cfg.TaskName) || ~isempty(cfg.task)));
-need_channels_tsv     = need_meg_json || need_eeg_json || need_ieeg_json;
+need_events_tsv       = need_events_tsv || need_meg_json || need_eeg_json || need_ieeg_json || need_emg_json || (need_mri_json && (contains(cfg.outputfile, 'task') || ~isempty(cfg.TaskName) || ~isempty(cfg.task)));
+need_channels_tsv     = need_meg_json || need_eeg_json || need_ieeg_json || need_emg_json;
 need_coordsystem_json = need_meg_json; % FIXME this is also needed when EEG and iEEG electrodes are present
+
+if need_emg_json
+  ft_warning('EMG is not yet part of the official BIDS specification');
+end
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% get the defaults and user-specified settings for each possible sidecar file
@@ -740,6 +777,7 @@ mri_json         = [];
 meg_json         = [];
 eeg_json         = [];
 ieeg_json        = [];
+emg_json         = [];
 events_tsv       = [];
 channels_tsv     = [];
 electrodes_tsv   = [];
@@ -776,6 +814,11 @@ fn = fn(~cellfun(@isempty, regexp(fn, '^[A-Z].*|^iEEG')));
 ieeg_settings = keepfields(cfg.ieeg, fn);
 
 % make the relevant selection, all json fields start with a capital letter
+fn = fieldnames(cfg.emg);
+fn = fn(~cellfun(@isempty, regexp(fn, '^[A-Z].*')));
+emg_settings = keepfields(cfg.emg, fn);
+
+% make the relevant selection, all json fields start with a capital letter
 fn = fieldnames(cfg.coordsystem);
 fn = fn(~cellfun(@isempty, regexp(fn, '^[A-Z].*')));
 coordsystem_settings = keepfields(cfg.coordsystem, fn);
@@ -788,11 +831,11 @@ coordsystem_settings = keepfields(cfg.coordsystem, fn);
 %% need_mri_json
 if need_mri_json
   % start with the information from the DICOM header
-  mri_json = keepfields(dcm, fieldnames(mri_settings));
+  mri_json = keepfields(dcm, [fieldnames(mri_settings); fieldnames(generic_settings)]);
   % merge the information specified by the user with that from the data
   % in case fields appear in both, the first input overrules the second
-  mri_json = mergeconfig(mri_json, mri_settings, false);
-  mri_json = mergeconfig(mri_json, generic_settings, false);
+  mri_json = mergeconfig(mri_settings,     mri_json, false);
+  mri_json = mergeconfig(generic_settings, mri_json, false);
 end % if need_mri_json
 
 %% need_meg_json
@@ -819,17 +862,17 @@ if need_meg_json
     meg_json.Manufacturer             = 'CTF';
     meg_json.ManufacturersModelName   = 'CTF-275';
   elseif ft_senstype(hdr.grad, 'neuromag122')
-    meg_json.Manufacturer             = 'Neuromag/Elekta';
+    meg_json.Manufacturer             = 'Neuromag/Elekta/MEGIN';
     meg_json.ManufacturersModelName   = 'Neuromag-122';
   elseif ft_senstype(hdr.grad, 'neuromag306')
-    meg_json.Manufacturer             = 'Neuromag/Elekta';
+    meg_json.Manufacturer             = 'Neuromag/Elekta/MEGIN';
     % the ManufacturersModelName could be either Vectorview or Triux
   end
-
+  
   % merge the information specified by the user with that from the data
   % in case fields appear in both, the first input overrules the second
-  meg_json = mergeconfig(meg_json, meg_settings, false);
-  meg_json = mergeconfig(meg_json, generic_settings, false);
+  meg_json = mergeconfig(meg_settings,     meg_json, false);
+  meg_json = mergeconfig(generic_settings, meg_json, false);
 end % if need_meg_json
 
 %% need_eeg_json
@@ -843,11 +886,11 @@ if need_eeg_json
   eeg_json.MiscChannelCount           = sum(strcmp(hdr.chantype, 'misc') | strcmp(hdr.chantype, 'unknown'));
   eeg_json.RecordingDuration          = (hdr.nTrials*hdr.nSamples)/hdr.Fs;
   eeg_json.EpochLength                = hdr.nSamples/hdr.Fs;
-
+  
   % merge the information specified by the user with that from the data
   % in case fields appear in both, the first input overrules the second
-  eeg_json = mergeconfig(eeg_json, eeg_settings, false);
-  eeg_json = mergeconfig(eeg_json, generic_settings, false);
+  eeg_json = mergeconfig(eeg_settings,     eeg_json, false);
+  eeg_json = mergeconfig(generic_settings, eeg_json, false);
 end % if need_eeg_json
 
 %% need_ieeg_json
@@ -863,11 +906,26 @@ if need_ieeg_json
   ieeg_json.MiscChannelCount           = sum(strcmp(hdr.chantype, 'misc') | strcmp(hdr.chantype, 'unknown'));
   ieeg_json.RecordingDuration          = (hdr.nTrials*hdr.nSamples)/hdr.Fs;
   ieeg_json.EpochLength                = hdr.nSamples/hdr.Fs;
-
+  
   % merge the information specified by the user with that from the data
   % in case fields appear in both, the first input overrules the second
-  ieeg_json = mergeconfig(ieeg_json, ieeg_settings, false);
-  ieeg_json = mergeconfig(ieeg_json, generic_settings, false);
+  ieeg_json = mergeconfig(ieeg_settings,    ieeg_json, false);
+  ieeg_json = mergeconfig(generic_settings, ieeg_json, false);
+end
+
+%% need_emg_json
+if need_emg_json
+  emg_json.SamplingFrequency          = hdr.Fs;
+  emg_json.EOGChannelCount            = sum(strcmp(hdr.chantype, 'eog'));
+  emg_json.ECGChannelCount            = sum(strcmp(hdr.chantype, 'ecg'));
+  emg_json.EMGChannelCount            = sum(strcmp(hdr.chantype, 'emg'));
+  emg_json.RecordingDuration          = (hdr.nTrials*hdr.nSamples)/hdr.Fs;
+  emg_json.EpochLength                = hdr.nSamples/hdr.Fs;
+  
+  % merge the information specified by the user with that from the data
+  % in case fields appear in both, the first input overrules the second
+  emg_json = mergeconfig(emg_settings,     emg_json, false);
+  emg_json = mergeconfig(generic_settings, emg_json, false);
 end
 
 %% need_coordsystem_json
@@ -877,7 +935,7 @@ if need_coordsystem_json
     coordsystem_json.MEGCoordinateSystem            = 'CTF';
     coordsystem_json.MEGCoordinateUnits             = 'cm';
     coordsystem_json.MEGCoordinateSystemDescription = 'CTF head coordinates, orientation ALS, origin between the ears';
-
+    
     % coordinate system for head localization coils
     coordsystem_json.HeadCoilCoordinates                 = []; % see below
     coordsystem_json.HeadCoilCoordinateSystem            = 'CTF';
@@ -903,7 +961,7 @@ end % if need_coordsystem_json
 if need_channels_tsv
   % start with an empty table
   channels_tsv = table();
-
+  
   % ensure that all columns have the correct number of elements
   fn = setdiff(fieldnames(cfg.channels), 'writesidecar');
   for i=1:numel(fn)
@@ -919,13 +977,13 @@ if need_channels_tsv
       ft_error('incorrect specification of cfg.channels.%s', fn{i});
     end
   end
-
+  
   % these columns can be determined from the header
   channels_tsv.name                = merge_vector(hdr.label(:),    cfg.channels.name);
   channels_tsv.type                = merge_vector(hdr.chantype(:), cfg.channels.type);
   channels_tsv.units               = merge_vector(hdr.chanunit(:), cfg.channels.units);
   channels_tsv.sampling_frequency  = merge_vector(repmat(hdr.Fs, hdr.nChans, 1), cfg.channels.sampling_frequency);
-
+  
   % all other columns have to be specified by the user
   fn = setdiff(fieldnames(cfg.channels), {'writesidecar', 'name', 'type', 'unit', 'sampling_frequency'});
   for i=1:numel(fn)
@@ -941,7 +999,7 @@ end % if need_channels_tsv
 if need_electrodes_tsv
   % start with an empty table
   electrodes_tsv = table();
-
+  
   % ensure that all columns have the correct number of elements
   fn = setdiff(fieldnames(cfg.electrodes), 'writesidecar');
   for i=1:numel(fn)
@@ -957,13 +1015,13 @@ if need_electrodes_tsv
       ft_error('incorrect specification of cfg.electrodes.%s', fn{i});
     end
   end
-
+  
   % these columns can be determined from the header
   electrodes_tsv.name   = merge_vector(elec.label,        cfg.electrodes.name);
   electrodes_tsv.x      = merge_vector(elec.elecpos(:,1), cfg.electrodes.x);
   electrodes_tsv.y      = merge_vector(elec.elecpos(:,2), cfg.electrodes.y);
   electrodes_tsv.z      = merge_vector(elec.elecpos(:,3), cfg.electrodes.z);
-
+  
   % all other columns have to be specified by the user
   fn = setdiff(fieldnames(cfg.electrodes), {'writesidecar', 'name', 'x', 'y', 'z'});
   for i=1:numel(fn)
@@ -983,40 +1041,40 @@ if need_events_tsv
   else
     presentation = [];
   end
-
+  
   if need_mri_json
-
+    
     if isempty(presentation)
       ft_warning('cfg.presentationfile not specified, cannot determine events')
-
+      
       onset    = [];
       duration = [];
       events_tsv = table(onset, duration);
-
+      
     else
       % align the events from the presentation log file with the MR volumes
       % this requires one event per volume in the presentation file
-
+      
       % merge the information with the json sidecar file
       % in case fields appear in both, the first input overrules the second
       tmp = mergeconfig(mri_json, read_json(corresponding_json(cfg.outputfile)), false);
       assert(~isempty(tmp.RepetitionTime), 'you must specify cfg.mri.RepetitionTime');
-
+      
       % create a header structure that represents the fMRI timeseries
       hdr.Fs = 1/tmp.RepetitionTime;
       hdr.nSamples = mri.dim(4);
-
+      
       % create a event structure with one event for each fMRI volume
       volume = [];
       for i=1:hdr.nSamples
         volume(i).type   = 'volume';
         volume(i).sample = i;
       end
-
+      
       % find the presentation events corresponding to each volume
       selpres = select_event(presentation, cfg.presentation.eventtype, cfg.presentation.eventvalue);
       selpres = presentation(selpres);
-
+      
       ft_info('%d volumes, %d presentation events', length(volume), length(selpres));
       if length(volume)>length(selpres)
         % this happens when the scanner keeps running while presentation has already been stopped
@@ -1037,15 +1095,15 @@ if need_events_tsv
             ft_error('not enough volumes to match the presentation events');
         end % case
       end
-
+      
       %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
       % the following code is largely shared between the MEG and MRI section
       %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
+      
       % predict the sample number from the timestamp
       model     = polyfit([selpres.timestamp], [volume.sample], 1);
       estimated = polyval(model, [selpres.timestamp]);
-
+      
       if istrue(cfg.feedback)
         [p, f, x] = fileparts(cfg.dataset);
         figure('name', ['PRESENTATION - ' f]);
@@ -1057,13 +1115,13 @@ if need_events_tsv
         xlabel('presentation time (s)')
         ylabel('MRI volumes')
         legend({'observed', 'predicted'})
-
+        
         subplot(2,1,2)
         plot([selpres.timestamp]/1e4, ([volume.sample]-estimated)/hdr.Fs, 'g.')
         xlabel('presentation time (s)')
         ylabel('difference (s)')
       end
-
+      
       % estimate the time in seconds of all presentation events
       estimated = polyval(model, [presentation.timestamp]);
       estimated = round(1000*estimated)/1000; % round to three decimals
@@ -1075,18 +1133,18 @@ if need_events_tsv
       % rename the column to "volume" instead of "sample"
       sel = strcmp(presentation_tsv.Properties.VariableNames, 'sample');
       presentation_tsv.Properties.VariableNames{sel} = 'volume';
-
+      
       % for fMRI the presentation log file is the only source of events
       events_tsv = presentation_tsv;
       clear presentation_tsv selpres volume
-
+      
       % sort ascending on the onset of each event
       events_tsv = sortrows(events_tsv, 'onset');
     end
-
-  elseif need_meg_json || need_eeg_json || need_ieeg_json
+    
+  elseif need_meg_json || need_eeg_json || need_ieeg_json || need_emg_json
     % merge the events from the trigger channel with those from the (optional) presentation file
-
+    
     if istable(cfg.events.trl)
       % check that the column names are valid
       assert(strcmp(cfg.events.trl.Properties.VariableNames{1}, 'begsample'));
@@ -1113,20 +1171,20 @@ if need_events_tsv
       % convert the events from the dataset into a table
       events_tsv = event2table(hdr, trigger);
     end
-
+    
     if ~isempty(presentation) && ~isempty(trigger)
       % align the events from the presentation log file with the triggers
-
+      
       % select the correspopnding triggers and events in the presentation file
       seltrig = select_event(trigger,      cfg.trigger.eventtype,      cfg.trigger.eventvalue);
       selpres = select_event(presentation, cfg.presentation.eventtype, cfg.presentation.eventvalue);
       seltrig = trigger(seltrig);
       selpres = presentation(selpres);
-
+      
       %if length(seltrig)~=length(selpres)
       %  ft_error('inconsistent number: %d triggers, %d presentation events', length(seltrig), length(selpres));
       %end
-
+      
       ft_info('%d triggers, %d presentation events', length(seltrig), length(selpres));
       if length(seltrig)>length(selpres)
         % don't know how to solve this
@@ -1147,15 +1205,15 @@ if need_events_tsv
             ft_error('not enough triggers to match the presentation events');
         end % case
       end
-
+      
       %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
       % the following code is largely shared between the MEG and MRI section
       %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
+      
       % predict the presentation sample number from the presentation timestamp
       model     = polyfit([selpres.timestamp], [seltrig.sample], 1);
       estimated = polyval(model, [selpres.timestamp]);
-
+      
       if istrue(cfg.feedback)
         [~, f, ~] = fileparts(cfg.dataset);
         figure('name', ['PRESENTATION - ' f]);
@@ -1167,13 +1225,13 @@ if need_events_tsv
         xlabel('presentation time (s)')
         ylabel('data samples')
         legend({'observed', 'predicted'})
-
+        
         subplot(2,1,2)
         plot([selpres.timestamp]/1e4, ([seltrig.sample]-estimated)/hdr.Fs, 'g.')
         xlabel('presentation time (s)')
         ylabel('difference (s)')
       end
-
+      
       % estimate the sample number and time in seconds of all presentation events
       estimated = polyval(model, [presentation.timestamp]);
       estimated = round(estimated); % round to the nearest sample
@@ -1182,7 +1240,7 @@ if need_events_tsv
       end
       % convert the event structure to a TSV table
       presentation_tsv = event2table(hdr, presentation);
-
+      
       % the events from the the presentation log file should be merged with the triggers
       % trigger values are often numeric, whereas presentation event values are often strings
       if isnumeric(events_tsv.value) && ~isnumeric(presentation_tsv.value)
@@ -1191,10 +1249,10 @@ if need_events_tsv
       end
       % concatenate them
       events_tsv = [events_tsv; presentation_tsv];
-
+      
       clear presentation_tsv selpres seltrig
     end
-
+    
   elseif need_events_tsv
     % convert the presentation structure to a TSV table
     events_tsv = struct2table(presentation);
@@ -1211,14 +1269,14 @@ if need_events_tsv
     order = [order find(strcmp(events_tsv.Properties.VariableNames, 'duration'))];
     order = [order setdiff(1:numel(events_tsv.Properties.VariableNames), order)];
     events_tsv = events_tsv(:,order);
-
+    
   end
-
+  
   if ~isempty(events_tsv) && isfield(events_tsv, 'offset')
     % sort the events ascending on the onset
     events_tsv = sortrows(events_tsv, 'onset');
   end
-
+  
 end % if need_events_tsv
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -1227,7 +1285,7 @@ end % if need_events_tsv
 switch cfg.method
   case 'decorate'
     % there is nothing to do here
-
+    
   case 'convert'
     % the output depends on the type of input data
     switch typ
@@ -1268,13 +1326,13 @@ switch cfg.method
         end
         ft_info('writing %s\n', cfg.outputfile);
         ft_write_mri(cfg.outputfile, mri, 'dataformat', 'nifti');
-
+        
       case {'presentation_log'}
         % do not write data, but only write the events.tsv file
-
+        
       case {'ctf_ds', 'ctf_meg4', 'ctf_res4', 'ctf151', 'ctf275', 'neuromag_fif', 'neuromag122', 'neuromag306'}
         ft_error('please use a system specific tool for converting MEG datasets');
-
+        
       otherwise
         [p, f, x] = fileparts(cfg.outputfile);
         if ~isequal(x, '.vhdr')
@@ -1283,33 +1341,36 @@ switch cfg.method
         ft_info('writing %s\n', cfg.outputfile);
         ft_write_data(cfg.outputfile, dat, 'dataformat', 'brainvision_eeg', 'header', hdr, 'event', trigger);
     end % switch typ
-
+    
   case 'copy'
     [~, ~, xin] = fileparts(cfg.dataset);
     [p, ~, xout] = fileparts(cfg.outputfile);
     if ~strcmp(xin, xout)
       ft_error('input and output filename extension do not match');
     end
-
+    
     switch typ
+      case {'dicom'}
+        ft_error('DICOM files must be converted to NIfTI for BIDS compliance');
+        
       case {'ctf_ds', 'ctf_meg4', 'ctf_res4', 'ctf151', 'ctf275'}
         % the data consists of a directory with multiple files inside
         ft_info('copying %s to %s\n', cfg.dataset, cfg.outputfile);
         isdir_or_mkdir(p);
         copy_ctf_files(cfg.dataset, cfg.outputfile, false);
-
+        
       case {'brainvision_vhdr', 'brainvision_vmrk', 'brainvision_eeg', 'brainvision_dat', 'brainvision_seg'}
         % the data consists of three files and the header file contains pointers to the markers and data
         ft_info('copying %s to %s\n', cfg.dataset, cfg.outputfile);
         isdir_or_mkdir(p);
         copy_brainvision_files(cfg.dataset, cfg.outputfile, false);
-
+        
       otherwise
         ft_info('copying %s to %s\n', cfg.dataset, cfg.outputfile);
         isdir_or_mkdir(p);
         copyfile(cfg.dataset, cfg.outputfile);
     end
-
+    
   otherwise
     ft_error('unsupported value for cfg.method')
 end % switch method
@@ -1324,6 +1385,7 @@ mri_json  = remove_empty(mri_json);
 meg_json  = remove_empty(meg_json);
 eeg_json  = remove_empty(eeg_json);
 ieeg_json = remove_empty(ieeg_json);
+emg_json  = remove_empty(emg_json);
 
 if ~isempty(mri_json)
   filename = corresponding_json(cfg.outputfile);ls
@@ -1422,6 +1484,31 @@ if ~isempty(ieeg_json)
       % do nothing
     otherwise
       ft_error('incorrect option for cfg.ieeg.writesidecar');
+  end % switch
+end
+
+if ~isempty(emg_json)
+  filename = corresponding_json(cfg.outputfile);
+  if isfile(filename)
+    existing = read_json(filename);
+  else
+    existing = [];
+  end
+  switch cfg.emg.writesidecar
+    case 'yes'
+      if ~isempty(existing)
+        ft_warning('not overwriting the existing and non-empty file ''%s''', filename);
+      else
+        write_json(filename, emg_json);
+      end
+    case 'replace'
+      write_json(filename, emg_json);
+    case 'merge'
+      write_json(filename, mergeconfig(emg_json, existing, false));
+    case 'no'
+      % do nothing
+    otherwise
+      ft_error('incorrect option for cfg.emg.writesidecar');
   end % switch
 end
 
@@ -1557,7 +1644,7 @@ if ~isempty(cfg.bidsroot)
   % update the dataset_description
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   filename = fullfile(cfg.bidsroot, 'dataset_description.json');
-
+  
   if isfile(filename)
     existing = read_json(filename);
   else
@@ -1579,12 +1666,12 @@ if ~isempty(cfg.bidsroot)
     otherwise
       ft_error('incorrect option for cfg.dataset_description.writesidecar');
   end % switch
-
+  
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   % update the participants.tsv
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   filename = fullfile(cfg.bidsroot, 'participants.tsv');
-
+  
   this = table();
   this.participant_id = ['sub-' cfg.sub];
   fn = fieldnames(cfg.participants);
@@ -1594,17 +1681,17 @@ if ~isempty(cfg.bidsroot)
     % write boolean as 'True' or 'False'
     this.(fn{i}) = output_compatible(cfg.participants.(fn{i}));
   end
-
+  
   if isfile(filename)
     participants = read_tsv(filename);
     participants = merge_table(participants, this, 'participant_id');
   else
     participants = this;
   end
-
+  
   % write the updated file back to disk
   write_tsv(filename, participants);
-
+  
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   % update the scans.tsv
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -1615,10 +1702,10 @@ if ~isempty(cfg.bidsroot)
     % construct the output filename, without session directory
     filename = fullfile(cfg.bidsroot, ['sub-' cfg.sub], ['sub-' cfg.sub '_scans.tsv']);
   end
-
+  
   this = table();
   [~, f, x] = fileparts(cfg.outputfile);
-  this.filename = fullfile(cfg.datatype, [f x]);
+  this.filename = fullfile(datatype2dirname(cfg.datatype), [f x]);
   fn = fieldnames(cfg.scans);
   for i=1:numel(fn)
     % write [] as 'n/a'
@@ -1626,17 +1713,17 @@ if ~isempty(cfg.bidsroot)
     % write boolean as 'True' or 'False'
     this.(fn{i}) = output_compatible(cfg.scans.(fn{i}));
   end
-
+  
   if isfile(filename)
     scans = read_tsv(filename);
     scans = merge_table(scans, this, 'filename');
   else
     scans = this;
   end
-
+  
   % write the updated file back to disk
   write_tsv(filename, scans);
-
+  
 end
 
 % do not return an output variable if not requested
@@ -1683,7 +1770,7 @@ function f = add_datatype(f, typ)
 f = [f '_' typ];
 
 function f = remove_datatype(f)
-typ = {'FLAIR', 'FLASH', 'PD', 'PDT2', 'PDmap', 'T1map', 'T1rho', 'T1w', 'T2map', 'T2star', 'T2w', 'angio', 'bold', 'bval', 'bvec', 'channels', 'coordsystem', 'defacemask', 'dwi', 'eeg', 'epi', 'events', 'fieldmap', 'headshape', 'ieeg', 'inplaneT1', 'inplaneT2', 'magnitude', 'magnitude1', 'magnitude2', 'meg', 'phase1', 'phase2', 'phasediff', 'photo', 'physio', 'sbref', 'stim'};
+typ = {'FLAIR', 'FLASH', 'PD', 'PDT2', 'PDmap', 'T1map', 'T1rho', 'T1w', 'T2map', 'T2star', 'T2w', 'angio', 'bold', 'bval', 'bvec', 'channels', 'coordsystem', 'defacemask', 'dwi', 'eeg', 'epi', 'events', 'fieldmap', 'headshape', 'ieeg', 'inplaneT1', 'inplaneT2', 'magnitude', 'magnitude1', 'magnitude2', 'meg', 'phase1', 'phase2', 'phasediff', 'photo', 'physio', 'sbref', 'stim', 'emg'};
 for i=1:numel(typ)
   if endsWith(f, ['_' typ{i}])
     f = f(1:end-length(typ{i})-1); % also the '_'
@@ -1795,7 +1882,7 @@ fclose(fid);
 function filename = corresponding_json(filename)
 [p, f, x] = fileparts(filename);
 if isequal(x, '.gz') && endsWith(f, '.nii')
-  % it is a gzip compressed nifti file, remove the .nii from the file name
+  % it is a gzip compressed NIfTI file, remove the .nii from the file name
   f = f(1:end-4);
 end
 filename = fullfile(p, [f '.json']);
@@ -1888,6 +1975,8 @@ switch typ
     dir = 'eeg';
   case {'ieeg'} % this could also include 'channels' 'photo' 'coordsystem'
     dir = 'ieeg';
+  case {'emg'} % this could also include 'channels'
+    dir = 'emg';
   otherwise
     ft_error('unrecognized data type "%s"', typ);
 end

--- a/test/test_issue1196.m
+++ b/test/test_issue1196.m
@@ -70,14 +70,16 @@ cfg.SoftwareVersions = 'n/a';
 cfg.emg.PowerLineFrequency = 50;
 % cfg.emg.HardwareFilters
 % cfg.emg.SoftwareFilters
-cfg.emg.EMGChannelCount = 2;
-cfg.emg.EOGChannelCount = pi;
-cfg.emg.ECGChannelCount = 42;
+% cfg.emg.EMGChannelCount
+% cfg.emg.EOGChannelCount
+% cfg.emg.ECGChannelCount
+cfg.emg.MiscChannelCount = 2; % Resp and HR
+
 cfg.emg.ElectrodeManufacturer = 'Kendall';
 cfg.emg.ElectrodeManufacturersModelName = 'schuim, 24mm';
-% cfg.emg.EMGPlacementScheme
-% cfg.emg.EMGReference
-% cfg.emg.EMGGround
+cfg.emg.EMGPlacementScheme = 'unknown';
+cfg.emg.EMGReference = 'somewhere';
+cfg.emg.EMGGround = 'else';
 
 cfg.method = 'copy'; % no need to convert
 cfg.dataset = emgfile;

--- a/test/test_issue1196.m
+++ b/test/test_issue1196.m
@@ -1,0 +1,88 @@
+function test_issue1196
+
+% MEM 2gb
+% WALLTIME 00:20:00
+% DEPENDENCY data2bids
+
+cd(dccnpath('/home/common/matlab/fieldtrip/data/test/issue1196'));
+
+if isfolder('/home/common/matlab/fieldtrip/data/test/issue1196/bids')
+  system('rm -rf /home/common/matlab/fieldtrip/data/test/issue1196/bids');
+end
+
+%%
+
+emgfile = 'raw/006_3013065.02_rest1.vhdr';
+t1wfile = 'raw/sub-139075/015-T1w_MPR/00175_1.3.12.2.1107.5.2.43.66068.2019080415440698293169043.IMA'; % any slice is fine
+t2wfile = 'raw/sub-139075/017-T2w_SPC/00011_1.3.12.2.1107.5.2.43.66068.2019080415500178296969403.IMA';
+
+%%
+% the first part is general to the different recordings
+
+cfg = [];
+cfg.bidsroot = 'bids';
+cfg.sub = '139075';
+cfg.ses = 'mri'; % all data was recorded in a single MRI session
+
+cfg.InstitutionName             = 'Radboud University';
+cfg.InstitutionalDepartmentName = 'Donders Institute for Brain, Cognition and Behaviour';
+cfg.InstitutionAddress          = 'Kapittelweg 29, 6525 EN, Nijmegen, The Netherlands';
+
+% REQUIRED
+cfg.dataset_description.Name                = 'n/a';
+cfg.dataset_description.BIDSVersion         = '1.2';
+% OPTIONAL
+cfg.dataset_description.License             = 'n/a';
+cfg.dataset_description.Authors             = 'n/a';
+cfg.dataset_description.Acknowledgements    = 'n/a';
+cfg.dataset_description.Funding             = 'n/a';
+cfg.dataset_description.ReferencesAndLinks  = 'n/a';
+cfg.dataset_description.DatasetDOI          = 'n/a';
+
+%%
+% convert the T1w dicom files
+
+cfg.dataset = t1wfile;
+cfg.datatype = 'T1w';
+data2bids(cfg);
+
+%%
+% convert the T2w dicom files
+
+cfg.dataset = t2wfile;
+cfg.datatype = 'T2w';
+data2bids(cfg);
+
+%%
+% copy the EMG
+
+% these are general fields and need to be added for EMG
+% for MRI they can (hopefully) be read from the DICOM headers
+cfg.Manufacturers = 'BrainProducts';
+cfg.ManufacturersModelName = 'BrainAmp MR plus';
+cfg.DeviceSerialNumber = 'n/a';
+cfg.SoftwareVersions = 'n/a';
+
+% FIXME we should agree upon the metadata fields for the JSON
+% cfg.emg.SamplingFrequency         % this will be determined from the file
+% cfg.emg.RecordingDuration         % this will be determined from the file, in seconds
+% cfg.emg.RecordingType             % this will probably be determined from the file, continuous
+cfg.emg.PowerLineFrequency = 50;
+% cfg.emg.HardwareFilters
+% cfg.emg.SoftwareFilters
+cfg.emg.EMGChannelCount = 2;
+cfg.emg.EOGChannelCount = pi;
+cfg.emg.ECGChannelCount = 42;
+cfg.emg.ElectrodeManufacturer = 'Kendall';
+cfg.emg.ElectrodeManufacturersModelName = 'schuim, 24mm';
+% cfg.emg.EMGPlacementScheme
+% cfg.emg.EMGReference
+% cfg.emg.EMGGround
+
+cfg.method = 'copy'; % no need to convert
+cfg.dataset = emgfile;
+cfg.datatype = 'emg';
+
+data2bids(cfg);
+
+


### PR DESCRIPTION
- small improvements for eeg and ieeg handling in data2bids
- changed the precedence of fields for the JSON file: user-supplied fields replace those obtained from the data file (esp relevant for DICOM)
- added support for EMG data type, similar to other electrophys formats