### PR TITLE
feed the option: tolerance down to ft_selectdata via ft_timelockanalysis

### DIFF
--- a/ft_timelockanalysis.m
+++ b/ft_timelockanalysis.m
@@ -136,7 +136,7 @@ end
 
 % compute the covariance matrix, if requested
 if computecov
-  tmpcfg = keepfields(cfg, {'trials', 'channel'});
+  tmpcfg = keepfields(cfg, {'trials', 'channel','tolerance'});
   tmpcfg.latency = cfg.covariancewindow;
   datacov = ft_selectdata(tmpcfg, data);
   % restore the provenance information
@@ -191,7 +191,7 @@ if computecov
 end
 
 % select trials and channels of interest
-tmpcfg = keepfields(cfg, {'trials', 'channel', 'latency'});
+tmpcfg = keepfields(cfg, {'trials', 'channel', 'latency','tolerance'});
 data   = ft_selectdata(tmpcfg, data);
 % restore the provenance information
 [cfg, data] = rollback_provenance(cfg, data);


### PR DESCRIPTION
Dear Fieldtrip-Team,
I'd like to suggest to use 1/samp_freq as a reasonable tolerance value when comparing different time vectors over trials. Using 10^-5 for all sampling rates does not make much sense to me. However, to be able to configure this parameter, it should not be removed from the cfg struct.
best,
Burkhard
