### PR TITLE
[ENH] LCMV beamformer: automatically compute noise for NAI weight normalization

### DIFF
--- a/inverse/beamformer_lcmv.m
+++ b/inverse/beamformer_lcmv.m
@@ -168,8 +168,9 @@ else
   tmplambda = 0;
 end
 
-if projectnoise
+if projectnoise || strcmp(weightnorm, 'nai')
     % estimate the noise level in the covariance matrix by the smallest singular (non-zero) value
+    % always needed for the NAI weight normalization case
     noise = svd(Cy);
     noise = noise(rankCy);
     % estimated noise floor is equal to or higher than lambda

--- a/inverse/beamformer_lcmv.m
+++ b/inverse/beamformer_lcmv.m
@@ -34,6 +34,7 @@ function [dipout] = beamformer_lcmv(dip, grad, headmodel, dat, Cy, varargin)
 %  'keepmom'          = remember the estimated dipole moment timeseries, can be 'yes' or 'no'
 %  'keepcov'          = remember the estimated dipole covariance,        can be 'yes' or 'no'
 %  'kurtosis'         = compute the kurtosis of the dipole timeseries,   can be 'yes' or 'no'
+%  'weightnorm'       = normalize the beamformer weights,                can be 'no', 'unitnoisegain' or 'nai'
 %
 % These options influence the forward computation of the leadfield
 %  'reducerank'       = reduce the leadfield rank, can be 'no' or a number (e.g. 2)


### PR DESCRIPTION
If the LCMV beamformer is run with ``cfg.weightnorm = 'nai'`` but without explicitly setting ``cfg.projectnoise = 'yes'``, the code crashes with ``Undefined function or variable 'noise'.``

This PR makes the noise computation in the NAI case automatic.
Furthermore, it adds ``weightnorm`` to the documentation where it was missing so far.