### PR TITLE
add support for BIDS data represented in tsv/json files  

### DIFF
--- a/fileio/ft_filetype.m
+++ b/fileio/ft_filetype.m
@@ -1425,6 +1425,11 @@ elseif filetype_check_extension(filename, '.tck')
   type = 'mrtrix_tck';
   manufacturer = 'Mrtrix';
   content = 'tractography data';  
+elseif exist(fullfile(p, [f '.tsv']), 'file') && exist(fullfile(p, [f '.json']), 'file')
+  % BIDS uses tsv and json file pairs for behavioral and physiological data
+  type = 'bids_tsv';
+  manufacturer = 'BIDS';
+  content = 'timeseries data';  
 end
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/fileio/ft_read_data.m
+++ b/fileio/ft_read_data.m
@@ -1,8 +1,8 @@
 function [dat] = ft_read_data(filename, varargin)
 
-% FT_READ_DATA reads electrophysiological data from a variety of EEG, MEG and LFP
-% files and represents it in a common data-independent format. The supported formats
-% are listed in the accompanying FT_READ_HEADER function.
+% FT_READ_DATA reads data from a variety of EEG, MEG and other time series data files
+% and represents it in a common data-independent format. The supported formats are
+% listed in the accompanying FT_READ_HEADER function.
 %
 % Use as
 %   dat = ft_read_data(filename, ...)
@@ -29,15 +29,14 @@ function [dat] = ft_read_data(filename, varargin)
 % Nchans*Nsamples*Ntrials for epoched or trial-based data when begtrial
 % and endtrial are specified.
 %
-% The list of supported file formats can be found in FT_READ_HEADER.
-%
-% To use an external reading function, you can specify the function name as argument
-% to 'dataformat'. The function needs to be on the path, and should take as input:
-% filename, hdr, begsample, endsample, chanindx.
+% To use an external reading function, you can specify a function as the 'dataformat'
+% option. This function should take five input arguments: filename, hdr, begsample,
+% endsample, chanindx. Please check the code of this function for details, and search
+% for BIDS_TSV as example.
 %
 % See also FT_READ_HEADER, FT_READ_EVENT, FT_WRITE_DATA, FT_WRITE_EVENT
 
-% Copyright (C) 2003-2018 Robert Oostenveld
+% Copyright (C) 2003-2019 Robert Oostenveld
 %
 % This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
 % for the documentation and details.
@@ -1468,6 +1467,7 @@ switch dataformat
     % this allows the user to specify an external reading function
     % if it fails, the regular unsupported warning message is thrown
     try
+      % this is used for bids_tsv, biopac_acq, motion_c3d, qualisys_tsv, and possibly others
       dat = feval(dataformat, filename, hdr, begsample, endsample, chanindx);
     catch
       if strcmp(fallback, 'biosig') && ft_hastoolbox('BIOSIG', 1)

--- a/fileio/ft_read_data.m
+++ b/fileio/ft_read_data.m
@@ -1416,6 +1416,17 @@ switch dataformat
   case 'spmeeg_mat'
     dat = read_spmeeg_data(filename, 'header', hdr, 'begsample', begsample, 'endsample', endsample, 'chanindx', chanindx);
     
+  case 'smi_txt'
+    if isfield(hdr.orig, 'trigger')
+      % this is inefficient, since it keeps the complete data in memory
+      % but it does speed up subsequent read operations without the user
+      % having to care about it
+      smi = hdr.orig;
+    else
+      smi = read_smi_txt(filename);
+    end
+    dat = smi.dat(chanindx,begsample:endsample);
+  
   case 'tmsi_poly5'
     blocksize = hdr.orig.header.SamplePeriodsPerBlock;
     begtrial = floor((begsample-1)/blocksize) + 1;

--- a/fileio/ft_read_event.m
+++ b/fileio/ft_read_event.m
@@ -1,9 +1,8 @@
 function [event] = ft_read_event(filename, varargin)
 
-% FT_READ_EVENT reads all events from an EEG/MEG dataset and returns
-% them in a well defined structure. It is a wrapper around different
-% EEG/MEG file importers, directly supported formats are CTF, Neuromag,
-% EEP, BrainVision, Neuroscan, Neuralynx and Nervus/Nicolet.
+% FT_READ_EVENT reads all events from an EEG, MEG or other time series dataset and
+% returns them in a common data-independent structure. The supported formats are
+% listed in the accompanying FT_READ_HEADER function.
 %
 % Use as
 %   [event] = ft_read_event(filename, ...)
@@ -22,22 +21,6 @@ function [event] = ft_read_event(filename, varargin)
 %   'tolerance'      tolerance in samples when merging analogue trigger channels, only for Neuromag (default = 1, meaning
 %                    that an offset of one sample in both directions is compensated for)
 %
-% Furthermore, you can specify optional arguments as key-value pairs
-% for filtering the events, e.g. to select only events of a specific
-% type, of a specific value, or events between a specific begin and
-% end sample. This event filtering is especially usefull for real-time
-% processing. See FT_FILTER_EVENT for more details.
-%
-% Some data formats have trigger channels that are sampled continuously with
-% the same rate as the electrophysiological data. The default is to detect
-% only the up-going TTL flanks. The trigger events will correspond with the
-% first sample where the TTL value is up. This behavior can be changed
-% using the 'detectflank' option, which also allows for detecting the
-% down-going flank or both. In case of detecting the down-going flank, the
-% sample number of the event will correspond with the first sample at which
-% the TTF went down, and the value will correspond to the TTL value just
-% prior to going down.
-%
 % This function returns an event structure with the following fields
 %   event.type      = string
 %   event.sample    = expressed in samples, the first sample of a recording is 1
@@ -46,11 +29,29 @@ function [event] = ft_read_event(filename, varargin)
 %   event.duration  = expressed in samples
 %   event.timestamp = expressed in timestamp units, which vary over systems (optional)
 %
-% The event type and sample fields are always defined, other fields can be empty,
-% depending on the type of event file. Events are sorted by the sample on
-% which they occur. After reading the event structure, you can use the
-% following tricks to extract information about those events in which you
-% are interested.
+% You can specify optional arguments as key-value pairs for filtering the events,
+% e.g. to select only events of a specific type, of a specific value, or events
+% between a specific begin and end sample. This event filtering is especially usefull
+% for real-time processing. See FT_FILTER_EVENT for more details.
+%
+% Some data formats have trigger channels that are sampled continuously with the same
+% rate as the electrophysiological data. The default is to detect only the up-going
+% TTL flanks. The trigger events will correspond with the first sample where the TTL
+% value is up. This behavior can be changed using the 'detectflank' option, which
+% also allows for detecting the down-going flank or both. In case of detecting the
+% down-going flank, the sample number of the event will correspond with the first
+% sample at which the TTF went down, and the value will correspond to the TTL value
+% just prior to going down.
+%
+% To use an external reading function, you can specify a function as the
+% 'eventformat' option. This function should take the filename  and the headeras
+% input arguments. Please check the code of this function for details, and search for
+% BIDS_TSV as example.
+%
+% The event type and sample fields are always defined, other fields are present but
+% can be empty, depending on the type of event file. Events are sorted by the sample
+% on which they occur. After reading the event structure, you can use the following
+% tricks to extract information about those events in which you are interested.
 %
 % Determine the different event types
 %   unique({event.type})
@@ -67,12 +68,9 @@ function [event] = ft_read_event(filename, varargin)
 %
 % The list of supported file formats can be found in FT_READ_HEADER.
 %
-% To use an external reading function, use key-value pair: 'eventformat', FUNCTION_NAME.
-% (Function needs to be on the path, and take as input: filename)
-%
 % See also FT_READ_HEADER, FT_READ_DATA, FT_WRITE_EVENT, FT_FILTER_EVENT
 
-% Copyright (C) 2004-2016 Robert Oostenveld (Nervus by Jan Brogger)
+% Copyright (C) 2004-2019 Robert Oostenveld (Nervus by Jan Brogger)
 %
 % This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
 % for the documentation and details.
@@ -2238,6 +2236,7 @@ switch eventformat
     % this allows the user to specify an external reading function
     % if it fails, the regular unsupported warning message is thrown
     try
+      % this is used for bids_tsv, biopac_acq, motion_c3d, qualisys_tsv, and possibly others
       hdr   = feval(eventformat, filename);
       event = feval(eventformat, filename, hdr);
     catch

--- a/fileio/ft_read_event.m
+++ b/fileio/ft_read_event.m
@@ -1051,25 +1051,10 @@ switch eventformat
     if isempty(hdr)
       hdr = ft_read_header(filename);
     end
-    if isfield(hdr.orig, 'trigger')
-      % this is inefficient, since it keeps the complete data in memory
-      % but it does speed up subsequent read operations without the user
-      % having to care about it
-      smi = hdr.orig;
-    else
-      smi = read_smi_txt(filename);
-    end
-    timestamp = [smi.trigger(:).timestamp];
-    value     = [smi.trigger(:).value];
-    % note that in this dataformat the first input trigger can be before
-    % the start of the data acquisition
-    for i=1:length(timestamp)
-      event(end+1).type       = 'Trigger';
-      event(end  ).sample     = (timestamp(i)-hdr.FirstTimeStamp)/hdr.TimeStampPerSample + 1;
-      event(end  ).timestamp  = timestamp(i);
-      event(end  ).value      = value(i);
-      event(end  ).duration   = 1;
-      event(end  ).offset     = 0;
+    chanindx = find(strcmp(hdr.label, 'Trigger'));
+    event = read_trigger(filename, 'header', hdr, 'dataformat', dataformat, 'begsample', flt_minsample, 'endsample', flt_maxsample, 'chanindx', chanindx, 'detectflank', detectflank, 'trigshift', trigshift);
+    for i=1:numel(event)
+      event(i).timestamp = hdr.orig.timestamp(event(i).sample);
     end
     
   case 'eyelink_asc'

--- a/fileio/ft_read_header.m
+++ b/fileio/ft_read_header.m
@@ -2418,31 +2418,20 @@ switch headerformat
     hdr.nSamples            = size(smi.dat,2);
     hdr.nSamplesPre         = 0;
     hdr.nTrials             = 1;
-    hdr.FirstTimeStamp      = smi.trigger(1,1).timestamp;
-
-    % if the header contains the sampling rate use it and if not, compute
-    % it from scratch. If computed, sampling rate might have numerical
-    % issues due to tolerance (the reason that I write the two options)
-    if isfield(smi,'Fs') && ~isempty(smi.Fs);
-      hdr.Fs = smi.Fs;
-      hdr.TimeStampPerSample = 1000./hdr.Fs;
-    else
-      hdr.TimeStampPerSample  = mean(diff(smi.dat(1,:)));
-      hdr.Fs                  = 1000/hdr.TimeStampPerSample;  % these timestamps are in miliseconds
-    end
-
-    if hdr.nChans ~= size(smi.label,1)
-      ft_error('data and header have different number of channels');
-    else
-      hdr.label = smi.label;
-    end
-
-    % remember the original header details
-    hdr.orig.header = smi.header;
-    % remember all header and data details upon request
+    
+    hdr.label               = smi.label;
+    hdr.Fs                  = smi.Fs;
+    hdr.FirstTimeStamp      = smi.timestamp(1);
+    hdr.TimeStampPerSample  = mean(diff(smi.timestamp)); % these timestamps are in microseconds
+    
     if cache
+      % remember all header and data details upon request
       hdr.orig = smi;
+    else
+      % remember only the original header details
+      hdr.orig.header = smi.header;
     end
+    
     % add channel units when possible.
     for i=1:hdr.nChans
       chanunit = regexp(hdr.label{i,1},'(?<=\[).+?(?=\])','match');

--- a/fileio/private/bids_tsv.m
+++ b/fileio/private/bids_tsv.m
@@ -1,0 +1,131 @@
+function varargout = bids_tsv(filename, hdr, begsample, endsample, chanindx)
+
+% BIDS_TSV reads time series data from a BIDS tsv and json file pair
+%
+% Use as
+%   hdr = bids_tsv(filename);
+%   dat = bids_tsv(filename, hdr, begsample, endsample, chanindx);
+%   evt = bids_tsv(filename, hdr);
+%
+% See also FT_FILETYPE, FT_READ_HEADER, FT_READ_DATA, FT_READ_EVENT, QUALISYS_TSV, MOTION_C3D
+
+% Copyright (C) 2019 Robert Oostenveld
+%
+% This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
+% for the documentation and details.
+%
+%    FieldTrip is free software: you can redistribute it and/or modify
+%    it under the terms of the GNU General Public License as published by
+%    the Free Software Foundation, either version 3 of the License, or
+%    (at your option) any later version.
+%
+%    FieldTrip is distributed in the hope that it will be useful,
+%    but WITHOUT ANY WARRANTY; without even the implied warranty of
+%    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%    GNU General Public License for more details.
+%
+%    You should have received a copy of the GNU General Public License
+%    along with FieldTrip. If not, see <http://www.gnu.org/licenses/>.
+%
+% $Id$
+
+needhdr = (nargin==1);
+needevt = (nargin==2);
+needdat = (nargin==5);
+
+% use the full filename including path to distinguish between similarly named files in different directories
+[p, f, x] = fileparts(filename);
+if isempty(p)
+  % no path was specified
+  fullname = which(filename);
+elseif startsWith(p, ['.' filesep])
+  % a relative path was specified
+  fullname = fullfile(pwd, p(3:end), [f, x]);
+else
+  fullname = filename;
+end
+
+[p, f, x] = fileparts(fullname);
+jsonfile   = fullfile(p, [f '.json']);
+tsvfile    = fullfile(p, [f '.tsv']);
+
+fid = fopen_or_error(jsonfile, 'r');
+str = fread(fid, [1, inf], 'char=>char');
+fclose(fid);
+% convert the json string into a structure
+orig = jsondecode(str);
+
+dat = readtable(tsvfile, 'FileType', 'text', 'Delimiter', '\t');
+dat = table2array(dat)';
+assert(length(orig.Columns)==size(dat,1), 'number of channels does not match');
+
+if needhdr
+  %% parse the header
+  hdr.Fs = orig.SamplingFrequency;
+  hdr.nChans = length(orig.Columns);
+  hdr.nTrials = 1;
+  hdr.nSamplesPre = 0;
+  hdr.nSamples = size(dat,2);
+  hdr.label = [orig.Columns{:}];
+  
+  % remember the details
+  hdr.orig = orig;
+  
+  % return the header details
+  varargout = {hdr};
+  
+elseif needdat
+  %% parse the data
+  dat = dat(chanindx, begsample:endsample);
+  
+  % return the data
+  varargout = {dat};
+  
+elseif needevt
+  %% parse the events
+  
+  % construct the filename for the events
+  [p, f, x] = fileparts(fullname);
+  pieces = split(f, '_');
+  base = sprintf('%s_', pieces{1:end-1}); % this ends with an inderscore
+  eventsfile = fullfile(p, [base 'events.tsv']);
+  
+  if ~exist(eventsfile, 'file')
+    ft_error('cannot read events');
+  end
+  
+  % read the BIDS events as a table
+  event = readtable(eventsfile, 'FileType', 'text', 'Delimiter', '\t');
+  
+  % Construct an events struct array that contains these fields
+  %   event.type      = string
+  %   event.sample    = expressed in samples, the first sample of a recording is 1
+  %   event.value     = number or string
+  %   event.offset    = expressed in samples
+  %   event.duration  = expressed in samples
+  %   event.timestamp = expressed in timestamp units, which vary over systems (optional)
+  
+  if any(strcmp(event.Properties.VariableNames, 'duration'))
+    if iscell(event.duration)
+      % it cannot have string values
+      event.duration = [];
+    elseif isnumeric(event.duration)
+      % express the duration in samples
+      [event(:).duration] = deal(event.duration*hdr.Fs);
+    end
+  end
+  
+  event = table2struct(event);
+  if ~isfield(event, 'sample')
+    % the onset in events.tsv is always relative to the corresponding dataset
+    [event(:).sample] = deal(event.onset*hdr.Fs);
+  end
+  [event(:).timestamp] = deal(event.onset);
+  
+  % remove all fields/columns that are not consistent with the output of FT_READ_EVENT
+  event = keepfields(event, {'type', 'sample', 'value', 'offset', 'duration', 'timestamp'});
+  
+  % return the events
+  varargout = {event};
+  
+end

--- a/fileio/private/read_smi_txt.m
+++ b/fileio/private/read_smi_txt.m
@@ -29,7 +29,7 @@ function smi = read_smi_txt(filename)
 smi.header  = {};
 smi.label   = {};
 smi.dat     = [];
-current   = 0;
+current     = 0;
 
 % read the whole file at once
 fid = fopen_or_error(filename, 'rt');
@@ -53,9 +53,9 @@ for i=1:numel(aline)
     smi.type{1,current} =  sscanf(tmp{smpidx}, '%s');
     tmp(smpidx,:) = [];
     
-    for j=1:size(tmp,1);
+    for j=1:size(tmp,1)
       val = sscanf(tmp{j,1}, '%f');
-      if isempty(val);
+      if isempty(val)
         smi.dat(j,current) =  NaN;
       else
         smi.dat(j,current) =  val;
@@ -66,17 +66,17 @@ for i=1:numel(aline)
     smi.header = cat(1, smi.header, {tline});
     
     template ='## Sample Rate:';
-    if strncmp(tline,template,length(template));
+    if strncmp(tline,template,length(template))
       smi.Fs = cellfun(@str2num,regexp(tline,'[\d]+','match'));
     end
     
     template = '## Number of Samples:';
-    if strncmp(tline,template,length(template));
+    if strncmp(tline,template,length(template))
       smi.nsmp = cellfun(@str2num,regexp(tline,'[\d]+','match'));
     end
     
     template = '## Head Distance [mm]:';
-    if strncmp(tline,template,length(template));
+    if strncmp(tline,template,length(template))
       smi.headdist = cellfun(@str2num,regexp(tline,'[\d]+','match'));
     end
     	    
@@ -98,17 +98,12 @@ for i=1:numel(aline)
 end
 
 % remove the samples that were not filled with real data
-%smi.dat = smi.dat(:,1:current);
+% smi.dat = smi.dat(:,1:current);
 
-% put the trigger channel outside of the data to take it easier with ft_read_event
-for c=1:size(smi.label,1);
-  if strcmp(smi.label{c,1},'Trigger');
-    for k = 1:size(smi.dat,2);
-      smi.trigger(k,1).timestamp = smi.dat(1,k);
-      smi.trigger(k,1).value     = smi.dat(c,k);
-    end
-  end
+% place the timestamp channel outside of the data
+c = find(strcmp(smi.label, 'Time'));
+if numel(c)==1
+  smi.timestamp = smi.dat(c,:);
+  smi.dat(c,:) = [];
+  smi.label(c) = [];
 end
-smi.dat([1 c],:)      = [];
-smi.label([1 c],:)    = [];
-

--- a/utilities/ft_checkconfig.m
+++ b/utilities/ft_checkconfig.m
@@ -653,12 +653,12 @@ if istrue(checkfilenames)
     % this requires correct autodetection of the format of the data set
     [cfg.dataset, cfg.headerfile, cfg.datafile] = dataset2files(cfg.dataset, []);
 
-  elseif ~isempty(cfg.datafile) && isempty(cfg.headerfile);
+  elseif ~isempty(cfg.datafile) && isempty(cfg.headerfile)
     % assume that the datafile also contains the header information
     cfg.dataset    = cfg.datafile;
     cfg.headerfile = cfg.datafile;
 
-  elseif isempty(cfg.datafile) && ~isempty(cfg.headerfile);
+  elseif isempty(cfg.datafile) && ~isempty(cfg.headerfile)
     % assume that the headerfile also contains the data
     cfg.dataset  = cfg.headerfile;
     cfg.datafile = cfg.headerfile;

--- a/utilities/private/dataset2files.m
+++ b/utilities/private/dataset2files.m
@@ -100,6 +100,14 @@ switch format
     if length(path)>3 && strcmp(path(end-2:end), '.ds')
       filename = path; % this is the *.ds directory
     end
+  case 'bids_tsv'
+    [path, file, ext] = fileparts(filename);
+    if exist(fullfile(path, [file '.json']), 'file')
+      headerfile   = fullfile(path, [file '.json']);
+    end
+    if exist(fullfile(path, [file '.tsv']), 'file')
+      datafile   = fullfile(path, [file '.tsv']);
+    end
   case 'brainvision_vhdr'
     [path, file, ext] = fileparts(filename);
     headerfile = fullfile(path, [file '.vhdr']);


### PR DESCRIPTION
This is used for `physio.tsv` and `stim.tsv` in the current BIDS specification, but I am also using it for eyetracker and motion capture data. See for example <http://www.fieldtriptoolbox.org/example/bids_eyetracker/>

If the data is accompanied by an `events.tsv` file, that can also be read using FT_READ_EVENT.  