### PR TITLE
Update in ft_redefinetrial to enable overlap

### DIFF
--- a/ft_redefinetrial.m
+++ b/ft_redefinetrial.m
@@ -239,6 +239,9 @@ elseif ~isempty(cfg.trl)
   % ensure that sampleinfo is present, otherwise ft_fetch_data will crash
   data = ft_checkdata(data, 'hassampleinfo', 'yes');
   
+  % check for overlap info, otherwise ft_fetch_data will ignore it
+  overlap = cfg.overlap;
+  
   dataold = data;   % make a copy of the old data
   clear data        % this line is very important, we want to completely reconstruct the data from the old data!
   
@@ -271,7 +274,7 @@ elseif ~isempty(cfg.trl)
   
   for iTrl=1:size(trl, 1)
     
-    data.trial{iTrl} = ft_fetch_data(dataold, 'header', hdr, 'begsample', begsample(iTrl), 'endsample', endsample(iTrl), 'chanindx', 1:hdr.nChans, 'skipcheckdata', 1);
+    data.trial{iTrl} = ft_fetch_data(dataold, 'header', hdr, 'begsample', begsample(iTrl), 'endsample', endsample(iTrl), 'chanindx', 1:hdr.nChans, 'skipcheckdata', 1, ''allowoverlap, overlap);
     data.time{iTrl}  = offset2time(offset(iTrl), dataold.fsample, trllength(iTrl));
     
     % ensure correct handling of trialinfo.


### PR DESCRIPTION
So far the option allow for overlap is not possible because the option is not retrieved and not taken into account by ft_fetch_data. With this modification, adding cfg.overlap = true will enable it when calling ft_redefintrial. Apparently this was to prevent some issues, but when you need to manually add some buffer that will be further removed, for instance, then it can become useful to have data overlap.