### PR TITLE
ft_resampledata now returns 0 as extrapolation value

### DIFF
--- a/ft_resampledata.m
+++ b/ft_resampledata.m
@@ -150,14 +150,14 @@ if usefsample
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   % resample/downsample based on new sampling frequency
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-  
+
   ntr = length(data.trial);
   nchan  = numel(data.label);
-  
+
   ft_progress('init', cfg.feedback, 'resampling data');
   [fsorig, fsres] = rat(cfg.origfs./cfg.resamplefs); %account for non-integer fs
   cfg.resamplefs  = cfg.origfs.*(fsres./fsorig); %get new fs exact
-  
+
   % make sure that the resampled time axes are aligned (this is to avoid rounding
   % errors in the time axes). this procedure relies on the fact that resample assumes
   % all data outside the data window to be zero anyway. therefore, padding with zeros
@@ -170,27 +170,27 @@ if usefsample
   end
   begpad = begsample-min(begsample);
   endpad = max(endsample)-endsample;
-  
+
   if any(begpad~=0) || any(endpad~=0)
     ft_warning('not all trials have the same time axis; data will be zero-padded prior to resampling to avoid rounding issues in the resampled time axes');
   end
-  
+
   if any(strcmp(cfg.method, {'downsample', 'mean', 'median'}))
     ft_warning('using cfg.method = ''%s''; only use this if you have applied an anti-aliasing filter prior to downsampling!', cfg.method);
   end
-  
+
   if any(strcmp(cfg.method, {'decimate', 'downsample', 'mean', 'median'}))
     if mod(fsorig, fsres) ~= 0
       ft_error('the new sampling rate needs to be an integer division of the original sampling rate');
     end
   end
-  
+
   for itr = 1:ntr
     ft_progress(itr/ntr, 'resampling data in trial %d from %d\n', itr, ntr);
-    
+
     olddat = data.trial{itr};
     oldtim = data.time{itr};
-    
+
     % detrending is in general not recommended
     if istrue(cfg.detrend)
       if ~strcmp(cfg.baselinewindow, 'all')
@@ -199,18 +199,18 @@ if usefsample
         olddat = ft_preproc_detrend(olddat);
       end
     end
-    
+
     % remove the mean to avoid edge effects when there's a strong offset, the cfg.demean option is dealt with below
     if ~strcmp(cfg.baselinewindow, 'all')
       [olddat, bsl] = ft_preproc_baselinecorrect(olddat, nearest(oldtim, cfg.baselinewindow(1)), nearest(oldtim, cfg.baselinewindow(2)));
     else
       [olddat, bsl] = ft_preproc_baselinecorrect(olddat);
     end
-    
+
     % pad the data with zeros on both sides
     olddat = [zeros(nchan, begpad(itr)) olddat zeros(nchan, endpad(itr))];
     oldtim = ((begsample(itr)-begpad(itr)):(endsample(itr)+endpad(itr))) / cfg.origfs;
-    
+
     % perform the resampling
     if strcmp(cfg.method, 'downsample')
       if isa(olddat, 'single')
@@ -219,7 +219,7 @@ if usefsample
       else
         newdat = transpose(downsample(transpose(olddat),fsorig/fsres));
       end
-      
+
     elseif strcmp(cfg.method, 'resample')
       if isa(olddat, 'single')
         % temporary convert this trial to double precision
@@ -227,7 +227,7 @@ if usefsample
       else
         newdat = transpose(resample(transpose(olddat),fsres,fsorig));
       end
-      
+
     elseif strcmp(cfg.method, 'decimate')
       if isa(olddat, 'single')
         % temporary convert this trial to double precision
@@ -235,7 +235,7 @@ if usefsample
       else
         newdat = transpose(my_decimate(transpose(olddat),fsorig/fsres));
       end
-      
+
     elseif strcmp(cfg.method, 'mean')
       if isa(olddat, 'single')
         % temporary convert this trial to double precision
@@ -243,7 +243,7 @@ if usefsample
       else
         newdat = transpose(my_mean(transpose(olddat),fsorig/fsres));
       end
-      
+
     elseif strcmp(cfg.method, 'median')
       if isa(olddat, 'single')
         % temporary convert this trial to double precision
@@ -251,26 +251,26 @@ if usefsample
       else
         newdat = transpose(my_median(transpose(olddat), fsorig/fsres));
       end
-      
+
     else
       ft_error('unknown method ''%s''', cfg.method);
     end
-    
+
     % add back the mean
     if ~strcmp(cfg.demean, 'yes')
       nsmp   = size(newdat,2);
       newdat = newdat + bsl(:,ones(1,nsmp));
     end
-    
+
     % compute the new time axis, assuming that it starts at the same time
     nsmp   = size(newdat,2);
     newtim = (0:(nsmp-1))/cfg.resamplefs;
-    
+
     % the middle of the time bin represented by the first samples are not aligned
     % the new time axis can be shifted by a sub-sample amount
     shift  = mean(oldtim) - mean(newtim);
     newtim = newtim + shift;
-    
+
     if begpad(itr)>0 || endpad(itr)>0
       % un-pad the data
       sel = (1+round(begpad(itr)*cfg.resamplefs/cfg.origfs)):(length(newtim)-round(endpad(itr)*cfg.resamplefs/cfg.origfs));
@@ -280,26 +280,26 @@ if usefsample
     
     data.time{itr}  = newtim;
     data.trial{itr} = newdat;
-    
+
   end % for itr
   ft_progress('close');
-  
+
   % specify the new sampling frequency in the output
   data.fsample = cfg.resamplefs;
-  
+
 elseif usetime
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   % resample based on the specified new time axes for each trial
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   ntr = length(data.trial);
-  
+
   ft_progress('init', cfg.feedback, 'resampling data');
   for itr = 1:ntr
     ft_progress(itr/ntr, 'resampling data in trial %d from %d\n', itr, ntr);
-    
+
     olddat = data.trial{itr};
     oldtim = data.time{itr};
-    
+
     % detrending is in general not recommended
     if istrue(cfg.detrend)
       if ~strcmp(cfg.baselinewindow, 'all')
@@ -308,39 +308,39 @@ elseif usetime
         olddat = ft_preproc_detrend(olddat);
       end
     end
-    
+
     % always remove the mean to avoid edge effects when there's a strong offset, the cfg.demean option is dealt with below
     if ~strcmp(cfg.baselinewindow, 'all')
       [olddat, bsl] = ft_preproc_baselinecorrect(olddat, nearest(oldtim, cfg.baselinewindow(1)), nearest(oldtim, cfg.baselinewindow(2)));
     else
       [olddat, bsl] = ft_preproc_baselinecorrect(olddat);
     end
-    
+
     % perform the resampling
     newtim = cfg.time{itr};
     if length(oldtim)>1
-      newdat = interp1(oldtim', olddat', newtim', cfg.method)';
+      newdat = interp1(oldtim', olddat', newtim', cfg.method, 0)';
     else
       newdat = repmat(olddat, [1 numel(newtim)]);
     end
-    
+
     % add back the mean
     if ~strcmp(cfg.demean, 'yes')
       nsmp   = size(newdat, 2);
       newdat = newdat + bsl(:,ones(1,nsmp));
     end
-    
+
     data.trial{itr} = newdat;
     data.time{itr}  = newtim;
-    
+
   end % for itr
   ft_progress('close');
-  
+
   % specify the new sampling frequency in the output
   t1 = cfg.time{1}(1);
   t2 = cfg.time{1}(2);
   data.fsample = 1/(t2-t1);
-  
+
 end % if usefsample or usetime
 
 ft_info('original sampling rate = %d Hz\nnew sampling rate = %d Hz\n', cfg.origfs, data.fsample);


### PR DESCRIPTION
Specified the 'extrapolation' parameter for interp1 to ensure data is not extrapolated. This can happen when cfg.time is used and times are given outside the range of the current data. The added parameter enforces that all values outside the data range are set to zero. 
(Add ?w=1 to github's URL to see the diff with whitespace ignored)