### PR TITLE
Update ignorefields for cfg-handling in reproducescript

### DIFF
--- a/utilities/private/ignorefields.m
+++ b/utilities/private/ignorefields.m
@@ -274,6 +274,7 @@ switch purpose
       'opto'
       'sourcemodel'
       'vol'
+      'trl'
       };
 
   otherwise

--- a/utilities/private/ignorefields.m
+++ b/utilities/private/ignorefields.m
@@ -152,6 +152,7 @@ switch purpose
       'trackusage'
       'version'
       'warning'
+      'event'
       };
 
   case 'trackconfig'


### PR DESCRIPTION
If reproducescript is enabled, make sure cfg.event does not appear in output script.m