### PR TITLE
No warning when overlapping is identical

### DIFF
--- a/test/test_issue1292.m
+++ b/test/test_issue1292.m
@@ -1,0 +1,43 @@
+function test_issue1292
+
+%% This one has identical overlap
+
+data1 = [];
+data1.label = {'1'};
+data1.trial{1} = 1*ones(1,100);
+data1.trial{2} = 1*ones(1,100);
+data1.time{1} = 1:100;
+data1.time{2} = 1:100;
+data1.sampleinfo = [
+  1 100
+  91 190
+  ];
+
+%% This one has non-identical overlap
+
+data2 = [];
+data2.label = {'1'};
+data2.trial{1} = 1*ones(1,100);
+data2.trial{2} = 2*ones(1,100); % NOTE HERE
+data2.time{1} = 1:100;
+data2.time{2} = 1:100;
+data2.sampleinfo = [
+  1 100
+  91 190
+  ];
+
+%%
+
+dat1a = ft_fetch_data(data1, 'begsample', 1, 'endsample', 190, 'allowoverlap', true);
+
+%%
+
+dat1b = ft_fetch_data(data1, 'begsample', 1, 'endsample', 190);
+
+%%
+
+dat2a = ft_fetch_data(data2, 'begsample', 1, 'endsample', 190, 'allowoverlap', true);
+
+%%
+
+dat2b = ft_fetch_data(data2, 'begsample', 1, 'endsample', 190);

--- a/test/test_issue1292.m
+++ b/test/test_issue1292.m
@@ -1,5 +1,10 @@
 function test_issue1292
 
+MEM 2gb
+WALLTIME 00:10:00
+
+DEPENDENCY ft_fetch_data
+
 %% This one has identical overlap
 
 data1 = [];

--- a/utilities/ft_fetch_data.m
+++ b/utilities/ft_fetch_data.m
@@ -150,25 +150,26 @@ if trlnum>1
   
   % check if all samples are present and are not present twice or more
   if any(count>1)
-    if ~allowoverlap
-      % ft_error('some of the requested samples occur twice in the data');
-      % this  can be considered OK if the overlap has exactly identical values
-      sel = find(count>1); % must be row vector
-      for smplop=sel
-        % find in which trials the sample occurs
-        seltrl = find(smplop>=trl(:,1) + 1 - begsample & ... 
-                      smplop<=trl(:,2) + 1 - begsample);  % which trials, requires the adjustment with begsample, if different from 1, JM 20180116
-        selsmp = smplop - trl(seltrl,1) + begsample; % which sample in each of the trials, requires the adjustment with begsample, rather than 1
-        for i=2:length(seltrl)
-          % compare all occurences to the first one
-          % consider also mutual occurring NaNs as equal values
-          if ~all(isequaln(data.trial{seltrl(i)}(:,selsmp(i)), data.trial{seltrl(1)}(:,selsmp(1))))
+    % Lists the repeated (overlapped) samples.
+    sel = find(count>1);
+    for smplop=sel
+      % find in which trials the sample occurs
+      seltrl = find(smplop>=trl(:,1) + 1 - begsample & ... 
+                    smplop<=trl(:,2) + 1 - begsample);  % which trials, requires the adjustment with begsample, if different from 1, JM 20180116
+      selsmp = smplop - trl(seltrl,1) + begsample; % which sample in each of the trials, requires the adjustment with begsample, rather than 1
+      for i=2:length(seltrl)
+        eqsamp = all(isequaln(data.trial{seltrl(i)}(:,selsmp(i)), data.trial{seltrl(1)}(:,selsmp(1))));
+        if ~eqsamp
+          % If overlap is not allowed, rises an error.
+          if ~allowoverlap
             ft_error('some of the requested samples occur twice in the data and have conflicting values');
           end
+          % Otherwise rises a warning and exits the loop.
+          ft_warning('some of the requested samples occur twice in the data and have conflicting values, using only the last occurence of each sample');
+          break
         end
       end
-    else
-      ft_warning('samples present in multiple trials, using only the last occurence of each sample')
+      if ~eqsamp, break, end
     end
   end
   


### PR DESCRIPTION
This update removes the warning on overlapping samples when all appearances of the samples are identical.

It still rises a warning when different appearances have conflicting values and overlapping is allowed, and an error if it is not allowed.