### PR TITLE
Deal with empty cfg.inputfile/outputfile

### DIFF
--- a/utilities/private/reproducescript.m
+++ b/utilities/private/reproducescript.m
@@ -30,6 +30,12 @@ else
 end
 
 tmpcfg = copyfields(cfg, tmpcfg, {'inputfile', 'outputfile'});
+if isempty(tmpcfg.inputfile)
+  tmpcfg = removefields(tmpcfg, 'inputfile');
+end
+if isempty(cfg.outputfile)
+  tmpcfg = removefields(tmpcfg, 'outputfile');
+end
 tmpcfg = printstruct('cfg', tmpcfg);
 
 % We're going to explicitly mention any input files going into the pipeline


### PR DESCRIPTION
Do not print cfg.inputfile or cfg.outputfile in the generated script when these are empty.