### PR TITLE
small cleanups to statfuns

### DIFF
--- a/ft_statistics_montecarlo.m
+++ b/ft_statistics_montecarlo.m
@@ -34,10 +34,8 @@ function [stat, cfg] = ft_statistics_montecarlo(cfg, dat, design, varargin)
 % statistics will be thresholded and combined into one statistical
 % value per cluster.
 %   cfg.clusterstatistic = how to combine the single samples that belong to a cluster, 'maxsum', 'maxsize', 'wcm' (default = 'maxsum')
-%                          option 'wcm' refers to 'weighted cluster mass',
-%                          a statistic that combines cluster size and
-%                          intensity; see Hayasaka & Nichols (2004) NeuroImage
-%                          for details
+%                          the option 'wcm' refers to 'weighted cluster mass', a statistic that combines cluster size and intensity; 
+%                          see Hayasaka & Nichols (2004) NeuroImage for details
 %   cfg.clusterthreshold = method for single-sample threshold, 'parametric', 'nonparametric_individual', 'nonparametric_common' (default = 'parametric')
 %   cfg.clusteralpha     = for either parametric or nonparametric thresholding per tail (default = 0.05)
 %   cfg.clustercritval   = for parametric thresholding (default is determined by the statfun)
@@ -300,6 +298,12 @@ if strcmp(cfg.precondition, 'after')
   [tmpstat, tmpcfg, dat] = statfun(tmpcfg, dat, design);
 end
 
+if strcmp(cfg.correctm, 'max')
+  % pre-allocate the memory to hold the distribution of most extreme positive (right) and negative (left) statistical values
+  posdistribution = nan(1,Nrand);
+  negdistribution = nan(1,Nrand);
+end
+
 % compute the statistic for the randomized data and count the outliers
 for i=1:Nrand
   ft_progress(i/Nrand, 'computing statistic %d from %d\n', i, Nrand);
@@ -487,12 +491,7 @@ if exist('statrand', 'var')
 end
 
 % return optional other details that were returned by the statfun
-fn = fieldnames(statfull);
-for i=1:length(fn)
-  if ~isfield(stat, fn{i})
-    stat = setfield(stat, fn{i}, getfield(statfull, fn{i}));
-  end
-end
+stat = copyfields(statfull, stat, fieldnames(statfull));
 
 ft_warning(ws); % revert to original state
 

--- a/statfun/ft_statfun_actvsblT.m
+++ b/statfun/ft_statfun_actvsblT.m
@@ -13,31 +13,30 @@ function [s, cfg] = ft_statfun_actvsblT(cfg, dat, design)
 %   [stat] = ft_timelockstatistics(cfg, timelock1, timelock2, ...)
 %   [stat] = ft_freqstatistics(cfg, freq1, freq2, ...)
 %   [stat] = ft_sourcestatistics(cfg, source1, source2, ...)
-% with the following configuration option
+% with the following configuration option:
 %   cfg.statistic = 'ft_statfun_actvsblT'
 %
-% Configuration options
+% You can specify the following configuration options:
 %   cfg.computestat    = 'yes' or 'no', calculate the statistic (default='yes')
 %   cfg.computecritval = 'yes' or 'no', calculate the critical values of the test statistics (default='no')
 %   cfg.computeprob    = 'yes' or 'no', calculate the p-values (default='no')
 %
-% The following options are relevant if cfg.computecritval='yes' and/or
-% cfg.computeprob='yes'.
+% The following options are relevant if cfg.computecritval='yes' and/or cfg.computeprob='yes':
 %   cfg.alpha = critical alpha-level of the statistical test (default=0.05)
 %   cfg.tail  = -1, 0, or 1, left, two-sided, or right (default=1)
 %               cfg.tail in combination with cfg.computecritval='yes'
 %               determines whether the critical value is computed at
 %               quantile cfg.alpha (with cfg.tail=-1), at quantiles
 %               cfg.alpha/2 and (1-cfg.alpha/2) (with cfg.tail=0), or at
-%               quantile (1-cfg.alpha) (with cfg.tail=1).
+%               quantile (1-cfg.alpha) (with cfg.tail=1)
 %
-% Design specification
-%   cfg.ivar  = row number of the design that contains the labels of the conditions that must be
-%               compared (default=1). The first condition, indicated by 1, corresponds to the
-%               activation period and the second, indicated by 2, corresponds to the baseline period.
-%   cfg.uvar  = row number of design that contains the labels of the units-of-observation (subjects or trials)
-%               (default=2). The labels are assumed to be integers ranging from 1 to
-%               the number of units-of-observation.
+% The experimental design is specified as:
+%   cfg.ivar  = independent variable, row number of the design that contains the labels of the conditions to be compared (default=1)
+%   cfg.uvar  = unit variable, row number of design that contains the labels of the units-of-observation, i.e. subjects or trials (default=2)
+%
+% The first condition, indicated by 1, corresponds to the activation period and the second,
+% indicated by 2, corresponds to the baseline period. The labels for the unit of observation
+% should be integers ranging from 1 to the number of observations (subjects or trials).
 %
 % See also FT_TIMELOCKSTATISTICS, FT_FREQSTATISTICS or FT_SOURCESTATISTICS
 
@@ -61,12 +60,14 @@ function [s, cfg] = ft_statfun_actvsblT(cfg, dat, design)
 %
 % $Id$
 
-% set defaults
-if ~isfield(cfg, 'computestat'),       cfg.computestat='yes';     end
-if ~isfield(cfg, 'computecritval'),    cfg.computecritval='no';   end
-if ~isfield(cfg, 'computeprob'),       cfg.computeprob='no';      end
-if ~isfield(cfg, 'alpha'),             cfg.alpha=0.05;            end
-if ~isfield(cfg, 'tail'),              cfg.tail=1;                end
+% set the defaults
+cfg.computestat    = ft_getopt(cfg, 'computestat', 'yes');
+cfg.computecritval = ft_getopt(cfg, 'computecritval', 'no');
+cfg.computeprob    = ft_getopt(cfg, 'computeprob', 'no');
+cfg.alpha          = ft_getopt(cfg, 'alpha', 0.05);
+cfg.tail           = ft_getopt(cfg, 'tail', 1);
+cfg.ivar           = ft_getopt(cfg, 'ivar', 1);
+cfg.uvar           = ft_getopt(cfg, 'uvar', 2);
 
 % perform some checks on the configuration
 if strcmp(cfg.computeprob,'yes') && strcmp(cfg.computestat,'no')
@@ -81,7 +82,7 @@ switch cfg.dimord
     ntime = cfg.dim(3);
     [nsmpls,nrepl] = size(dat);
   otherwise
-    ft_error('Inappropriate dimord for the statistics function FT_STATFUN_ACTVSBLT.');
+    ft_error('Inappropriate dimord.');
 end
 
 sel1 = find(design(cfg.ivar,:)==1);
@@ -94,7 +95,7 @@ end
 nunits = max(design(cfg.uvar,:));
 df = nunits - 1;
 if nunits<2
-  ft_error('The data must contain at least two units (trials or subjects).')
+  ft_error('The data must contain at least two units of observation (trials or subjects).')
 end
 if (nunits*2)~=(n1+n2)
   ft_error('Invalid specification of the design array.');
@@ -106,26 +107,26 @@ if strcmp(cfg.computestat,'yes')
   % for all units-of-observation.
   meanreshapeddat=nanmean(reshape(dat,nchan,nfreq,ntime,nrepl),3);
   timeavgdat=repmat(reshape(meanreshapeddat,(nchan*nfreq),nrepl),ntime,1);
-  
+
   % store the positions of the 1-labels and the 2-labels in a nunits-by-2 array
   poslabelsperunit=zeros(nunits,2);
   poslabel1=find(design(cfg.ivar,:)==1);
   poslabel2=find(design(cfg.ivar,:)==2);
-  [dum,i]=sort(design(cfg.uvar,poslabel1),'ascend');
+  [dum,i]=sort(design(cfg.uvar,poslabel1), 'ascend');
   poslabelsperunit(:,1)=poslabel1(i);
-  [dum,i]=sort(design(cfg.uvar,poslabel2),'ascend');
+  [dum,i]=sort(design(cfg.uvar,poslabel2), 'ascend');
   poslabelsperunit(:,2)=poslabel2(i);
-  
+
   % calculate the differences between the conditions
-  diffmat=dat(:,poslabelsperunit(:,1))-timeavgdat(:,poslabelsperunit(:,2));
-  
+  diffmat = dat(:,poslabelsperunit(:,1))-timeavgdat(:,poslabelsperunit(:,2));
+
   % calculate the dependent samples t-statistics
-  avgdiff=nanmean(diffmat,2);
-  vardiff=nanvar(diffmat,0,2);
-  s.stat=sqrt(nunits)*avgdiff./sqrt(vardiff);
+  avgdiff = nanmean(diffmat,2);
+  vardiff = nanvar(diffmat,0,2);
+  s.stat = sqrt(nunits)*avgdiff./sqrt(vardiff);
 end
 
-if strcmp(cfg.computecritval,'yes')
+if strcmp(cfg.computecritval, 'yes')
   % also compute the critical values
   s.df      = df;
   if cfg.tail==-1
@@ -137,7 +138,7 @@ if strcmp(cfg.computecritval,'yes')
   end
 end
 
-if strcmp(cfg.computeprob,'yes')
+if strcmp(cfg.computeprob, 'yes')
   % also compute the p-values
   s.df      = df;
   if cfg.tail==-1

--- a/statfun/ft_statfun_cohensd.m
+++ b/statfun/ft_statfun_cohensd.m
@@ -19,10 +19,12 @@ function stat = ft_statfun_cohensd(cfg, dat, design)
 %   cfg.statistic = 'ft_statfun_cohensd'
 %
 % The experimental design is specified as:
-%   cfg.ivar  = row number of the design that contains the labels of the conditions that must be compared (default=1).
-%               The labels should be specified as numbers ranging from 1 to the number of conditions.
-%   cfg.uvar  = optional, row number of design that contains the labels of the units-of-observation, i.e. subjects or trials (default=2).
-%               The labels should be integers ranging from 1 to the number of units-of-observation.
+%   cfg.ivar  = independent variable, row number of the design that contains the labels of the conditions to be compared (default=1)
+%   cfg.uvar  = optional, row number of design that contains the labels of the units-of-observation, i.e. subjects or trials (default=2)
+%
+% The labels for the independent variable should be specified as the number 1 and 2.
+% The labels for the unit of observation should be integers ranging from 1 to the
+% total number of observations (subjects or trials).
 %
 % The cfg.uvar option is only needed for paired data, you should leave it empty
 % for non-paired data.
@@ -64,16 +66,16 @@ if isempty(cfg.uvar)
   sel2 = find(design(cfg.ivar,:)==2); % select replications that belong to condition 2
   n1 = length(sel1);
   n2 = length(sel2);
-  
+
   x1 = dat(:,sel1);
   x2 = dat(:,sel2);
-  
+
   pooled_sd = sqrt(((n1-1)*std(x1, w, 2)^2 + (n2-1)*std(x2, w, 2)^2) / (n1+n2-1));
   cohensd   = (mean(x1, 2) - mean(x2, 2)) / pooled_sd;
-  
+
 else
   subj = unique(design(cfg.uvar,:)); % it can also be paired over trials
-  
+
   n = length(subj);
   sel1 = nan(size(subj));
   sel2 = nan(size(subj));
@@ -83,7 +85,7 @@ else
   end
   x1 = dat(:,sel1);
   x2 = dat(:,sel2);
-  
+
   cohensd = mean(x1 - x2, 2) ./ std(x1 - x2, w, 2);
 end
 

--- a/statfun/ft_statfun_depsamplesFmultivariate.m
+++ b/statfun/ft_statfun_depsamplesFmultivariate.m
@@ -8,36 +8,36 @@ function [s, cfg] = ft_statfun_depsamplesFmultivariate(cfg, dat, design)
 %   [stat] = ft_timelockstatistics(cfg, timelock1, timelock2, ...)
 %   [stat] = ft_freqstatistics(cfg, freq1, freq2, ...)
 %   [stat] = ft_sourcestatistics(cfg, source1, source2, ...)
-% with the following configuration option
+% with the following configuration option:
 %   cfg.statistic = 'ft_statfun_depsamplesFmultivariate'
 %
-% Configuration options
+% You can specify the following configuration options:
 %   cfg.contrastcoefs  = matrix of contrast coefficients determining the
 %                        effect being tested. The number of columns of this
-%                        matrix has to be equal to the number of conditions. 
+%                        matrix has to be equal to the number of conditions.
 %                        The default is a matrix that specifies the
 %                        main effect of the independent variable. This matrix
-%                        has size [(ncond-1),ncond]. 
+%                        has size [(ncond-1),ncond].
 %   cfg.computestat    = 'yes' or 'no', calculate the statistic (default='yes')
 %   cfg.computecritval = 'yes' or 'no', calculate the critical values of the test statistics (default='no')
 %   cfg.computeprob    = 'yes' or 'no', calculate the p-values (default='no')
 %
-% The following options are relevant if cfg.computecritval='yes' and/or
-% cfg.computeprob='yes'.
+% The following options are relevant if cfg.computecritval='yes' and/or cfg.computeprob='yes':
 %   cfg.alpha = critical alpha-level of the statistical test (default=0.05)
 %   cfg.tail  = -1, 0, or 1, left, two-sided, or right (default=1)
 %               cfg.tail in combination with cfg.computecritval='yes'
 %               determines whether the critical value is computed at
 %               quantile cfg.alpha (with cfg.tail=-1), at quantiles
 %               cfg.alpha/2 and (1-cfg.alpha/2) (with cfg.tail=0), or at
-%               quantile (1-cfg.alpha) (with cfg.tail=1).
+%               quantile (1-cfg.alpha) (with cfg.tail=1)
 %
-% Design specification
-%   cfg.ivar  = row number of the design that contains the labels of the conditions that must be 
-%               compared (default=1). The labels range from 1 to the number of conditions.
-%   cfg.uvar  = row number of design that contains the labels of the units-of-observation (subjects or trials)
-%               (default=2). The labels are assumed to be integers ranging from 1 to 
-%               the number of units-of-observation.
+% The experimental design is specified as:
+%   cfg.ivar  = independent variable, row number of the design that contains the labels of the conditions to be compared (default=1)
+%   cfg.uvar  = unit variable, row number of design that contains the labels of the units-of-observation, i.e. subjects or trials (default=2)
+%
+% The labels for the independent variable should be specified as numbers ranging
+% from 1 to the number of conditions. The labels for the unit of observation should
+% be integers ranging from 1 to the total number of observations (subjects or trials).
 %
 % See also FT_TIMELOCKSTATISTICS, FT_FREQSTATISTICS or FT_SOURCESTATISTICS
 
@@ -61,17 +61,19 @@ function [s, cfg] = ft_statfun_depsamplesFmultivariate(cfg, dat, design)
 %
 % $Id$
 
+% set the defaults
+cfg.computestat    = ft_getopt(cfg, 'computestat', 'yes');
+cfg.computecritval = ft_getopt(cfg, 'computecritval', 'no');
+cfg.computeprob    = ft_getopt(cfg, 'computeprob', 'no');
+cfg.alpha          = ft_getopt(cfg, 'alpha', 0.05);
+cfg.tail           = ft_getopt(cfg, 'tail', 1);
+cfg.ivar           = ft_getopt(cfg, 'ivar', 1);
+cfg.uvar           = ft_getopt(cfg, 'uvar', 2);
 
-% set defaults
-if ~isfield(cfg, 'computestat'),       cfg.computestat='yes';     end
-if ~isfield(cfg, 'computecritval'),    cfg.computecritval='no';   end
-if ~isfield(cfg, 'computeprob'),       cfg.computeprob='no';      end
-if ~isfield(cfg, 'alpha'),             cfg.alpha=0.05;            end
-if ~isfield(cfg, 'tail'),              cfg.tail=1;                end
+nconds = length(unique(design(cfg.ivar,:)));
 
-nconds=length(unique(design(cfg.ivar,:)));
 if ~isfield(cfg,'contrastcoefs')
-    % specify the default contrast coefficient matrix.
+    % specify the default contrast coefficient matrix
     ncontrasts = nconds-1;
     cfg.contrastcoefs = zeros(ncontrasts,nconds);
     cfg.contrastcoefs(:,1) = 1;

--- a/statfun/ft_statfun_depsamplesT.m
+++ b/statfun/ft_statfun_depsamplesT.m
@@ -1,37 +1,37 @@
 function [s, cfg] = ft_statfun_depsamplesT(cfg, dat, design)
 
-% FT_STATFUN_DEPSAMPLEST calculates the dependent samples T-statistic on the
-% biological data in dat (the dependent variable), using the information on the
-% independent variable (ivar) in design.
+% FT_STATFUN_DEPSAMPLEST calculates the dependent samples t-statistic on the
+% biological data (the dependent variable), using the information on the independent
+% variable (ivar) in the design.
 %
 % Use this function by calling one of the high-level statistics functions as
 %   [stat] = ft_timelockstatistics(cfg, timelock1, timelock2, ...)
 %   [stat] = ft_freqstatistics(cfg, freq1, freq2, ...)
 %   [stat] = ft_sourcestatistics(cfg, source1, source2, ...)
-% with the following configuration option
+% with the following configuration option:
 %   cfg.statistic = 'ft_statfun_depsamplesT'
 %
-% Configuration options
+% You can specify the following configuration options:
 %   cfg.computestat    = 'yes' or 'no', calculate the statistic (default='yes')
 %   cfg.computecritval = 'yes' or 'no', calculate the critical values of the test statistics (default='no')
 %   cfg.computeprob    = 'yes' or 'no', calculate the p-values (default='no')
 %
-% The following options are relevant if cfg.computecritval='yes' and/or
-% cfg.computeprob='yes'.
+% The following options are relevant if cfg.computecritval='yes' and/or cfg.computeprob='yes':
 %   cfg.alpha = critical alpha-level of the statistical test (default=0.05)
 %   cfg.tail  = -1, 0, or 1, left, two-sided, or right (default=1)
 %               cfg.tail in combination with cfg.computecritval='yes'
 %               determines whether the critical value is computed at
 %               quantile cfg.alpha (with cfg.tail=-1), at quantiles
 %               cfg.alpha/2 and (1-cfg.alpha/2) (with cfg.tail=0), or at
-%               quantile (1-cfg.alpha) (with cfg.tail=1).
+%               quantile (1-cfg.alpha) (with cfg.tail=1)
 %
-% Design specification
-%   cfg.ivar  = row number of the design that contains the labels of the conditions that must be
-%               compared (default=1). The labels are the numbers 1 and 2.
-%   cfg.uvar  = row number of design that contains the labels of the units-of-observation (subjects or trials)
-%               (default=2). The labels are assumed to be integers ranging from 1 to
-%               the number of units-of-observation.
+% The experimental design is specified as:
+%   cfg.ivar  = independent variable, row number of the design that contains the labels of the conditions to be compared (default=1)
+%   cfg.uvar  = unit variable, row number of design that contains the labels of the units-of-observation, i.e. subjects or trials (default=2)
+%
+% The labels for the independent variable should be specified as the number 1 and 2.
+% The labels for the unit of observation should be integers ranging from 1 to the
+% total number of observations (subjects or trials).
 %
 % See also FT_TIMELOCKSTATISTICS, FT_FREQSTATISTICS or FT_SOURCESTATISTICS
 
@@ -55,19 +55,18 @@ function [s, cfg] = ft_statfun_depsamplesT(cfg, dat, design)
 %
 % $Id$
 
-% set defaults
-if ~isfield(cfg, 'computestat'),    cfg.computestat    = 'yes'; end
-if ~isfield(cfg, 'computecritval'), cfg.computecritval = 'no';  end
-if ~isfield(cfg, 'computeprob'),    cfg.computeprob    = 'no';  end
-if ~isfield(cfg, 'alpha'),          cfg.alpha          = 0.05;  end
-if ~isfield(cfg, 'tail'),           cfg.tail           = 1;     end
+% set the defaults
+cfg.computestat    = ft_getopt(cfg, 'computestat', 'yes');
+cfg.computecritval = ft_getopt(cfg, 'computecritval', 'no');
+cfg.computeprob    = ft_getopt(cfg, 'computeprob', 'no');
+cfg.alpha          = ft_getopt(cfg, 'alpha', 0.05);
+cfg.tail           = ft_getopt(cfg, 'tail', 1);
+cfg.ivar           = ft_getopt(cfg, 'ivar', 1);
+cfg.uvar           = ft_getopt(cfg, 'uvar', 2);
 
 % perform some checks on the configuration
 if strcmp(cfg.computeprob,'yes') && strcmp(cfg.computestat,'no')
-  ft_error('P-values can only be calculated if the test statistics are calculated.');
-end
-if ~isfield(cfg,'uvar') || isempty(cfg.uvar)
-  ft_error('uvar must be specified for dependent samples statistics');
+  ft_error('P-values can only be calculated if the test statistics are calculated');
 end
 
 % perform some checks on the design
@@ -81,7 +80,7 @@ end
 nunits = length(design(cfg.uvar, sel1));
 df = nunits - 1;
 if nunits<2
-  ft_error('The data must contain at least two units (usually subjects).')
+  ft_error('The data must contain at least two units of observation (trials or subjects).')
 end
 if (nunits*2)~=(n1+n2)
   ft_error('Invalid specification of the design array.');
@@ -97,10 +96,10 @@ if strcmp(cfg.computestat,'yes')
   poslabelsperunit(:,1) = poslabel1(i);
   [dum,i]          = sort(design(cfg.uvar,poslabel2), 'ascend');
   poslabelsperunit(:,2) = poslabel2(i);
-  
+
   % calculate the differences between the conditions
   diffmat = dat(:,poslabelsperunit(:,1)) - dat(:,poslabelsperunit(:,2));
-  
+
   % calculate the dependent samples t-statistics
   if any(isnan(diffmat(:)))
     avgdiff = nanmean(diffmat,2);
@@ -137,4 +136,3 @@ if strcmp(cfg.computeprob, 'yes')
     s.prob = 1-tcdf(s.stat,s.df);
   end
 end
-

--- a/statfun/ft_statfun_depsamplesregrT.m
+++ b/statfun/ft_statfun_depsamplesregrT.m
@@ -1,36 +1,36 @@
 function [s, cfg] = ft_statfun_depsamplesregrT(cfg, dat, design)
 
-% FT_STATFUN_DEPSAMPLESREGRT calculates dependent samples regression T-statistic on
-% the biological data in dat (the dependent variable), using the information on the
-% independent variable (ivar) in design.
+% FT_STATFUN_DEPSAMPLESREGRT calculates independent samples regression coefficient
+% t-statistics on the biological data (the dependent variable), using the information
+% on the independent variable (predictor) in the design.
 %
 % Use this function by calling one of the high-level statistics functions as
 %   [stat] = ft_timelockstatistics(cfg, timelock1, timelock2, ...)
 %   [stat] = ft_freqstatistics(cfg, freq1, freq2, ...)
 %   [stat] = ft_sourcestatistics(cfg, source1, source2, ...)
-% with the following configuration option
+% with the following configuration option:
 %   cfg.statistic = 'ft_statfun_depsamplesregrT'
 %
-% Configuration options
+% You can specify the following configuration options:
 %   cfg.computestat    = 'yes' or 'no', calculate the statistic (default='yes')
 %   cfg.computecritval = 'yes' or 'no', calculate the critical values of the test statistics (default='no')
 %   cfg.computeprob    = 'yes' or 'no', calculate the p-values (default='no')
 %
-% The following options are relevant if cfg.computecritval='yes' and/or
-% cfg.computeprob='yes'.
+% The following options are relevant if cfg.computecritval='yes' and/or cfg.computeprob='yes':
 %   cfg.alpha = critical alpha-level of the statistical test (default=0.05)
 %   cfg.tail  = -1, 0, or 1, left, two-sided, or right (default=1)
 %               cfg.tail in combination with cfg.computecritval='yes'
 %               determines whether the critical value is computed at
 %               quantile cfg.alpha (with cfg.tail=-1), at quantiles
 %               cfg.alpha/2 and (1-cfg.alpha/2) (with cfg.tail=0), or at
-%               quantile (1-cfg.alpha) (with cfg.tail=1).
+%               quantile (1-cfg.alpha) (with cfg.tail=1)
 %
-% Design specification
-%   cfg.ivar  = row number of the design that contains the independent variable.
-%   cfg.uvar  = row number of design that contains the labels of the units-of-observation (subjects or trials)
-%               (default=2). The labels are assumed to be integers ranging from 1 to
-%               the number of units-of-observation.
+% The experimental design is specified as:
+%   cfg.ivar  = row number of the design that contains the independent variable, i.e. the predictor (default=1)
+%   cfg.uvar  = unit variable, row number of design that contains the labels of the units-of-observation, i.e. subjects or trials (default=2)
+%
+% The labels for the unit of observation should be integers ranging from 1 to the
+% total number of observations (subjects or trials).
 %
 % See also FT_TIMELOCKSTATISTICS, FT_FREQSTATISTICS or FT_SOURCESTATISTICS
 
@@ -54,12 +54,14 @@ function [s, cfg] = ft_statfun_depsamplesregrT(cfg, dat, design)
 %
 % $Id$
 
-% set defaults
-if ~isfield(cfg, 'computestat'),       cfg.computestat='yes';     end
-if ~isfield(cfg, 'computecritval'),    cfg.computecritval='no';   end
-if ~isfield(cfg, 'computeprob'),       cfg.computeprob='no';      end
-if ~isfield(cfg, 'alpha'),             cfg.alpha=0.05;            end
-if ~isfield(cfg, 'tail'),              cfg.tail=1;                end
+% set the defaults
+cfg.computestat    = ft_getopt(cfg, 'computestat', 'yes');
+cfg.computecritval = ft_getopt(cfg, 'computecritval', 'no');
+cfg.computeprob    = ft_getopt(cfg, 'computeprob', 'no');
+cfg.alpha          = ft_getopt(cfg, 'alpha', 0.05);
+cfg.tail           = ft_getopt(cfg, 'tail', 1);
+cfg.ivar           = ft_getopt(cfg, 'ivar', 1);
+cfg.uvar           = ft_getopt(cfg, 'uvar', 2);
 
 % perform some checks on the configuration
 if strcmp(cfg.computeprob,'yes') && strcmp(cfg.computestat,'no')
@@ -70,10 +72,10 @@ if ~isfield(cfg,'uvar') || isempty(cfg.uvar)
 end
 
 if ~isempty(cfg.cvar)
-  condlabels=unique(design(cfg.cvar,:));
-  nblocks=length(condlabels);
+  condlabels = unique(design(cfg.cvar,:));
+  nblocks = length(condlabels);
 else
-  nblocks=1;
+  nblocks = 1;
 end
 
 nunits = max(design(cfg.uvar,:));
@@ -129,4 +131,3 @@ if strcmp(cfg.computeprob,'yes')
     s.prob = 1-tcdf(s.stat,s.df);
   end
 end
-

--- a/statfun/ft_statfun_diff.m
+++ b/statfun/ft_statfun_diff.m
@@ -1,18 +1,27 @@
 function [s, cfg] = ft_statfun_diff(cfg, dat, design)
 
-% FT_STATFUN_DIFF computes the difference of the mean in two conditions. Although it
-% can be used for statistical testing, it is not very usefull since it will have
-% rather limited sensitivity.
-% 
-% The purpose of this function is to show you an example on how to write a statfun
-% that expresses the difference in the data between two conditions. You can use such
-% a function with the statistical framework in FieldTrip to perform a simple (or more
-% complex) permutation test, without having to worry about the representation of the
-% data.
+% FT_STATFUN_DIFF demonstrates how to compute the difference of the mean in two
+% conditions. Although it can be used for statistical testing, it will have rather
+% limited sensitivity and is not really suited for inferential testing.
 %
-% See also FT_STATFUN_MEAN for another example function
+% This function serves as an example for a statfun. You can use such a function with
+% the statistical framework in FieldTrip using FT_TIMELOCKSTATISTICS,
+% FT_FREQSTATISTICS or FT_SOURCESTATISTICS to perform a statistical test, without
+% having to worry about the representation of the data.
+%
+% Use this function by calling the high-level statistic functions as
+%   [stat] = ft_freqstatistics(cfg, freq1, freq2, ...)
+% with the following configuration option:
+%   cfg.statistic = 'ft_statfun_diff_itc'
+%
+% The experimental design is specified as:
+%   cfg.ivar  = independent variable, row number of the design that contains the labels of the conditions to be compared (default=1)
+%
+% The labels for the independent variable should be specified as the number 1 and 2.
+%
+% See also FT_TIMELOCKSTATISTICS, FT_FREQSTATISTICS or FT_SOURCESTATISTICS, and see FT_STATFUN_MEAN for a similar example
 
-% Copyright (C) 2006, Robert Oostenveld 
+% Copyright (C) 2006, Robert Oostenveld
 %
 % This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
 % for the documentation and details.
@@ -32,20 +41,22 @@ function [s, cfg] = ft_statfun_diff(cfg, dat, design)
 %
 % $Id$
 
-selA = find(design(cfg.ivar,:)==1); % selecton condition 1 or A
-selB = find(design(cfg.ivar,:)==2); % selecton condition 2 or B
-dfA  = length(selA);
-dfB  = length(selB);
-if (dfA+dfB)<size(design, 2)
+% set the defaults
+cfg.ivar           = ft_getopt(cfg, 'ivar', 1);
+
+sel1 = find(design(cfg.ivar,:)==1); % select replications that belong to condition 1
+sel2 = find(design(cfg.ivar,:)==2); % select replications that belong to condition 2
+n1  = length(sel1);
+n2  = length(sel2);
+
+if (n1+n2)<size(design, 2)
   % there are apparently replications that belong neither to condition 1, nor to condition 2
   ft_warning('inappropriate design, it should only contain 1''s and 2''s');
 end
+
 % compute the averages and the difference
-avgA = nanmean(dat(:,selA), 2);
-avgB = nanmean(dat(:,selB), 2);
-s.stat = avgA - avgB;
+avg1 = nanmean(dat(:,sel1), 2);
+avg2 = nanmean(dat(:,sel2), 2);
 
-% the stat field is used in STATISTICS_MONTECARLO to make the
-% randomization distribution, but you can also return other fields
-% which will be passed on to the command line in the end.
-
+% return the difference in the means as statistic of interest
+s.stat = avg1 - avg2;

--- a/statfun/ft_statfun_indepsamplesT.m
+++ b/statfun/ft_statfun_indepsamplesT.m
@@ -8,16 +8,15 @@ function [s, cfg] = ft_statfun_indepsamplesT(cfg, dat, design)
 %   [stat] = ft_timelockstatistics(cfg, timelock1, timelock2, ...)
 %   [stat] = ft_freqstatistics(cfg, freq1, freq2, ...)
 %   [stat] = ft_sourcestatistics(cfg, source1, source2, ...)
-% with the following configuration option
+% with the following configuration option:
 %   cfg.statistic = 'ft_statfun_indepsamplesT'
 %
-% Configuration options
+% You can specify the following configuration options:
 %   cfg.computestat    = 'yes' or 'no', calculate the statistic (default='yes')
 %   cfg.computecritval = 'yes' or 'no', calculate the critical values of the test statistics (default='no')
 %   cfg.computeprob    = 'yes' or 'no', calculate the p-values (default='no')
 %
-% The following options are relevant if cfg.computecritval='yes' and/or
-% cfg.computeprob='yes'.
+% The following options are relevant if cfg.computecritval='yes' and/or cfg.computeprob='yes':
 %   cfg.alpha = critical alpha-level of the statistical test (default=0.05)
 %   cfg.tail  = -1, 0, or 1, left, two-sided, or right (default=1)
 %               cfg.tail in combination with cfg.computecritval='yes'
@@ -26,9 +25,10 @@ function [s, cfg] = ft_statfun_indepsamplesT(cfg, dat, design)
 %               cfg.alpha/2 and (1-cfg.alpha/2) (with cfg.tail=0), or at
 %               quantile (1-cfg.alpha) (with cfg.tail=1).
 %
-% Design specification
-%   cfg.ivar  = row number of the design that contains the labels of the conditions that must be
-%               compared (default=1). The labels are the numbers 1 and 2.
+% The experimental design is specified as:
+%   cfg.ivar  = independent variable, row number of the design that contains the labels of the conditions to be compared (default=1)
+%
+% The labels for the independent variable should be specified as the number 1 and 2.
 %
 % See also FT_TIMELOCKSTATISTICS, FT_FREQSTATISTICS or FT_SOURCESTATISTICS
 
@@ -58,6 +58,7 @@ cfg.computecritval = ft_getopt(cfg, 'computecritval', 'no');
 cfg.computeprob    = ft_getopt(cfg, 'computeprob', 'no');
 cfg.alpha          = ft_getopt(cfg, 'alpha', 0.05);
 cfg.tail           = ft_getopt(cfg, 'tail', 1);
+cfg.ivar           = ft_getopt(cfg, 'ivar', 1);
 
 % perform some checks on the configuration
 if strcmp(cfg.computeprob,'yes') && strcmp(cfg.computestat,'no')
@@ -83,7 +84,7 @@ end
 df = nrepl - 2;
 
 if strcmp(cfg.computestat, 'yes')
-  % compute the statistic use nanmean only if necessary
+  % compute the statistic, use nanmean only if necessary
   if hasnans1
     avg1 = nanmean(dat(:,sel1), 2);
     var1 = nanvar(dat(:,sel1), 0, 2);
@@ -102,12 +103,12 @@ if strcmp(cfg.computestat, 'yes')
     % the following achieves the same as the line above, but faster
     var2 = (sum(dat(:,sel2).^2,2)-(avg2.^2).*nreplc2)./(nreplc2-1);
   end
-  
+
   varc = (1./nreplc1 + 1./nreplc2).*((nreplc1-1).*var1 + (nreplc2-1).*var2)./df;
-  
-  % in the case of non-equal triallengths, and tfrs as input-data nreplc are
-  % vectors with different values. when the triallengths are equal, and the
-  % input is a tfr, nreplc are vectors with either zeros (all trials contain nan
+
+  % in the case of non-equal trial lengths, and TFRs as input-data, nreplc are
+  % vectors with different values. When the trial lengths are equal, and the
+  % input is a TFR, nreplc are vectors with either zeros (all trials contain nan
   % meaning that t_ftimwin did not fit around data), or the number of trials
   s.stat = (avg1 - avg2)./sqrt(varc);
 end

--- a/statfun/ft_statfun_indepsamplesZcoh.m
+++ b/statfun/ft_statfun_indepsamplesZcoh.m
@@ -19,24 +19,24 @@ function [s, cfg] = ft_statfun_indepsamplesZcoh(cfg, dat, design)
 % channel combinations are the elements of the lower diagonal of the cross-spectral
 % density matrix.
 %
-% Configuration options
+% You can specify the following configuration options:
 %   cfg.computestat    = 'yes' or 'no', calculate the statistic (default='yes')
 %   cfg.computecritval = 'yes' or 'no', calculate the critical values of the test statistics (default='no')
 %   cfg.computeprob    = 'yes' or 'no', calculate the p-values (default='no')
 %
-% The following options are relevant if cfg.computecritval='yes' and/or
-% cfg.computeprob='yes'.
+% The following options are relevant if cfg.computecritval='yes' and/or cfg.computeprob='yes':
 %   cfg.alpha = critical alpha-level of the statistical test (default=0.05)
 %   cfg.tail  = -1, 0, or 1, left, two-sided, or right (default=1)
 %               cfg.tail in combination with cfg.computecritval='yes'
 %               determines whether the critical value is computed at
 %               quantile cfg.alpha (with cfg.tail=-1), at quantiles
 %               cfg.alpha/2 and (1-cfg.alpha/2) (with cfg.tail=0), or at
-%               quantile (1-cfg.alpha) (with cfg.tail=1).
+%               quantile (1-cfg.alpha) (with cfg.tail=1)
 %
-% Design specification
-%   cfg.ivar  = column number of the design that contains the labels of the conditions that
-%               must be compared (default=1). The labels are the numbers 1 and 2.
+% The experimental design is specified as:
+%   cfg.ivar  = independent variable, row number of the design that contains the labels of the conditions to be compared (default=1)
+%
+% The labels for the independent variable should be specified as the number 1 and 2.
 %
 % See also FT_TIMELOCKSTATISTICS, FT_FREQSTATISTICS or FT_SOURCESTATISTICS
 
@@ -61,19 +61,18 @@ function [s, cfg] = ft_statfun_indepsamplesZcoh(cfg, dat, design)
 % $Id$
 
 % set the defaults
-if ~isfield(cfg, 'computestat'),       cfg.computestat='yes';     end
-if ~isfield(cfg, 'computecritval'),    cfg.computecritval='no';   end
-if ~isfield(cfg, 'computeprob'),       cfg.computeprob='no';      end
-if ~isfield(cfg, 'alpha'),             cfg.alpha=0.05;            end
-if ~isfield(cfg, 'tail'),              cfg.tail=1;                end
+cfg.computestat    = ft_getopt(cfg, 'computestat', 'yes');
+cfg.computecritval = ft_getopt(cfg, 'computecritval', 'no');
+cfg.computeprob    = ft_getopt(cfg, 'computeprob', 'no');
+cfg.alpha          = ft_getopt(cfg, 'alpha', 0.05);
+cfg.tail           = ft_getopt(cfg, 'tail', 1);
+cfg.ivar           = ft_getopt(cfg, 'ivar', 1);
 
 % perform some checks on the configuration
 if strcmp(cfg.computeprob,'yes') && strcmp(cfg.computestat,'no')
-    ft_error('P-values can only be calculated if the test statistics are calculated.');
+  ft_error('P-values can only be calculated if the test statistics are calculated.');
 end
-if isfield(cfg,'uvar') && ~isempty(cfg.uvar)
-    ft_error('cfg.uvar should not exist for an independent samples statistic');
-end
+
 % if ~isfield(cfg, 'label') && ~isfield(cfg, 'pos')
 %   ft_error('the configuration needs to contain either a label or a pos field');
 % elseif isfield(cfg, 'label') && isfield(cfg, 'pos') && ~isempty(cfg.label) && ~isempty(cfg.pos)
@@ -95,7 +94,7 @@ if nrepl<size(design,1)
   ft_error('Invalid specification of the independent variable in the design array.');
 end
 if nreplc1<2 || nreplc2<2
-    ft_error('Every condition must contain at least two trials/tapers.');
+  ft_error('Every condition must contain at least two trials/tapers.');
 end
 dfc1 = nreplc1*2;
 dfc2 = nreplc2*2;
@@ -158,11 +157,9 @@ elseif strcmp(cfg.dimord(1:4), 'chan')
   cfg.dimord = ['chancmb',cfg.dimord(5:end)];
 end
 
-% append an indexing matrix to the cfg to be able to recover the channel
-% combinations
-chanindx = tril(true(nchan),-1);
+% append an indexing matrix to the cfg to be able to recover the channel combinations
+chanindx = tril(true(nchan), -1);
 cmbindx1 = repmat((1:nchan)', [1 nchan]);
 cmbindx2 = repmat((1:nchan),  [nchan 1]);
 cfg.chancmbindx(:,1) = cmbindx1(chanindx);
 cfg.chancmbindx(:,2) = cmbindx2(chanindx);
-

--- a/statfun/ft_statfun_indepsamplesregrT.m
+++ b/statfun/ft_statfun_indepsamplesregrT.m
@@ -1,8 +1,8 @@
 function [s, cfg] = ft_statfun_indepsamplesregrT(cfg, dat, design)
 
 % FT_STATFUN_INDEPSAMPLESREGRT calculates independent samples regression coefficient
-% T-statistics on the biological data in dat (the dependent variable), using the
-% information on the independent variable (predictor) in design.
+% t-statistics on the biological data (the dependent variable), using the information
+% on the independent variable (predictor) in the design.
 %
 % Use this function by calling one of the high-level statistics functions as
 %   [stat] = ft_timelockstatistics(cfg, timelock1, timelock2, ...)
@@ -11,23 +11,22 @@ function [s, cfg] = ft_statfun_indepsamplesregrT(cfg, dat, design)
 % with the following configuration option
 %   cfg.statistic = 'ft_statfun_indepsamplesregrT'
 %
-% Configuration options
-%   cfg.computestat    = 'yes' or 'no', calculate the statistic (default='yes')
-%   cfg.computecritval = 'yes' or 'no', calculate the critical values of the test statistics (default='no')
-%   cfg.computeprob    = 'yes' or 'no', calculate the p-values (default='no')
+% You can specify the following configuration options:
+%   cfg.computestat    = 'yes' or 'no', calculate the statistic (default = 'yes')
+%   cfg.computecritval = 'yes' or 'no', calculate the critical values of the test statistics (default = 'no')
+%   cfg.computeprob    = 'yes' or 'no', calculate the p-values (default = 'no')
 %
-% The following options are relevant if cfg.computecritval='yes' and/or
-% cfg.computeprob='yes'.
+% The following options are relevant if cfg.computecritval='yes' and/or cfg.computeprob='yes':
 %   cfg.alpha = critical alpha-level of the statistical test (default=0.05)
 %   cfg.tail  = -1, 0, or 1, left, two-sided, or right (default=1)
 %               cfg.tail in combination with cfg.computecritval='yes'
 %               determines whether the critical value is computed at
 %               quantile cfg.alpha (with cfg.tail=-1), at quantiles
 %               cfg.alpha/2 and (1-cfg.alpha/2) (with cfg.tail=0), or at
-%               quantile (1-cfg.alpha) (with cfg.tail=1).
+%               quantile (1-cfg.alpha) (with cfg.tail=1)
 %
-% Design specification
-%   cfg.ivar  = row number of the design that contains the independent variable (default=1)
+% The experimental design is specified as:
+%   cfg.ivar  = row number of the design that contains the independent variable, i.e. the predictor (default=1)
 %
 % See also FT_TIMELOCKSTATISTICS, FT_FREQSTATISTICS or FT_SOURCESTATISTICS
 
@@ -51,26 +50,27 @@ function [s, cfg] = ft_statfun_indepsamplesregrT(cfg, dat, design)
 %
 % $Id$
 
-% set defaults
-if ~isfield(cfg, 'computestat'),       cfg.computestat='yes';     end
-if ~isfield(cfg, 'computecritval'),    cfg.computecritval='no';   end
-if ~isfield(cfg, 'computeprob'),       cfg.computeprob='no';      end
-if ~isfield(cfg, 'alpha'),             cfg.alpha=0.05;            end
-if ~isfield(cfg, 'tail'),              cfg.tail=1;                end
+% set the defaults
+cfg.computestat    = ft_getopt(cfg, 'computestat', 'yes');
+cfg.computecritval = ft_getopt(cfg, 'computecritval', 'no');
+cfg.computeprob    = ft_getopt(cfg, 'computeprob', 'no');
+cfg.alpha          = ft_getopt(cfg, 'alpha', 0.05);
+cfg.tail           = ft_getopt(cfg, 'tail', 1);
+cfg.ivar           = ft_getopt(cfg, 'ivar', 1);
 
 % perform some checks on the configuration
 if strcmp(cfg.computeprob,'yes') && strcmp(cfg.computestat,'no')
-    ft_error('P-values can only be calculated if the test statistics are calculated.');
+  ft_error('P-values can only be calculated if the test statistics are calculated.');
 end
 if isfield(cfg,'uvar') && ~isempty(cfg.uvar)
-    ft_error('cfg.uvar should not exist for an independent samples statistic');
+  ft_error('cfg.uvar should not exist for an independent samples statistic');
 end
 
 if ~isempty(cfg.cvar)
-  condlabels=unique(design(cfg.cvar,:));
-  nblocks=length(condlabels);
+  condlabels = unique(design(cfg.cvar,:));
+  nblocks = length(condlabels);
 else
-  nblocks=1;
+  nblocks = 1;
 end
 
 [nsmpl,nrepl] = size(dat);
@@ -81,30 +81,30 @@ end
 
 if strcmp(cfg.computestat, 'yes')
   % compute the statistic
-    indvar = design(cfg.ivar,:);
-    if isempty(cfg.cvar)
-      designmat = [ones(nrepl,1) indvar']; % designmat is a matrix of order Nrepl x 2
-    else
-      designmat = zeros(nrepl,(nblocks+1));
-      for blockindx=1:nblocks
-        selvec=find(design(cfg.cvar,:)==condlabels(blockindx));
-        designmat(selvec,blockindx)=1; 
-      end
-      designmat(:,(nblocks+1))=indvar'; % designmat is a matrix of order Nrepl x (nblocks+1)
+  indvar = design(cfg.ivar,:);
+  if isempty(cfg.cvar)
+    designmat = [ones(nrepl,1) indvar']; % designmat is a matrix of order Nrepl x 2
+  else
+    designmat = zeros(nrepl,(nblocks+1));
+    for blockindx=1:nblocks
+      selvec=find(design(cfg.cvar,:)==condlabels(blockindx));
+      designmat(selvec,blockindx)=1;
     end
-    cpmat = designmat'*designmat;
-    invcpmat = inv(cpmat);
-    projmat = invcpmat*designmat';
-    B = dat*projmat'; % B is a matrix of order Nsamples x (nblocks+1)
-    res = dat - B*designmat';
-    resvar = zeros(nsmpl,1);
-    for indx=1:nsmpl
-      resvar(indx)=res(indx,:)*res(indx,:)';
-    end
-    resvar=resvar/df;
-    
-    se=sqrt(invcpmat(nblocks+1,nblocks+1)*resvar);
-    s.stat=B(:,nblocks+1)./se;
+    designmat(:,(nblocks+1))=indvar'; % designmat is a matrix of order Nrepl x (nblocks+1)
+  end
+  cpmat = designmat'*designmat;
+  invcpmat = inv(cpmat);
+  projmat = invcpmat*designmat';
+  B = dat*projmat'; % B is a matrix of order Nsamples x (nblocks+1)
+  res = dat - B*designmat';
+  resvar = zeros(nsmpl,1);
+  for indx=1:nsmpl
+    resvar(indx)=res(indx,:)*res(indx,:)';
+  end
+  resvar=resvar/df;
+
+  se=sqrt(invcpmat(nblocks+1,nblocks+1)*resvar);
+  s.stat=B(:,nblocks+1)./se;
 end
 
 if strcmp(cfg.computecritval,'yes')
@@ -130,4 +130,3 @@ if strcmp(cfg.computeprob,'yes')
     s.prob = 1-tcdf(s.stat,s.df);
   end
 end
-

--- a/statfun/ft_statfun_mean.m
+++ b/statfun/ft_statfun_mean.m
@@ -1,16 +1,15 @@
 function [s, cfg] = ft_statfun_mean(cfg, dat, design)
 
-% FT_STATFUN_MEAN computes the mean over all replications for each of the
-% observations (i.e. channel-time-frequency points or voxels).
+% FT_STATFUN_MEAN demonstrates how to compute the mean over all conditions in the
+% data. Since this does NOT depend on the experimental design, it cannot be used for
+% testing for differences between conditions.
 %
-% This function does not depend on the experimental design and cannot be used for any
-% statistical testing. However, it serves as example how you can use the statistical
-% framework in FieldTrip to perform a simple (or more complex) task, without having
-% to worry about the representation of the data. The output of FT_TIMELOCKSTATISTICS,
-% FT_FREQSTATISTICS or FT_SOURCESTATISTICS will be an appropriate structure, that
-% contains the result of the computation inside this function in the stat field.
+% This function serves as an example for a statfun. You can use such a function with
+% the statistical framework in FieldTrip using FT_TIMELOCKSTATISTICS,
+% FT_FREQSTATISTICS or FT_SOURCESTATISTICS to perform a statistical test, without
+% having to worry about the representation of the data.
 %
-% See also FT_STATFUN_DIFF for another example statfun
+% See also FT_TIMELOCKSTATISTICS, FT_FREQSTATISTICS or FT_SOURCESTATISTICS, and see FT_STATFUN_DIFF for a similar example
 
 % Copyright (C) 2012, Donders Centre for Cognitive Neuroimaging, Nijmegen, NL
 %
@@ -32,9 +31,9 @@ function [s, cfg] = ft_statfun_mean(cfg, dat, design)
 %
 % $Id$
 
-% the stat field is used in STATISTICS_MONTECARLO to make the
-% randomization distribution, but you can also return other fields
-% which will be passed on to the command line in the end.
+if numel(unique(design(cfg.ivar,:)))>1
+  ft_warning('inappropriate design, it should only contain one condition');
+end
 
+% return the means as the statistic of interest
 s.stat = mean(dat,2);
-

--- a/statfun/ft_statfun_pooledT.m
+++ b/statfun/ft_statfun_pooledT.m
@@ -1,23 +1,10 @@
 function [s, cfg] = ft_statfun_pooledT(cfg, dat, design)
 
 % FT_STATFUN_POOLEDT computes the pooled t-value over a number of replications. The
-% idea is that you compute a contrast between two conditions per subject The t-values
-% are pooled over subjects and compared against the pooled pseudo-values. Since
-% according to H0 the expected t-value for each subject value is zero, the difference
-% between the pooled t-value and the pseudo-value (which is set to zero) is a
-% fixed-effects statistic.
-% 
-% The computation of the difference between pooled t-values can be repeated after
-% randomly permuting the t-values and pseudo-values within the subjects. Each random
-% permutation gives you an estimate of the difference. The random permutations build
-% up a randomization distributin, against which you can compare the observed pooled
-% t-values.
-% 
-% The statistical inference based on the comparison of the observed pooled t-values
-% with the randomization distribution is not a fixed-effect statistic, one or a few
-% outlier will cause the randomization distribution to broaden and result in the
-% conclusion of "not significant".
-% 
+% idea behind this function is that you first (prior to calling this function)
+% compute a contrast between two conditions per subject, and that subsequently you
+% test this over subjects using random sign-flipping.
+%
 % Use this function by calling one of the high-level statistics functions as
 %   [stat] = ft_timelockstatistics(cfg, timelock1, timelock2, ...)
 %   [stat] = ft_freqstatistics(cfg, freq1, freq2, ...)
@@ -25,40 +12,65 @@ function [s, cfg] = ft_statfun_pooledT(cfg, dat, design)
 % with the following configuration option
 %   cfg.statistic = 'ft_statfun_pooledT'
 %
-% Configuration options that are relevant for this function are
-%   cfg.ivar      = number, index into the design matrix with the independent variable
+% The expected values for the pooled-t, which is zero according to H0, have to be
+% passed as pseudo-values. The subject-specific t-values will be randomly swapped with
+% the pseudo-values and the difference is computed; in effect this implements random
+% sign-flipping.
+%
+% The randimization distribution (with optional clustering) of the randomly
+% sign-flipped pooled-t values is computed and used for statistical inference.
+%
+% Note that, although the output of this function is to be interpreted as a
+% fixed-effects statistic, the statistical inference based on the comparison of the
+% observed pooled t-values with the randomization distribution is not a fixed-effect
+% statistic, one or a few outlier will cause the randomization distribution to
+% broaden and result in the conclusion of "not significant".
+%
+% The experimental design is specified as:
+%   cfg.ivar  = independent variable, row number of the design that contains the labels of the conditions to be sign-flipped (default=1)
+%
+% The labels independent variable should be specified as the number 1 for the
+% observed t-values and 2 for the pseudo-values.
 %
 % See also FT_TIMELOCKSTATISTICS, FT_FREQSTATISTICS or FT_SOURCESTATISTICS
 
 % Copyright (C) 2007, Robert Oostenveld
 %
-% This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
-% for the documentation and details.
+% This file is part of FieldTrip, see http://www.fieldtriptoolbox.org for the
+% documentation and details.
 %
-%    FieldTrip is free software: you can redistribute it and/or modify
-%    it under the terms of the GNU General Public License as published by
-%    the Free Software Foundation, either version 3 of the License, or
-%    (at your option) any later version.
+%    FieldTrip is free software: you can redistribute it and/or modify it under the
+%    terms of the GNU General Public License as published by the Free Software
+%    Foundation, either version 3 of the License, or (at your option) any later
+%    version.
 %
-%    FieldTrip is distributed in the hope that it will be useful,
-%    but WITHOUT ANY WARRANTY; without even the implied warranty of
-%    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-%    GNU General Public License for more details.
+%    FieldTrip is distributed in the hope that it will be useful, but WITHOUT ANY
+%    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+%    PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 %
-%    You should have received a copy of the GNU General Public License
-%    along with FieldTrip. If not, see <http://www.gnu.org/licenses/>.
+%    You should have received a copy of the GNU General Public License along with
+%    FieldTrip. If not, see <http://www.gnu.org/licenses/>.
 %
 % $Id$
 
+% set the defaults
+cfg.ivar = ft_getopt(cfg, 'ivar', 1);
 
-selA = find(design(cfg.ivar,:)==1);
-selB = find(design(cfg.ivar,:)==2);
-dfA  = length(selA);
-dfB  = length(selB);
-if (dfA+dfB)<size(design, 2)
-  ft_error('inappropriate design, should only contain 1''s and 2''s');
+sel1 = find(design(cfg.ivar,:)==1);
+sel2 = find(design(cfg.ivar,:)==2);
+df1  = length(sel1);
+df2  = length(sel2);
+
+if (df1+df2)<size(design, 2)
+  ft_error('inappropriate design, it should only contain 1''s and 2''s');
 end
-sumA = sum(dat(:,selA), 2);
-sumB = sum(dat(:,selB), 2);
-s.stat = (sumA - sumB)./sqrt(dfA);
 
+if df1~=df2
+  ft_error('inappropriate design, it should contain the same number of 1''s and 2''s');
+end
+
+sum1 = sum(dat(:,sel1), 2);
+sum2 = sum(dat(:,sel2), 2);
+
+% return the pooled-t value as the statistic of interest
+s.stat = (sum1 - sum2)./sqrt(df1);

--- a/test/test_tutorial_eventrelatedstatistics.m
+++ b/test/test_tutorial_eventrelatedstatistics.m
@@ -8,8 +8,6 @@ function test_tutorial_eventrelatedstatistics
 
 load(dccnpath('/home/common/matlab/fieldtrip/data/ftp/tutorial/eventrelatedstatistics/ERF_orig.mat'));
 
-% Tutorial update on 3 Feb: no longer give grandaverage inarg to
-% ft_XX_statistics, instead introduce cell-array inarg. 
 %% calculating the grand-average
 
 % calculate grand average for each condition
@@ -17,66 +15,75 @@ cfg = [];
 cfg.channel   = 'all';
 cfg.latency   = 'all';
 cfg.parameter = 'avg';
-GA_FC         = ft_timelockgrandaverage(cfg,allsubjFC{:});  
-GA_FIC        = ft_timelockgrandaverage(cfg,allsubjFIC{:});
+grandavgFIC   = ft_timelockgrandaverage(cfg, allsubjFIC{:});
+grandavgFC    = ft_timelockgrandaverage(cfg, allsubjFC{:});
+% "{:}" means to use data from all elements of the variable
 
-%% plotting the grand-average
-cfg = [];
+
+%% plotting the grand-averagecfg = [];
 cfg.showlabels  = 'yes';
-cfg.layout    	= 'CTF151.lay';
-figure; ft_multiplotER(cfg,GA_FC, GA_FIC)
- 
+cfg.layout      = 'CTF151_helmet.mat';
+figure; ft_multiplotER(cfg, grandavgFIC, grandavgFC)
+
 cfg = [];
 cfg.channel = 'MLT12';
-figure; ft_singleplotER(cfg,GA_FC, GA_FIC)
+figure; ft_singleplotER(cfg, grandavgFIC, grandavgFC)
 
+
+%%
 
 time = [0.3 0.7];
 % Scaling of the vertical axis for the plots below
-ymax = 1.9e-13; 
-figure; 
-for iSub = 1:10
-    subplot(3,4,iSub)
-    plot(allsubjFC{iSub}.time,allsubjFC{iSub}.avg(52,:));
-    hold on
-    % use the rectangle to indicate the time range used later 
-    rectangle('Position',[time(1) 0 (time(2)-time(1)) ymax],'FaceColor',[0.7 0.7 0.7]);
-    % repeat the plotting to get the line in front of the rectangle
-    plot(allsubjFIC{iSub}.time,allsubjFIC{iSub}.avg(52,:),'r');
-    title(strcat('subject ',num2str(iSub)))
-    ylim([0 1.9e-13])
-    xlim([-1 2])
+ymax = 1.9e-13;
+figure;
+for isub = 1:10
+  subplot(3,4,isub)
+  % use the rectangle to indicate the time range used later
+  rectangle('Position',[time(1) 0 (time(2)-time(1)) ymax],'FaceColor',[0.7 0.7 0.7]);
+  hold on;
+  % plot the lines in front of the rectangle
+  plot(allsubjFIC{isub}.time,allsubjFIC{isub}.avg(52,:), 'b');
+  plot(allsubjFC{isub}.time,allsubjFC{isub}.avg(52,:), 'r');
+  title(strcat('subject ',num2str(isub)))
+  ylim([0 1.9e-13])
+  xlim([-1 2])
 end
-subplot(3,4,11); 
-text(0.5,0.5,'FC','color','b') ;text(0.5,0.3,'FIC','color','r')
+subplot(3,4,11);
+text(0.5,0.5,'FIC','color','b') ;text(0.5,0.3,'FC','color','r')
 axis off
 
+
 %% plotting single subject averages
+
 chan = 52;
 time = [0.3 0.7];
- 
+
 % find the time points for the effect of interest in the grand average data
-timesel_FIC = find(GA_FIC.time >= time(1) & GA_FIC.time <= time(2));
-timesel_FC = find(GA_FC.time >= time(1) & GA_FC.time <= time(2));
- 
+timesel_FIC = find(grandavgFIC.time >= time(1) & grandavgFIC.time <= time(2));
+timesel_FC  = find(grandavgFC.time >= time(1) & grandavgFC.time <= time(2));
+
 % select the individual subject data from the time points and calculate the mean
 for isub = 1:10
-    values_FIC(isub)  = mean(allsubjFIC{isub}.avg(chan,timesel_FIC));   
-    values_FC(isub)  = mean(allsubjFC{isub}.avg(chan,timesel_FC));
+  valuesFIC(isub) = mean(allsubjFIC{isub}.avg(chan,timesel_FIC));
+  valuesFC(isub)  = mean(allsubjFC{isub}.avg(chan,timesel_FC));
 end
- 
+
 % plot to see the effect in each subject
-M = [values_FC',values_FIC'];
-figure; plot(M','o-'); xlim([0.5 2.5])
+M = [valuesFIC(:) valuesFC(:)];
+figure; plot(M', 'o-'); xlim([0.5 2.5])
 legend({'subj1', 'subj2', 'subj3', 'subj4', 'subj5', 'subj6', ...
-        'subj7', 'subj8', 'subj9', 'subj10'}, 'location','EastOutside');
-      
+  'subj7', 'subj8', 'subj9', 'subj10'}, 'location', 'EastOutside');
+
+
 %% T-test with MATLAB function
-% dependent samples ttest
-FCminFIC = values_FC - values_FIC;
-[h,p,ci,stats] = ttest_wrapper(FCminFIC, 0, 0.05) % H0: mean = 0, alpha 0.05;
+
+FICminFC = valuesFIC - valuesFC;
+[h,p,ci,stats] = ttest(FICminFC, 0, 0.05) % H0: mean = 0, alpha 0.05
+
 
 %% T-test with FieldTrip function
+
+% define the parameters for the statistical comparison
 cfg = [];
 cfg.channel     = 'MLT12';
 cfg.latency     = [0.3 0.7];
@@ -86,57 +93,67 @@ cfg.method      = 'analytic';
 cfg.statistic   = 'ft_statfun_depsamplesT';
 cfg.alpha       = 0.05;
 cfg.correctm    = 'no';
- 
+
 Nsub = 10;
 cfg.design(1,1:2*Nsub)  = [ones(1,Nsub) 2*ones(1,Nsub)];
 cfg.design(2,1:2*Nsub)  = [1:Nsub 1:Nsub];
 cfg.ivar                = 1; % the 1st row in cfg.design contains the independent variable
 cfg.uvar                = 2; % the 2nd row in cfg.design contains the subject number
- 
-stat = ft_timelockstatistics(cfg, allsubjFC{:}, allsubjFIC{:});
+
+stat = ft_timelockstatistics(cfg, allsubjFIC{:}, allsubjFC{:});   % don't forget the {:}!
+
 
 %% Multiple comparisons
 
-%loop over channels
+% loop over channels
 time = [0.3 0.7];
-timesel_FIC = find(GA_FIC.time >= time(1) & GA_FIC.time <= time(2));
-timesel_FC = find(GA_FC.time >= time(1) & GA_FC.time <= time(2));
+timesel_FIC = find(grandavgFIC.time >= time(1) & grandavgFIC.time <= time(2));
+timesel_FC  = find(grandavgFC.time >= time(1) & grandavgFC.time <= time(2));
 clear h p
- 
+
 FICminFC = zeros(1,10);
- 
+
 for iChan = 1:151
-    for isub = 1:10
-        FICminFC(isub) = mean(allsubjFIC{isub}.avg(iChan,timesel_FIC)) - mean(allsubjFC{isub}.avg(iChan,timesel_FC));
-        [h(iChan), p(iChan)] = ttest_wrapper(FICminFC, 0, 0.05 ); % test each channel separately
-    end
+  for isub = 1:10
+    FICminFC(isub) = ...
+      mean(allsubjFIC{isub}.avg(iChan,timesel_FIC)) - ...
+      mean(allsubjFC{isub}.avg(iChan,timesel_FC));
+  end
+  
+  [h(iChan), p(iChan)] = ttest(FICminFC, 0, 0.05 ); % test each channel separately
 end
- 
+
 % plot uncorrected "significant" channels
 cfg = [];
 cfg.style     = 'blank';
-cfg.layout    = 'CTF151.lay';
+cfg.layout    = 'CTF151_helmet.mat';
 cfg.highlight = 'on';
 cfg.highlightchannel = find(h);
 cfg.comment   = 'no';
-figure; ft_topoplotER(cfg, GA_FC)
+figure; ft_topoplotER(cfg, grandavgFIC)
 title('significant without multiple comparison correction')
 
 
 %% with Bonferoni correction for multiple comparisons
+
+% with Bonferroni correction for multiple comparisons
 FICminFC = zeros(1,10);
- 
+
 for iChan = 1:151
-    for isub = 1:10
-        FICminFC(isub) = mean(allsubjFIC{isub}.avg(iChan,timesel_FIC)) - mean(allsubjFC{isub}.avg(iChan,timesel_FC));
-        [h(iChan), p(iChan)] = ttest_wrapper(FICminFC, 0, 0.05/151); % test each channel separately
-    end
+  for isub = 1:10
+    FICminFC(isub) = ...
+      mean(allsubjFIC{isub}.avg(iChan,timesel_FIC)) - ...
+      mean(allsubjFC{isub}.avg(iChan,timesel_FC));
+  end
+  
+  [h(iChan), p(iChan)] = ttest(FICminFC, 0, 0.05/151); % test each channel separately
 end
 
 
 %% Bonferoni correction with FieldTrip function
+
 cfg = [];
-cfg.channel     = 'MEG'; %now all channels
+cfg.channel     = 'MEG'; % now all channels
 cfg.latency     = [0.3 0.7];
 cfg.avgovertime = 'yes';
 cfg.parameter   = 'avg';
@@ -144,18 +161,18 @@ cfg.method      = 'analytic';
 cfg.statistic   = 'ft_statfun_depsamplesT';
 cfg.alpha       = 0.05;
 cfg.correctm    = 'bonferroni';
- 
+
 Nsub = 10;
 cfg.design(1,1:2*Nsub)  = [ones(1,Nsub) 2*ones(1,Nsub)];
 cfg.design(2,1:2*Nsub)  = [1:Nsub 1:Nsub];
 cfg.ivar                = 1; % the 1st row in cfg.design contains the independent variable
 cfg.uvar                = 2; % the 2nd row in cfg.design contains the subject number
- 
- 
-stat = ft_timelockstatistics(cfg, allsubjFC{:}, allsubjFIC{:});
+
+stat = ft_timelockstatistics(cfg, allsubjFIC{:}, allsubjFC{:});
 
 
-%% NON-PARAMETRIC Permutation test based on t statistics
+%% NON-PARAMETRIC Permutation test based on t-statistics
+
 cfg = [];
 cfg.channel     = 'MEG';
 cfg.latency     = [0.3 0.7];
@@ -167,37 +184,42 @@ cfg.alpha       = 0.05;
 cfg.correctm    = 'no';
 cfg.correcttail = 'prob';
 cfg.numrandomization = 1000;
- 
+
 Nsub = 10;
 cfg.design(1,1:2*Nsub)  = [ones(1,Nsub) 2*ones(1,Nsub)];
 cfg.design(2,1:2*Nsub)  = [1:Nsub 1:Nsub];
 cfg.ivar                = 1; % the 1st row in cfg.design contains the independent variable
 cfg.uvar                = 2; % the 2nd row in cfg.design contains the subject number
- 
+
 stat = ft_timelockstatistics(cfg, allsubjFIC{:}, allsubjFC{:});
- 
+
 % make the plot
 cfg = [];
 cfg.style     = 'blank';
-cfg.layout    = 'CTF151.lay';
+cfg.layout    = 'CTF151_helmet.mat';
 cfg.highlight = 'on';
 cfg.highlightchannel = find(stat.mask);
 cfg.comment   = 'no';
-figure; ft_topoplotER(cfg, GA_FC)
+figure; ft_topoplotER(cfg, grandavgFIC)
 title('Nonparametric: significant without multiple comparison correction')
 
+
 %%  NON-PARAMETRIC: Permutation test based on cluster statistics
-cfg = [];
-cfg.method      = 'template'; % try 'distance' as well
-cfg.template    = 'ctf151_neighb.mat';               % specify type of template
-cfg.layout      = 'CTF151.lay';                      % specify layout of sensors*
-cfg.feedback    = 'yes';                             % show a neighbour plot 
-neighbours      = ft_prepare_neighbours(cfg, GA_FC); % define neighbouring channels
- 
 
 cfg = [];
-cfg.neighbours  = neighbours; % define neighbouring channels
+cfg.method      = 'template';                         % try 'distance' as well
+cfg.template    = 'ctf151_neighb.mat';                % specify type of template
+cfg.layout      = 'CTF151_helmet.mat';                % specify layout of sensors
+cfg.feedback    = 'yes';                              % show a neighbour plot
+neighbours      = ft_prepare_neighbours(cfg, grandavgFIC); % define neighbouring channels
+
+% note that the layout and template fields have to be entered because at the earlier stage
+% when ft_timelockgrandaverage is called the field 'grad' is removed. It is this field that
+% holds information about the (layout of the) sensors.
+
+cfg = [];
 cfg.channel     = 'MEG';
+cfg.neighbours  = neighbours; % defined as above
 cfg.latency     = [0.3 0.7];
 cfg.avgovertime = 'yes';
 cfg.parameter   = 'avg';
@@ -207,31 +229,32 @@ cfg.alpha       = 0.05;
 cfg.correctm    = 'cluster';
 cfg.correcttail = 'prob';
 cfg.numrandomization = 1000;
- 
+
 Nsub = 10;
 cfg.design(1,1:2*Nsub)  = [ones(1,Nsub) 2*ones(1,Nsub)];
 cfg.design(2,1:2*Nsub)  = [1:Nsub 1:Nsub];
 cfg.ivar                = 1; % the 1st row in cfg.design contains the independent variable
 cfg.uvar                = 2; % the 2nd row in cfg.design contains the subject number
- 
-stat = ft_timelockstatistics(cfg,allsubjFIC{:},allsubjFC{:});
- 
+
+stat = ft_timelockstatistics(cfg, allsubjFIC{:}, allsubjFC{:});
+
 % make a plot
 cfg = [];
 cfg.style     = 'blank';
-cfg.layout    = 'CTF151.lay';
+cfg.layout    = 'CTF151_helmet.mat';
 cfg.highlight = 'on';
 cfg.highlightchannel = find(stat.mask);
 cfg.comment   = 'no';
-figure; ft_topoplotER(cfg, GA_FC)
-title('Nonparametric: significant with cluster multiple comparison correction')
+figure; ft_topoplotER(cfg, grandavgFIC)
+title('Nonparametric: significant with cluster-based multiple comparison correction')
+
 
 %% longer time window for NON-PARAMETRIC: permutation test based on cluster statistics
 
 cfg = [];
 cfg.channel     = 'MEG';
 cfg.neighbours  = neighbours; % defined as above
-cfg.latency     = [0.1 0.5];
+cfg.latency     = [-0.25 1];
 cfg.avgovertime = 'no';
 cfg.parameter   = 'avg';
 cfg.method      = 'montecarlo';
@@ -239,51 +262,25 @@ cfg.statistic   = 'ft_statfun_depsamplesT';
 cfg.alpha       = 0.05;
 cfg.correctm    = 'cluster';
 cfg.correcttail = 'prob';
-%cfg.tail        = 1;          % options are -1, 1 and 0 (default = 0, for 2-tailed)
 cfg.numrandomization = 1000;
 cfg.minnbchan        = 2; % minimal neighbouring channels
- 
+
 Nsub = 10;
 cfg.design(1,1:2*Nsub)  = [ones(1,Nsub) 2*ones(1,Nsub)];
 cfg.design(2,1:2*Nsub)  = [1:Nsub 1:Nsub];
 cfg.ivar                = 1; % the 1st row in cfg.design contains the independent variable
 cfg.uvar                = 2; % the 2nd row in cfg.design contains the subject number
- 
-stat = ft_timelockstatistics(cfg,allsubjFIC{:},allsubjFC{:});
 
-failed = true;
-for i=1:1000 % this can fail sometime, like every second iteration or so, 100 is a *really* conservative number here
-  stat = ft_timelockstatistics(cfg,allsubjFIC{:},allsubjFC{:});
-  
-  % make a plot
-  pcfg = [];
-  pcfg.highlightsymbolseries = ['*','*','.','.','.'];
-  pcfg.layout = 'CTF151.lay';
-  pcfg.contournum = 0;
-  pcfg.markersymbol = '.';
-  pcfg.parameter = 'stat';
-  pcfg.alpha = 0.05;
-  pcfg.zlim = [-5 5];
-  try
-    ft_clusterplot(pcfg,stat);
-    failed = false;
-    break;
-  end
-end
+stat = ft_timelockstatistics(cfg, allsubjFIC{:}, allsubjFC{:});
 
+% make a plot
+cfg = [];
+cfg.highlightsymbolseries = ['*','*','.','.','.'];
+cfg.layout = 'CTF151_helmet.mat';
+cfg.contournum = 0;
+cfg.markersymbol = '.';
+cfg.alpha = 0.05;
+cfg.parameter='stat';
+cfg.zlim = [-5 5];
+ft_clusterplot(cfg, stat);
 
-if failed
-  error('ft_clusterplot fails cause p was too high');
-end
-
-
-function [h,p,ci,stats]=ttest_wrapper(x,y,alpha)
-% helper functions for ttest
-% - old Matlab, with syntax:                   ttest(x,y,alpha,tail,dim)
-% - new Matlab and GNU Octave, with syntax:    ttest(x,y,'alpha',alpha,...)
-
-    if nargin('ttest')>0
-        [h,p,ci,stats]=ttest(x,y,alpha);
-    else
-        [h,p,ci,stats]=ttest(x,y,'alpha',alpha);
-    end


### PR DESCRIPTION
See also #1285

These are mainly changes to documentation and whitespace, although I also cleaned up some of the functions (using sel1/sel2 rather than selA/selB), improved the default handling and other cleanups. There should not be any functional changes to the statfuns.

I also updated the test script for the eventrelatedstatistics tutorial.