### PR TITLE
improve partialization of CSD matrix prior to connectivity computation 

### DIFF
--- a/connectivity/ft_connectivity_corr.m
+++ b/connectivity/ft_connectivity_corr.m
@@ -114,22 +114,20 @@ if ~isempty(pchanindx) && isempty(powindx)
   newsiz = siz;
   newsiz(2:3) = numel(chan); % size of partialised csd
   
-  A  = zeros(newsiz);
+  A = zeros(newsiz);
   
-  % FIXME this only works for data without time dimension
-  if numel(siz)==5 && siz(5)>1, ft_error('this only works for data without time'); end
-  for j = 1:siz(1) %rpt loop
-    AA = reshape(input(j, chan,  chan, : ), [nchan  nchan  siz(4:end)]);
-    AB = reshape(input(j, chan,  pchan,: ), [nchan  npchan siz(4:end)]);
-    BA = reshape(input(j, pchan, chan, : ), [npchan nchan  siz(4:end)]);
-    BB = reshape(input(j, pchan, pchan, :), [npchan npchan siz(4:end)]);
-    for k = 1:siz(4) %freq loop
-      %A(j,:,:,k) = AA(:,:,k) - AB(:,:,k)*pinv(BB(:,:,k))*BA(:,:,k);
+  for j = 1:siz(1) % loop over rpt
+    AA = reshape(input(j, chan,  chan, : ), [nchan  nchan  prod(siz(4:end))]); % fold freq_time into one dimension
+    AB = reshape(input(j, chan,  pchan,: ), [nchan  npchan prod(siz(4:end))]);
+    BA = reshape(input(j, pchan, chan, : ), [npchan nchan  prod(siz(4:end))]);
+    BB = reshape(input(j, pchan, pchan, :), [npchan npchan prod(siz(4:end))]);
+    for k = 1:prod(siz(4:end)) % loop over freq or freq_time
       A(j,:,:,k) = AA(:,:,k) - AB(:,:,k)/(BB(:,:,k))*BA(:,:,k);
     end
   end
   input = A;
   siz = size(input);
+  
 elseif ~isempty(pchanindx)
   % linearly indexed crossspectra require some more complicated handling
   if numel(pchanindx)>1
@@ -163,7 +161,7 @@ elseif ~isempty(pchanindx)
     p_input(:,k,:,:) = input(:,k,:,:) - F_ap.*(1./F_pp).*F_pb;
     
   end
-  input = p_input; clear p_input; 
+  input = p_input; clear p_input;
 else
   % do nothing
 end

--- a/ft_connectivityanalysis.m
+++ b/ft_connectivityanalysis.m
@@ -501,7 +501,7 @@ end
 % convert the labels for the partialisation channels into indices
 % do the same for the labels of the channels that should be kept
 % convert the labels in the output to reflect the partialisation
-if ~isempty(cfg.partchannel) && (isfield(data, 'label')||isfield(data, 'labelcmb'))
+if ~isempty(cfg.partchannel) && (isfield(data, 'label') || isfield(data, 'labelcmb'))
   if isfield(data, 'label')
     label = data.label;
   elseif isfield(data, 'labelcmb')
@@ -523,8 +523,8 @@ if ~isempty(cfg.partchannel) && (isfield(data, 'label')||isfield(data, 'labelcmb
     keepchn{k} = [keepchn{k}, '\', partstr(2:end)];
   end
   if isfield(data, 'label')
-    data.label = keepchn; % update labels to remove the partialed channels
-    % FIXME consider keeping track of which channels have been partialised
+    % update labels of the partialed channels
+    data.label(kchanindx) = keepchn;
   elseif isfield(data, 'labelcmb')
     for k = 1:numel(data.labelcmb)
       data.labelcmb{k} = [data.labelcmb{k}, '\', partstr(2:end)];
@@ -656,6 +656,7 @@ switch cfg.method
       noisecov = shiftdim(noisecov,1);
       crsspctrm = shiftdim(crsspctrm,1);
     end
+    
   case {'granger' 'instantaneous_causality' 'total_interdependence' 'iis'}
     % granger causality
     if ft_datatype(data, 'freq') || ft_datatype(data, 'freqmvar')
@@ -935,6 +936,7 @@ switch cfg.method
         %data.dimord = 'chan_chan';
       case 'freq'
         ft_error('not yet implemented');
+        
       case 'source'
         % for the time being work with mom
         % dat = cat(2, data.mom{data.inside}).';

--- a/test/test_pull1304.m
+++ b/test/test_pull1304.m
@@ -1,0 +1,34 @@
+function test_pull1304
+
+% WALLTIME 00:10:00
+% MEM 3gb
+% DEPENDENCY ft_connectivityanalysis ft_connectivity_corr
+
+%%
+
+load(dccnpath('/home/common/matlab/fieldtrip/data/test/pull1304.mat'));
+
+%%
+
+cfg = [];
+cfg.method = 'mtmfft';
+cfg.output = 'fourier';
+cfg.taper = 'dpss';
+cfg.tapsmofrq = 1; % i.e. no real smoothing
+cfg.foilim = [1 100];
+[Data_freq] = ft_freqanalysis(cfg, Data);
+
+%%
+
+cfg = [];
+cfg.method = 'plv';
+cfg.partchannel = 'Stimuli';
+Data_stat = ft_connectivityanalysis(cfg, Data_freq);
+
+%%
+
+assert(~any(isnan(Data_stat.plvspctrm(:))));
+
+assert(length(Data_stat.label)==size(Data_stat.plvspctrm,1)); % nchan
+assert(length(Data_stat.label)==size(Data_stat.plvspctrm,2)); % nchan
+


### PR DESCRIPTION
The issue was reported by Raul in Leuven as 

> I was interested on computing the Phase Locking Value between two relevant brain sources. However it was suggested to partialise the contribution of the stimulus to the two signals. In this case the stimulation was a sinusoid of a frequency of 9.766 Hz evoking a brain response at the same frequency. After computing the plv in FieldTrip most of the computed values are Nans. The input to ft_connectivityanalysis was obtained as shown below. I had a look at the cross-spectrum and could not see anything 'strange' at the frequency bin of interest.

```
cfg = [];
cfg.method = 'mtmfft';
cfg.output = 'fourier';
cfg.taper = 'dpss';
cfg.tapsmofrq = 1; % i.e. no real smoothing
cfg.foilim = [1 100];
[Data_freq] = ft_freqanalysis(cfg, Data);
cfg = [];
cfg.method = 'plv';
cfg.partchannel = 'Stimuli';
Data_stat = ft_connectivityanalysis(cfg, Data_freq);
```

