### PR TITLE
small improvements to file reading, specifically to XDF

### DIFF
--- a/fileio/ft_read_data.m
+++ b/fileio/ft_read_data.m
@@ -1475,19 +1475,21 @@ switch dataformat
     end
     
   otherwise
-    % attempt to run "dataformat" as a function
-    % this allows the user to specify an external reading function
-    % if it fails, the regular unsupported warning message is thrown
-    try
-      % this is used for bids_tsv, biopac_acq, motion_c3d, opensignals_txt, qualisys_tsv, and possibly others
+    if exist(dataformat, 'file')
+      % attempt to run "dataformat" as a function, this allows the user to specify an external reading function
+      % this is also used for bids_tsv, biopac_acq, motion_c3d, opensignals_txt, qualisys_tsv, sccn_xdf, and possibly others
       dat = feval(dataformat, filename, hdr, begsample, endsample, chanindx);
-    catch
-      if strcmp(fallback, 'biosig') && ft_hastoolbox('BIOSIG', 1)
+    elseif strcmp(fallback, 'biosig') && ft_hastoolbox('BIOSIG', 1)
+      try
+        % there is no guarantee that biosig can read it
         dat = read_biosig_data(filename, hdr, begsample, endsample, chanindx);
-      else
+      catch
         ft_error('unsupported data format "%s"', dataformat);
       end
+    else
+      ft_error('unsupported data format "%s"', dataformat);
     end
+    
 end % switch dataformat
 
 if ~exist('dimord', 'var')

--- a/fileio/ft_read_event.m
+++ b/fileio/ft_read_event.m
@@ -2247,20 +2247,19 @@ switch eventformat
     event = read_presentation_log(filename);
     
   otherwise
-    % attempt to run "eventformat" as a function
-    % this allows the user to specify an external reading function
-    % if it fails, the regular unsupported warning message is thrown
-    try
-      % this is used for bids_tsv, biopac_acq, motion_c3d, opensignals_txt, qualisys_tsv, and possibly others
+    if exist(eventformat, 'file')
+      % attempt to run "eventformat" as a function, this allows the user to specify an external reading function
+      % this is also used for bids_tsv, biopac_acq, motion_c3d, opensignals_txt, qualisys_tsv, sccn_xdf, and possibly others
       if isempty(hdr)
         hdr = feval(eventformat, filename);
       end
       event = feval(eventformat, filename, hdr);
-    catch
-      ft_warning('FieldTrip:ft_read_event:unsupported_event_format','unsupported event format "%s"', eventformat);
+    else
+      ft_warning('unsupported event format "%s"', eventformat);
       event = [];
     end
-end
+    
+end % switch eventformat
 
 if ~isempty(hdr) && hdr.nTrials>1 && (isempty(event) || ~any(strcmp({event.type}, 'trial')))
   % the data suggests multiple trials and trial events have not yet been defined

--- a/fileio/ft_read_header.m
+++ b/fileio/ft_read_header.m
@@ -2589,18 +2589,19 @@ switch headerformat
     checkUniqueLabels = false;
     
   otherwise
-    % attempt to run "headerformat" as a function
-    % this allows the user to specify an external reading function
-    % if it fails, the regular unsupported warning message is thrown
-    try
-      % this is used for bids_tsv, biopac_acq, motion_c3d, opensignals_txt, qualisys_tsv, and possibly others
+    if exist(headerformat, 'file')
+      % attempt to run "headerformat" as a function, this allows the user to specify an external reading function
+      % this is also used for bids_tsv, biopac_acq, motion_c3d, opensignals_txt, qualisys_tsv, sccn_xdf, and possibly others
       hdr = feval(headerformat, filename);
-    catch
-      if strcmp(fallback, 'biosig') && ft_hastoolbox('BIOSIG', 1)
+    elseif strcmp(fallback, 'biosig') && ft_hastoolbox('BIOSIG', 1)
+      try
+        % there is no guarantee that biosig can read it
         hdr = read_biosig_header(filename);
-      else
+      catch
         ft_error('unsupported header format "%s"', headerformat);
       end
+    else
+      ft_error('unsupported header format "%s"', headerformat);
     end
     
 end % switch headerformat

--- a/fileio/private/bids_tsv.m
+++ b/fileio/private/bids_tsv.m
@@ -88,7 +88,7 @@ elseif needevt
   
   % construct the filename for the events
   [p, f, x] = fileparts(fullname);
-  pieces = split(f, '_');
+  pieces = tokenize(f, '_');
   base = sprintf('%s_', pieces{1:end-1}); % this ends with an inderscore
   eventsfile = fullfile(p, [base 'events.tsv']);
   

--- a/fileio/private/sccn_xdf.m
+++ b/fileio/private/sccn_xdf.m
@@ -61,7 +61,11 @@ if needhdr
   % this section of code is shared with xdf2fieldtrip
   hdr             = [];
   hdr.Fs          = stream.info.effective_srate;
-  hdr.nChans      = numel(stream.info.desc.channels.channel);
+  if isfield(stream.info.desc, 'channels')
+    hdr.nChans    = numel(stream.info.desc.channels.channel);
+  else
+    hdr.nChans    = str2double(stream.info.channel_count);
+  end
   hdr.nSamplesPre = 0;
   hdr.nSamples    = length(stream.time_stamps);
   hdr.nTrials     = 1;
@@ -70,10 +74,16 @@ if needhdr
   hdr.chanunit    = cell(hdr.nChans, 1);
   
   prefix = stream.info.name;
-  for i=1:hdr.nChans
-    hdr.label{i} = [prefix '_' stream.info.desc.channels.channel{i}.label];
-    hdr.chantype{i} = stream.info.desc.channels.channel{i}.type;
-    hdr.chanunit{i} = stream.info.desc.channels.channel{i}.unit;
+  for j=1:hdr.nChans
+    if isfield(stream.info.desc, 'channels')
+      hdr.label{j} = [prefix '_' stream.info.desc.channels.channel{j}.label];
+      hdr.chantype{j} = stream.info.desc.channels.channel{j}.type;
+      hdr.chanunit{j} = stream.info.desc.channels.channel{j}.unit;
+    else
+      hdr.label{j} = num2str(j);
+      hdr.chantype{j} = 'unknown';
+      hdr.chanunit{j} = 'unknown';
+    end
   end
   
   hdr.FirstTimeStamp     = stream.time_stamps(1);

--- a/xdf2fieldtrip.m
+++ b/xdf2fieldtrip.m
@@ -90,7 +90,11 @@ for i=1:numel(streams)
   % this section of code is shared with fileio/private/sccn_xdf
   hdr             = [];
   hdr.Fs          = stream.info.effective_srate;
-  hdr.nChans      = numel(stream.info.desc.channels.channel);
+  if isfield(stream.info.desc, 'channels')
+    hdr.nChans    = numel(stream.info.desc.channels.channel);
+  else
+    hdr.nChans    = str2double(stream.info.channel_count);
+  end
   hdr.nSamplesPre = 0;
   hdr.nSamples    = length(stream.time_stamps);
   hdr.nTrials     = 1;
@@ -101,9 +105,15 @@ for i=1:numel(streams)
   prefix = stream.info.name;
   
   for j=1:hdr.nChans
-    hdr.label{j} = [prefix '_' stream.info.desc.channels.channel{j}.label];
-    hdr.chantype{j} = stream.info.desc.channels.channel{j}.type;
-    hdr.chanunit{j} = stream.info.desc.channels.channel{j}.unit;
+    if isfield(stream.info.desc, 'channels')
+      hdr.label{j} = [prefix '_' stream.info.desc.channels.channel{j}.label];
+      hdr.chantype{j} = stream.info.desc.channels.channel{j}.type;
+      hdr.chanunit{j} = stream.info.desc.channels.channel{j}.unit;
+    else
+      hdr.label{j} = num2str(j);
+      hdr.chantype{j} = 'unknown';
+      hdr.chanunit{j} = 'unknown';
+    end
   end
   
   hdr.FirstTimeStamp     = stream.time_stamps(1);
@@ -111,7 +121,7 @@ for i=1:numel(streams)
   
   % keep the original header details
   hdr.orig = stream.info;
-
+  
   data{i}.hdr = hdr;
   data{i}.label = hdr.label;
   data{i}.time = {streams{i}.time_stamps};


### PR DESCRIPTION
see https://github.com/fieldtrip/fieldtrip/pull/1285

This includes some specific improvements to XDF, and a general improvement to reading data/header/event with dataformat/headerformat/eventformat as a (private) function. Rather than silently try-end, it now passes the error of the low-level function if it exists.