### PR TITLE
append_common doesn't append chans with dimord rpttap_chan_freq

### DIFF
--- a/private/append_common.m
+++ b/private/append_common.m
@@ -138,7 +138,7 @@ switch cfg.appenddim
             data.(cfg.parameter{i})(chansel,:) = varargin{j}.(cfg.parameter{i})(chansel,:);
           end
           
-        case {'rpt_chan_time' 'subj_chan_time' 'rpt_chan_freq' 'subj_chan_freq'}
+        case {'rpt_chan_time' 'subj_chan_time' 'rpt_chan_freq' 'rpttap_chan_freq' 'subj_chan_freq'}
           data.(cfg.parameter{i}) = nan(dimsiz);
           for j=1:numel(varargin)
             chansel = match_str(varargin{j}.label, oldlabel{j});


### PR DESCRIPTION
I think I should be able to append freq data across the channel dimension with a dimord "rpttap_chan_freq". I can't append 'fourierspctrm' right now: all relevant fields are returned with the expection of 'fourierspctrm':

freq1 = [];           
freq1.label= {'chan1'};
freq1.dimord = 'rpttap_chan_freq';
freq1.freq = 1:40;
freq1.fourierspctrm = rand(30,1,40);
freq1.cumsumcnt = ones(30,1).*500;
freq1.cumtapcnt = ones(30,1);

freq2 = freq1;
freq2.label = {'chan2'};

cfg=[];
cfg.parameter = 'fourierspctrm';
cfg.appenddim = 'chan';

ft_appendfreq(cfg,freq1,freq2)

ans = 

  struct with fields:

        label: {2×1 cell}
         freq: [1×40 double]
       dimord: 'rpttap_chan_freq'
    cumsumcnt: [30×1 double]
    cumtapcnt: [30×1 double]
          cfg: [1×1 struct]

