### PR TITLE
more than one channel to repair, allow entering them as a row vector.

### DIFF
--- a/ft_channelrepair.m
+++ b/ft_channelrepair.m
@@ -159,7 +159,7 @@ if ~isempty(cfg.missingchannel) && strcmp(cfg.method, 'weighted')
 end
 
 % get selection of channels that are missing and/or bad
-cfg.missingchannel = cat(1, cfg.missingchannel(:), cfg.badchannel);
+cfg.missingchannel = cat(1, cfg.missingchannel(:), cfg.badchannel(:));
 cfg.missingchannel = setdiff(cfg.missingchannel, data.label);
 cfg.badchannel = ft_channelselection(cfg.badchannel, data.label);
 fprintf('There are %d bad channels\n', length(cfg.badchannel));

--- a/test/test_pull1331.m
+++ b/test/test_pull1331.m
@@ -1,0 +1,22 @@
+function test_pull1331
+
+% MEM 2gb
+% WALLTIME 00:10:00
+% DEPENDENCY ft_prepare_layout ft_preprocessing ft_channelrepair
+
+load(fullfile(fileparts(which('ft_defaults')),'template/neighbours/ctf151_neighb.mat'));
+lay = ft_prepare_layout(struct('layout',fullfile(fileparts(which('ft_defaults')),'template/layout/CTF151.lay')));
+
+ds = 'Subject01.ds';
+cfg = [];
+cfg.dataset = ds;
+data = ft_preprocessing(cfg);
+
+
+cfg = [];
+cfg.badchannel =     {'MLC11','MLC12','MLC13' };
+
+cfg.neighbours = neighbours;
+cfg.layout = lay;
+data_clean = ft_channelrepair(cfg,data);
+


### PR DESCRIPTION
Allowing that code to run.
```
cfg = [];
cfg.badchannel = {'Fp2', 'AF8', 'FTT9h'};
cfg.neighbours = neighbours;
cfg.layout = lay;
data_clean = ft_channelrepair(cfg,data);

```
This was crashing because at modified location, badchannel was catenated as a row vector with a colon vector of missing channels.