### PR TITLE
general improvements to data2bids

### DIFF
--- a/fileio/private/read_presentation_log.m
+++ b/fileio/private/read_presentation_log.m
@@ -89,10 +89,17 @@ end
 numevent  = size(table1,1);
 type      = table1.event_type;
 value     = table1.code;
-sample    = num2cell(nan(numevent, 1));
-timestamp = num2cell(table1.time);
+sample    = nan(numevent, 1);
+timestamp = table1.time;
 duration  = cell(numevent, 1); % num2cell(table1.duration); % don't put the duration values in, because the units are non-defined
 offset    = cell(numevent, 1);
+
+if isnumeric(type),       type = num2cell(type); end
+if isnumeric(value),      value = num2cell(value); end
+if isnumeric(sample),     sample = num2cell(sample); end
+if isnumeric(timestamp),  timestamp = num2cell(timestamp); end
+if isnumeric(duration),   duration = num2cell(duration); end
+if isnumeric(offset),     offset = num2cell(offset); end
 
 event = struct('type', type, 'value', value, 'sample', sample, 'timestamp', timestamp, 'offset', offset, 'duration', duration);
 

--- a/private/merge_table.m
+++ b/private/merge_table.m
@@ -31,8 +31,14 @@ function t3 = merge_table(t1, t2, key)
 %
 % $Id$
 
+% deal with the easy cases
 if isequal(t1, t2)
-  % this is easy
+  t3 = t1;
+  return
+elseif isempty(t1)
+  t3 = t2;
+  return
+elseif isempty(t2)
   t3 = t1;
   return
 end

--- a/private/merge_table.m
+++ b/private/merge_table.m
@@ -5,6 +5,8 @@ function t3 = merge_table(t1, t2, key)
 % same row and column is also present in the 1st.
 %
 % Use as
+%   t3 = merge_table(t1, t2)
+% or
 %   t3 = merge_table(t1, t2, key)
 %
 % See also TABLE
@@ -29,97 +31,153 @@ function t3 = merge_table(t1, t2, key)
 %
 % $Id$
 
-assert(nargin==3);
+if isequal(t1, t2)
+  % this is easy
+  t3 = t1;
+  return
+end
 
-c1 = t1.Properties.VariableNames;
-c2 = t2.Properties.VariableNames;
-
-assert(contains(key, c1));
-assert(contains(key, c2));
-
-[m1, n1] = size(t1);
-[m2, n2] = size(t2);
-
-for i=1:n1
-  if ischar(t1{1,i})
-    t1.(c1{i}) = cellstr(t1{:,i});
-  elseif isnumeric(t1{1,i})
-    t1.(c1{i}) = num2cell(t1{:,i});
+if nargin==2
+  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  % merge by comparing the complete rows
+  
+  assert(isequal(t1.Properties.VariableNames, t2.Properties.VariableNames));
+  
+  [m1, n1] = size(t1);
+  [m2, n2] = size(t2);
+  
+  % the unique function fails on tables if the values are mixed, e.g. empty, scalars, and strings
+  % the following compares every row by computing a hash for it.
+  
+  h1 = cell(m1,1);
+  for i=1:m1
+    h1{i} = ft_hash(t1(i,:));
   end
-end
-
-for i=1:n2
-  if ischar(t2{1,i})
-    t2.(c2{i}) = cellstr(t2{:,i});
-  elseif isnumeric(t2{1,i})
-    t2.(c2{i}) = num2cell(t2{:,i});
+  h2 = cell(m2,1);
+  for i=1:m2
+    h2{i} = ft_hash(t2(i,:));
   end
-end
-
-t3 = table();
-
-% deal with the columns that are present in both inputs
-col = intersect(c1, c2);
-
-for i=1:numel(col)
-  % copy the existing column from t1 into t3
-  t3.(col{i}) = t1.(col{i});
-end
-
-for j=1:m2
-  row = findkey(t1.(key), t2.(key){j});
-  if ~any(row)
-    % add an empty row to t3
-    row = size(t3,1)+1;
-    try
-      % on MATLAB R2019a it is required to add a complete empty row first
-      t3(row,:) = cell(1, size(t3,2));
-    catch
-      % on MATLAB R2016b it is not possible to add an empty row, but looping over columns works fine
+  
+  [c, i1, i2] = union(h1, h2, 'stable');
+  t3 = cat(1, t1(i1,:), t2(i2,:));
+  
+  %     match = true(m2,1);
+  %
+  %     for j2=1:m2
+  %       for j1=1:m1
+  %         match(j2) = isequal(t1(j1,:), t2(j2,:));
+  %       end
+  %     end
+  %
+  %     t3 = cat(1, t1, t2(~match,:));
+  
+elseif nargin==3
+  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  % merge using the specific key
+  
+  c1 = t1.Properties.VariableNames;
+  c2 = t2.Properties.VariableNames;
+  
+  assert(contains(key, c1));
+  assert(contains(key, c2));
+  
+  [m1, n1] = size(t1);
+  [m2, n2] = size(t2);
+  
+  % don't try to merge if one of them is empty
+  if m1==0 && m2>0
+    t3 = t2;
+    return
+  elseif m1>0 && m2==0
+    t3 = t2;
+    return
+  end
+  
+  for i=1:n1
+    if ischar(t1{1,i})
+      t1.(c1{i}) = cellstr(t1{:,i});
+    elseif isnumeric(t1{1,i})
+      t1.(c1{i}) = num2cell(t1{:,i});
     end
   end
-  for i=1:numel(col)
-    % this also adds the row (when required) for R2016b
-    t3(row, col{i}) = t2(j, col{i});
+  
+  for i=1:n2
+    if ischar(t2{1,i})
+      t2.(c2{i}) = cellstr(t2{:,i});
+    elseif isnumeric(t2{1,i})
+      t2.(c2{i}) = num2cell(t2{:,i});
+    end
   end
-end
-
-n3 = size(t3,1);
-
-% deal with the columns that are only present in the 1st input
-col = setdiff(c1, c2);
-
-for i=1:numel(col)
-  % add an empty column to t3
-  t3.(col{i}) = cell(n3, 1);
-end
-
-for j=1:m1
-  row = findkey(t3.(key), t1.(key){j});
+  
+  t3 = table();
+  
+  % deal with the columns that are present in both inputs
+  col = intersect(c1, c2);
+  
   for i=1:numel(col)
-    t3(row, col{i}) = t1(j, col{i});
+    % copy the existing column from t1 into t3
+    t3.(col{i}) = t1.(col{i});
   end
-end
-
-% deal with the columns that are only present in the 2nd input
-col = setdiff(c2, c1);
-
-for i=1:numel(col)
-  % add an empty column to t3
-  t3.(col{i}) = cell(n3, 1);
-end
-
-for j=1:m2
-  row = findkey(t3.(key), t2.(key){j});
+  
+  for j=1:m2
+    row = findkey(t1.(key), t2.(key){j});
+    if ~any(row)
+      % add an empty row to t3
+      row = size(t3,1)+1;
+      try
+        % on MATLAB R2019a it is required to add a complete empty row first
+        t3(row,:) = cell(1, size(t3,2));
+      catch
+        % on MATLAB R2016b it is not possible to add an empty row, but looping over columns works fine
+      end
+    end
+    for i=1:numel(col)
+      % this also adds the row (when required) for R2016b
+      t3(row, col{i}) = t2(j, col{i});
+    end
+  end
+  
+  n3 = size(t3,1);
+  
+  % deal with the columns that are only present in the 1st input
+  col = setdiff(c1, c2);
+  
   for i=1:numel(col)
-    t3(row, col{i}) = t2(j, col{i});
+    % add an empty column to t3
+    t3.(col{i}) = cell(n3, 1);
   end
-end
-
-% reorder the columns to match the input
-c3 = unique(cat(2, c1, c2), 'stable');
-[c3, ia, ib] = intersect(c3, t3.Properties.VariableNames, 'stable');
-t3 = t3(:,ib);
+  
+  for j=1:m1
+    row = findkey(t3.(key), t1.(key){j});
+    for i=1:numel(col)
+      t3(row, col{i}) = t1(j, col{i});
+    end
+  end
+  
+  % deal with the columns that are only present in the 2nd input
+  col = setdiff(c2, c1);
+  
+  for i=1:numel(col)
+    % add an empty column to t3
+    t3.(col{i}) = cell(n3, 1);
+  end
+  
+  for j=1:m2
+    row = findkey(t3.(key), t2.(key){j});
+    for i=1:numel(col)
+      t3(row, col{i}) = t2(j, col{i});
+    end
+  end
+  
+  % reorder the columns to match the input
+  c3 = unique(cat(2, c1, c2), 'stable');
+  [c3, ia, ib] = intersect(c3, t3.Properties.VariableNames, 'stable');
+  t3 = t3(:,ib);
+  
+else
+  ft_error('incorrect number of input arguments');
+  
+end % if nargin
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/test/test_data2bids.m
+++ b/test/test_data2bids.m
@@ -231,43 +231,5 @@ cfg.RepetitionTime              = 2;
 
 data2bids(cfg);
 
-%%
-cd(dccnpath('/home/common/matlab/fieldtrip/data/test/data2bids/eeglab'));
-
-% the following uses a dataset that originates from the EEGLAB website
-% wget --no-check-certificate https://sccn.ucsd.edu/mediawiki/images/9/9c/Eeglab_data.set
-
-age = [11  96  nan 77  82  87  18 40  26  80];
-sex = {'f' [] 'f' 'f' 'f' 'm' 'm' 'm' 'm' 'm'};
-
-sub = {'01', '02', '03', '04', '05', '06', '07', '08', '09', '10'};
-ses = {'pre', 'post'};
-run = {1, 2};
-
-for subindx=1:numel(sub)
-  for sesindx=1:numel(ses)
-    for runindx=1:numel(run)
-      
-      cfg = [];
-      cfg.dataset   = 'sourcedata/Eeglab_data.set';
-      cfg.datatype  = 'eeg';
-      
-      cfg.participants.age = age(subindx);
-      cfg.participants.sex = sex{subindx};
-      
-      cfg.scans.acq_time = datestr(now, 'yyyy-mm-ddThh:MM:SS'); % RFC3339
-      
-      cfg.InstitutionName             = 'Radboud University';
-      cfg.InstitutionalDepartmentName = 'Donders Institute for Brain, Cognition and Behaviour';
-      
-      cfg.bidsroot  = 'bids';
-      cfg.sub       = sub{subindx};
-      cfg.ses       = ses{sesindx};
-      cfg.run       = run{runindx};
-      data2bids(cfg);
-      
-    end % for run
-  end % for ses
-end % for sub
 
 

--- a/test/test_data2bids.m
+++ b/test/test_data2bids.m
@@ -166,6 +166,8 @@ cfg.bidsroot = 'human_ecog';
 cfg.sub = 'UCI29';
 cfg.task = 'attention';
 cfg.datatype = 'ieeg';
+cfg.coordsystem.iEEGCoordinateSystem = 'ACPC';
+cfg.coordsystem.iEEGCoordinateSystemDescription = 'electrodes were aligned with ACPC and projected on the cortex hull';
 data2bids(cfg, data);
 
 cfg = [];

--- a/utilities/dccnpath.m
+++ b/utilities/dccnpath.m
@@ -53,6 +53,12 @@ alternative1 = [f x]; % this should not be used when it is only "test", since th
 alternative2 = strrep(filename, '/home/common/matlab/fieldtrip', '/Volumes/home/common/matlab/fieldtrip');
 alternative3 = strrep(filename, '/home/common/matlab/fieldtrip', '/Volumes/128GB/data/test');
 
+% exist(alternative1, 'file') returns 7 in case the present working directory matches alternative1
+if endsWith(pwd, alternative1)
+  % it is not a valid match
+  alternative1 = '';
+end
+
 if ~exist(file, 'file') && exist(alternative1, 'file') && ~strcmp(alternative1, 'test')
   warning('using local copy %s instead of %s', alternative1, file);
   file = alternative1;
@@ -63,4 +69,3 @@ elseif ~exist(file, 'file') && exist(alternative3, 'file')
   warning('using local copy %s instead of %s', alternative3, file);
   file = alternative3;
 end
-

--- a/utilities/ft_hash.m
+++ b/utilities/ft_hash.m
@@ -10,7 +10,7 @@ ft_hastoolbox('fileexchange', 1);
 
 try
   % this one uses a mex file
-  if isstruct(s) || iscell(s)
+  if isstruct(s) || iscell(s) || istable(s)
     h = CalcMD5(mxSerialize(s));
   else
     h = CalcMD5(s);


### PR DESCRIPTION
This makes the code much more consistent, handling of JSON and TSV is done in the same way. Subfields of the configuration (e.g. `cfg.mri` and `cfg.events`) are now exclusively used for the JSON and TSV information, and do not contain options that are only used in `data2bids`. 

I tried testing it with all test scripts, but it is important to do that once more with the regular dashboard test batch after merging.

 