### PR TITLE
add 'trl' to recursesize list

### DIFF
--- a/utilities/private/ignorefields.m
+++ b/utilities/private/ignorefields.m
@@ -273,6 +273,7 @@ switch purpose
       'opto'
       'sourcemodel'
       'vol'
+      'trl'
       };
 
   otherwise


### PR DESCRIPTION
If reproducescript is enabled, trial information (cfg.trl) is saved on disk instead of printed in script.m