### PR TITLE
Fix #1361

### DIFF
--- a/ft_prepare_sourcemodel.m
+++ b/ft_prepare_sourcemodel.m
@@ -251,7 +251,7 @@ if basedonmni
 end
 
 % these are mutually exclusive
-if sum([basedonresolution basedongrid basedonpos basedonshape basedonmri basedonvol basedoncortex basedonmni basedonfile])~=1
+if sum([basedonresolution basedongrid basedonpos basedonshape basedonmri basedonvol basedoncortex basedonmni])~=1
   ft_error('incorrect cfg specification for constructing a sourcemodel');
 end
 

--- a/ft_prepare_sourcemodel.m
+++ b/ft_prepare_sourcemodel.m
@@ -9,25 +9,26 @@ function [sourcemodel, cfg] = ft_prepare_sourcemodel(cfg)
 % where the details of the configuration structure determine how the source
 % model will be constructed.
 %
-% A source model can be constructed based on
-%   - regular 3D grid with explicit specification
-%   - regular 3D grid with specification of the resolution
-%   - regular 3D grid, based on segmented MRI, restricted to gray matter
-%   - regular 3D grid, based on a warped template grid, based on the MNI brain
-%   - surface mesh based on the brain surface from the volume conduction model
-%   - surface mesh based on the head surface from an external file
-%   - cortical sheet that was created in MNE or Freesurfer
-%   - using user-supplied source positions, which can be regular or irregular
+% % The different options for constructing a source model are
+%   cfg.mode =   'basedongrid'        regular 3D grid with explicit specification
+%                'basedonpos'         regular 3D grid with specification of the resolution
+%                'basedonshape'       surface mesh based on inward shifted head surface from external file
+%                'basedonmri'         regular 3D grid, based on segmented MRI, restricted to gray matter
+%                'basedonmni'         regular 3D grid, based on a warped template grid, based on the MNI brain
+%                'basedoncortex'      cortical sheet from external software such as Caret or FreeSurfer, can also be two separate hemispheres
+%                'basedonresolution'  regular 3D grid with specification of the resolution
+%                'basedonvol'         surface mesh based on inward shifted brain surface from volume conductor
+%                'basedonfile'        the sourcemodel should be read from file
 % The approach that will be used depends on the configuration options that
 % you specify.
 %
-% Configuration options for generating a regular 3D grid
+% The following parameters apply to cfg.mode='basedonresolution'
 %   cfg.xgrid      = vector (e.g. -20:1:20) or 'auto' (default = 'auto')
 %   cfg.ygrid      = vector (e.g. -20:1:20) or 'auto' (default = 'auto')
 %   cfg.zgrid      = vector (e.g.   0:1:20) or 'auto' (default = 'auto')
 %   cfg.resolution = number (e.g. 1 cm) for automatic grid generation
 %
-% Configuration options for predefined source positions
+% The following parameters apply to cfg.mode='basedonpos'
 %   cfg.sourcemodel.pos        = N*3 matrix with position of each source
 %   cfg.sourcemodel.inside     = N*1 vector with boolean value whether position is inside brain (optional)
 %   cfg.sourcemodel.dim        = [Nx Ny Nz] vector with dimensions in case of 3D grid (optional)
@@ -37,7 +38,7 @@ function [sourcemodel, cfg] = ft_prepare_sourcemodel(cfg)
 %   cfg.sourcemodel.subspace
 %   cfg.sourcemodel.lbex
 %
-% Configuration options for a warped MNI grid
+% The following parameters apply to cfg.mode='basedonmni'
 %   cfg.mri        = structure with anatomical MRI model or filename, see FT_READ_MRI
 %   cfg.warpmni    = 'yes'
 %   cfg.resolution = number (e.g. 6) of the resolution of the
@@ -48,12 +49,12 @@ function [sourcemodel, cfg] = ft_prepare_sourcemodel(cfg)
 %                                to be defined. If both are defined cfg.template prevails
 %   cfg.nonlinear  = 'no' (or 'yes'), use non-linear normalization
 %
-% Configuration options for cortex segmentation, i.e. for placing dipoles in grey matter
+% The following parameters apply to cfg.mode='basedonmri'
 %   cfg.mri           = can be filename, MRI structure or segmented MRI structure
 %   cfg.threshold     = 0.1, relative to the maximum value in the segmentation
 %   cfg.smooth        = 5, smoothing in voxels
 %
-% Configuration options for reading a cortical sheet from file
+% The following parameters apply to cfg.mode='basedoncortex'
 %   cfg.headshape     = string, should be a *.fif file
 %
 % The EEG or MEG sensor positions can be present in the data or can be specified as
@@ -166,96 +167,84 @@ if isfield(cfg, 'resolution') && isfield(cfg, 'zgrid') && ~ischar(cfg.zgrid)
 end
 
 % the source model can be constructed in a number of ways
-basedongrid       = isfield(cfg, 'xgrid') && ~ischar(cfg.xgrid);                              % regular 3D grid with explicit specification
-basedonshape      = ~isempty(cfg.headshape);                                                  % surface mesh based on inward shifted head surface from external file
-basedonmri        = isfield(cfg, 'mri') && ~(isfield(cfg, 'warpmni') && istrue(cfg.warpmni)); % regular 3D grid, based on segmented MRI, restricted to gray matter
-basedonmni        = isfield(cfg, 'mri') &&  (isfield(cfg, 'warpmni') && istrue(cfg.warpmni)); % regular 3D grid, based on warped MNI template
-basedonvol        = false;                                                                    % surface mesh based on inward shifted brain surface from volume conductor
-basedoncortex     = isfield(cfg, 'headshape') && (iscell(cfg.headshape) || any(ft_filetype(cfg.headshape, {'neuromag_fif', 'freesurfer_triangle_binary', 'caret_surf', 'gifti'}))); % cortical sheet from external software such as Caret or FreeSurfer, can also be two separate hemispheres
-basedonresolution = isfield(cfg, 'resolution') && ~basedonmri && ~basedonmni;                 % regular 3D grid with specification of the resolution
-basedonfile       = isfield(cfg, 'sourcemodel') && ischar(cfg.sourcemodel);
-basedonpos        = isfield(cfg.sourcemodel, 'pos') || basedonfile;                           % using user-supplied positions, which can be regular or irregular
-
-if basedonshape && basedoncortex
-  % treating it as cortical sheet has preference
-  basedonshape = false;
-end
-
-if basedongrid && basedonpos
-  % fall back to default behavior, in which the pos overrides the grid
-  basedongrid = false;
-end
-
-if ~any([basedonresolution basedongrid basedonpos basedonshape basedonmri basedoncortex basedonmni]) && ~isempty(cfg.headmodel)
-  % fall back to default behavior, which is to create a surface grid (e.g. used in FT_MEGREALIGN)
-  basedonvol = true;
+if ~isfield(cfg, 'mode') || isempty(cfg.mode)
+  if isfield(cfg, 'xgrid') && ~ischar(cfg.xgrid)
+    cfg.mode = 'basedongrid'; % regular 3D grid with explicit specification
+  elseif isfield(cfg.sourcemodel, 'pos')
+    cfg.mode = 'basedonpos'; % using user-supplied positions, which can be regular or irregular
+  elseif ~isempty(cfg.headshape)
+    cfg.mode = 'basedonshape'; % surface mesh based on inward shifted head surface from external file
+  elseif isfield(cfg, 'mri') && ~(isfield(cfg, 'warpmni') && istrue(cfg.warpmni))
+    cfg.mode = 'basedonmri'; % regular 3D grid, based on segmented MRI, restricted to gray matter
+  elseif isfield(cfg, 'mri') &&  (isfield(cfg, 'warpmni') && istrue(cfg.warpmni))
+    cfg.mode = 'basedonmni'; % regular 3D grid, based on warped MNI template
+  elseif isfield(cfg, 'headshape') && (iscell(cfg.headshape) || any(ft_filetype(cfg.headshape, {'neuromag_fif', 'freesurfer_triangle_binary', 'caret_surf', 'gifti'})))
+    cfg.mode = 'basedoncortex'; % cortical sheet from external software such as Caret or FreeSurfer, can also be two separate hemispheres
+  elseif isfield(cfg, 'resolution') && ~basedonmri && ~basedonmni
+    cfg.mode = 'basedonresolution'; % regular 3D grid with specification of the resolution
+  elseif isfield(cfg, 'mode') && isempty(cfg.mode) && ~isempty(cfg.headmodel)
+    cfg.mode = 'basedonvol'; % surface mesh based on inward shifted brain surface from volume conductor
+  elseif isfield(cfg, 'sourcemodel') && ischar(cfg.sourcemodel)
+    cfg.mode = 'basedonfile';
+  else
+    ft_error('incorrect cfg specification for constructing a sourcemodel');
+  end
 end
 
 % these are mutually exclusive, but printing all requested methods here
 % facilitates debugging of weird configs. Also specify the defaults here to
 % keep the overview
-if basedonfile
-  fprintf('reading sourcemodel from file\n');
-  cfg.tight       = ft_getopt(cfg, 'tight',   'no');
+switch cfg.mode
+  case 'basedonfile'
+    fprintf('reading sourcemodel from file\n');
+    cfg.tight       = ft_getopt(cfg, 'tight',   'no');
+    cfg.inwardshift = ft_getopt(cfg, 'inwardshift', 0); % in this case for inside detection
+
+  case 'basedonresolution'
+    fprintf('creating sourcemodel based on automatic 3D grid with specified resolution\n');
+    cfg.xgrid       = ft_getopt(cfg, 'xgrid',  'auto');
+    cfg.ygrid       = ft_getopt(cfg, 'ygrid',  'auto');
+    cfg.zgrid       = ft_getopt(cfg, 'zgrid',  'auto');
+    cfg.inwardshift = ft_getopt(cfg, 'inwardshift', 0); % in this case for inside detection
+    cfg.tight       = ft_getopt(cfg, 'tight',   'yes');
+    
+  case 'basedongrid'
+    fprintf('creating sourcemodel based on user specified 3D grid\n');
+    cfg.inwardshift = ft_getopt(cfg, 'inwardshift', 0); % in this case for inside detection
+    cfg.tight       = ft_getopt(cfg, 'tight',   'yes');
+    
+  case 'basedonpos'
+    fprintf('creating sourcemodel based on user specified dipole positions\n');
+    cfg.inwardshift = ft_getopt(cfg, 'inwardshift', 0); % in this case for inside detection
+    cfg.tight       = ft_getopt(cfg, 'tight',    'no');
+    
+  case 'basedonshape'
+    fprintf('creating sourcemodel based on inward-shifted head shape\n');
+    cfg.inwardshift = ft_getopt(cfg, 'inwardshift',  0); % in this case for inside detection
+    cfg.spheremesh  = ft_getopt(cfg, 'spheremesh', 642);
+    cfg.tight       = ft_getopt(cfg, 'tight',    'yes');
+    
+  case 'basedoncortex'
+    cfg.tight       = ft_getopt(cfg, 'tight', 'yes');
+    
+  case 'basedonmri'
+    fprintf('creating sourcemodel based on an anatomical volume\n');
+    cfg.threshold   = ft_getopt(cfg, 'threshold', 0.1); % relative
+    cfg.smooth      = ft_getopt(cfg, 'smooth',      5); % in voxels
+    cfg.tight       = ft_getopt(cfg, 'tight',   'yes');
+    
+  case 'basedonvol'
+    fprintf('creating sourcemodel based on inward-shifted brain surface from volume conductor model\n');
+    cfg.inwardshift = ft_getopt(cfg, 'inwardshift',   0); % in this case for inside detection
+    cfg.spheremesh  = ft_getopt(cfg, 'spheremesh',  642);
+    cfg.tight       = ft_getopt(cfg, 'tight',      'no');
+    
+  case 'basedonmni'
+    cfg.tight       = ft_getopt(cfg.sourcemodel, 'tight',       'no');
+    cfg.nonlinear   = ft_getopt(cfg.sourcemodel, 'nonlinear',   'no');
 end
 
-if basedonresolution
-  fprintf('creating sourcemodel based on automatic 3D grid with specified resolution\n');
-  cfg.xgrid       = ft_getopt(cfg, 'xgrid',  'auto');
-  cfg.ygrid       = ft_getopt(cfg, 'ygrid',  'auto');
-  cfg.zgrid       = ft_getopt(cfg, 'zgrid',  'auto');
-  cfg.inwardshift = ft_getopt(cfg, 'inwardshift', 0); % in this case for inside detection
-  cfg.tight       = ft_getopt(cfg, 'tight',   'yes');
-end
-
-if basedongrid
-  fprintf('creating sourcemodel based on user specified 3D grid\n');
-  cfg.inwardshift = ft_getopt(cfg, 'inwardshift', 0); % in this case for inside detection
-  cfg.tight       = ft_getopt(cfg, 'tight',   'yes');
-end
-
-if basedonpos
-  fprintf('creating sourcemodel based on user specified dipole positions\n');
-  cfg.inwardshift = ft_getopt(cfg, 'inwardshift', 0); % in this case for inside detection
-  cfg.tight       = ft_getopt(cfg, 'tight',    'no');
-end
-
-if basedonshape
-  fprintf('creating sourcemodel based on inward-shifted head shape\n');
-  cfg.inwardshift = ft_getopt(cfg, 'inwardshift',  0); % in this case for inside detection
-  cfg.spheremesh  = ft_getopt(cfg, 'spheremesh', 642);
-  cfg.tight       = ft_getopt(cfg, 'tight',    'yes');
-end
-
-if basedoncortex
-  cfg.tight       = ft_getopt(cfg, 'tight', 'yes');
-end
-
-if basedonmri
-  fprintf('creating sourcemodel based on an anatomical volume\n');
-  cfg.threshold   = ft_getopt(cfg, 'threshold', 0.1); % relative
-  cfg.smooth      = ft_getopt(cfg, 'smooth',      5); % in voxels
-  cfg.tight       = ft_getopt(cfg, 'tight',   'yes');
-end
-
-if basedonvol
-  fprintf('creating sourcemodel based on inward-shifted brain surface from volume conductor model\n');
-  cfg.inwardshift = ft_getopt(cfg, 'inwardshift',   0); % in this case for inside detection
-  cfg.spheremesh  = ft_getopt(cfg, 'spheremesh',  642);
-  cfg.tight       = ft_getopt(cfg, 'tight',      'no');
-end
-
-if basedonmni
-  cfg.tight       = ft_getopt(cfg.sourcemodel, 'tight',       'no');
-  cfg.nonlinear   = ft_getopt(cfg.sourcemodel, 'nonlinear',   'no');
-end
-
-% these are mutually exclusive
-if sum([basedonresolution basedongrid (basedonpos||basedonfile) basedonshape basedonmri basedonvol basedoncortex basedonmni])~=1
-  ft_error('incorrect cfg specification for constructing a sourcemodel');
-end
-
-if (isfield(cfg, 'smooth') && ~strcmp(cfg.smooth, 'no')) || basedonmni
+if (isfield(cfg, 'smooth') && ~strcmp(cfg.smooth, 'no')) || strcmp(cfg.mode, 'basedonmni')
   % check that the preferred SPM version is on the path
   ft_hastoolbox(cfg.spmversion, 1);
 end
@@ -278,7 +267,7 @@ catch
   sens = [];
 end
 
-if basedonfile
+if strcmp(cfg.mode, 'basedonfile')
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   % read the source model from a MATLAB file
   % this needs to be done prior to determining the default units
@@ -288,10 +277,10 @@ if basedonfile
 end
 
 if isempty(cfg.unit)
-  if basedonfile && isfield(sourcemodel, 'unit') && ~isempty(sourcemodel.unit)
+  if strcmp(cfg.mode, 'basedonfile') && isfield(sourcemodel, 'unit') && ~isempty(sourcemodel.unit)
     % take the existing source model units
     cfg.unit = sourcemodel.unit;
-  elseif basedonfile && isfield(sourcemodel, 'pos') && size(sourcemodel.pos,1)>10
+  elseif strcmp(cfg.mode, 'basedonfile') && isfield(sourcemodel, 'pos') && size(sourcemodel.pos,1)>10
     % estimate the units based on the existing source positions
     sourcemodel = ft_determine_units(cfg.sourcemodel);
     cfg.unit = sourcemodel.unit;
@@ -324,336 +313,329 @@ if ~isempty(headmodel)
   headmodel = ft_convert_units(headmodel, cfg.unit);
 end
 
-if basedonresolution
-  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-  % construct a regular 3D grid that spans a box encompassing all electrode
-  % or gradiometer coils, this will typically also cover the complete brain
-  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-  if ~isempty(sens) && isfield(headmodel, 'chanpos')
-    % determine the bounding box of the sensor array
-    minpos = min(sens.chanpos,[],1);
-    maxpos = max(sens.chanpos,[],1);
-  elseif ~isempty(headmodel)
-    % determine the bounding box of the volume conduction model
-    if isfield(headmodel, 'bnd') && isfield(headmodel.bnd, 'pos')
-      pos = cat(1, headmodel.bnd(:).pos);
-    elseif isfield(headmodel, 'bnd') && isfield(headmodel.bnd, 'pnt')
-      pos = cat(1, headmodel.bnd(:).pnt);
-    elseif isfield(headmodel, 'pos')
-      pos = headmodel.pos;
-    elseif ft_headmodeltype(headmodel, 'localspheres')
-      pos = headsurface(headmodel, sens);
-    elseif ft_headmodeltype(headmodel, 'singlesphere')
-      pos = [
-        headmodel.o - headmodel.r
-        headmodel.o + headmodel.r
-        ];
-    elseif ft_headmodeltype(headmodel, 'concentricspheres')
-      pos = [
-        headmodel.o - max(headmodel.r)
-        headmodel.o + max(headmodel.r)
-        ];
-    end
-    minpos = min(pos,[],1);
-    maxpos = max(pos,[],1);
-    % add a few percent on either side
-    minpos(minpos<0) = minpos(minpos<0).*1.08;
-    maxpos(maxpos>0) = maxpos(maxpos>0).*1.08;
-    minpos(minpos>0) = minpos(minpos>0).*0.92;
-    maxpos(maxpos<0) = maxpos(maxpos<0).*0.92;
-  else
-    ft_error('creating a 3D grid based on resolution requires either sensor positions or a headmodel to estimate the extent');
-  end
-  
-  fprintf('creating 3D grid with %g %s resolution\n', cfg.resolution, cfg.unit);
-  
-  % round the bounding box limits to the nearest cm
-  switch cfg.unit
-    case 'm'
-      minpos = floor(minpos*100)/100;
-      maxpos = ceil(maxpos*100)/100;
-    case 'cm'
-      minpos = floor(minpos);
-      maxpos = ceil(maxpos);
-    case 'mm'
-      minpos = floor(minpos/10)*10;
-      maxpos = ceil(maxpos/10)*10;
-  end
-  
-  if ischar(cfg.xgrid) && strcmp(cfg.xgrid, 'auto')
-    xgrid = minpos(1):cfg.resolution:maxpos(1);
-  end
-  if ischar(cfg.ygrid) && strcmp(cfg.ygrid, 'auto')
-    ygrid = minpos(2):cfg.resolution:maxpos(2);
-  end
-  if ischar(cfg.zgrid) && strcmp(cfg.zgrid, 'auto')
-    zgrid = minpos(3):cfg.resolution:maxpos(3);
-  end
-  sourcemodel.dim   = [length(xgrid) length(ygrid) length(zgrid)];
-  [X, Y, Z]  = ndgrid(xgrid, ygrid, zgrid);
-  sourcemodel.pos   = [X(:) Y(:) Z(:)];
-  sourcemodel.unit  = cfg.unit;
-  fprintf('initial 3D grid dimensions are [%d %d %d]\n', sourcemodel.dim(1), sourcemodel.dim(2), sourcemodel.dim(3));
-end
-
-if basedongrid
-  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-  % a detailed xgrid/ygrid/zgrid has been specified, the other details
-  % still need to be determined
-  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-  sourcemodel.dim   = [length(cfg.xgrid) length(cfg.ygrid) length(cfg.zgrid)];
-  [X, Y, Z]  = ndgrid(cfg.xgrid, cfg.ygrid, cfg.zgrid);
-  sourcemodel.pos   = [X(:) Y(:) Z(:)];
-  sourcemodel.unit  = cfg.unit;
-end
-
-if basedonpos
-  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-  % source positions are already specified in the configuration, reuse as much of the
-  % prespecified model as possible (but only known objects)
-  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-  sourcemodel = keepfields(cfg.sourcemodel, {'pos', 'unit', 'xgrid', 'ygrid', 'zgrid', 'mom', 'tri', 'dim', 'transform', 'inside', 'lbex', 'subspace', 'leadfield', 'filter', 'label', 'leadfielddimord'});
-end
-
-if basedonmri
-  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-  % construct a grid based on the segmented MRI that is provided in the
-  % configuration, only voxels in gray matter will be used
-  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-  
-  if ischar(cfg.mri)
-    mri = ft_read_mri(cfg.mri);
-  else
-    mri = cfg.mri;
-  end
-  
-  % ensure the mri to have units
-  if ~isfield(mri, 'unit')
-    mri = ft_determine_units(mri);
-  end
-  
-  if ~isfield(cfg, 'resolution')
-    switch cfg.unit
-      case 'mm'
-        cfg.resolution = 10;
-      case 'cm'
-        cfg.resolution = 1;
-      case 'dm'
-        cfg.resolution = 0.1;
-      case 'm'
-        cfg.resolution = 0.01;
-    end
-  end
-  
-  issegmentation = false;
-  if isfield(mri, 'gray')
-    % this is not a boolean segmentation, but based on tissue probability
-    % maps, being the original implementation here.
-    dat = double(mri.gray);
-    
-    % apply a smoothing of a certain amount of voxels
-    if ~strcmp(cfg.smooth, 'no')
-      dat = volumesmooth(dat, cfg.smooth, 'MRI gray matter');
-    end
-    
-  elseif isfield(mri, 'anatomy')
-    % this could be a tpm stored on disk, i.e. the result of
-    % ft_volumesegment. Reading it in always leads to the field 'anatomy'.
-    % Note this could be any anatomical mask
-    dat = double(mri.anatomy);
-    
-    % apply a smoothing of a certain amount of voxels
-    if ~strcmp(cfg.smooth, 'no')
-      dat = volumesmooth(dat, cfg.smooth, 'anatomy');
-    end
-    
-  elseif ft_datatype(mri, 'segmentation')
-    % this is a proper segmentation, where a set of boolean masks is in the
-    % input, or and indexed volume, along with labels. FIXME for now still
-    % only works for boolean volumes.
-    issegmentation = true;
-    fn = booleanfields(mri);
-    if isempty(fn)
-      % convert indexed segmentation into probabilistic
-      mri = ft_datatype_segmentation(mri, 'segmentationstyle', 'probabilistic');
-      fn  = booleanfields(mri);
-    end
-    
-    dat = false(mri.dim);
-    for i=1:numel(fn)
-      if ~strcmp(cfg.smooth, 'no')
-        mri.(fn{i}) = volumesmooth(double(mri.(fn{i})), cfg.smooth, fn{i}) > cfg.threshold;
+switch cfg.mode
+  case 'basedonresolution'
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    % construct a regular 3D grid that spans a box encompassing all electrode
+    % or gradiometer coils, this will typically also cover the complete brain
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    if ~isempty(sens) && isfield(headmodel, 'chanpos')
+      % determine the bounding box of the sensor array
+      minpos = min(sens.chanpos,[],1);
+      maxpos = max(sens.chanpos,[],1);
+    elseif ~isempty(headmodel)
+      % determine the bounding box of the volume conduction model
+      if isfield(headmodel, 'bnd') && isfield(headmodel.bnd, 'pos')
+        pos = cat(1, headmodel.bnd(:).pos);
+      elseif isfield(headmodel, 'bnd') && isfield(headmodel.bnd, 'pnt')
+        pos = cat(1, headmodel.bnd(:).pnt);
+      elseif isfield(headmodel, 'pos')
+        pos = headmodel.pos;
+      elseif ft_headmodeltype(headmodel, 'localspheres')
+        pos = headsurface(headmodel, sens);
+      elseif ft_headmodeltype(headmodel, 'singlesphere')
+        pos = [
+          headmodel.o - headmodel.r
+          headmodel.o + headmodel.r
+          ];
+      elseif ft_headmodeltype(headmodel, 'concentricspheres')
+        pos = [
+          headmodel.o - max(headmodel.r)
+          headmodel.o + max(headmodel.r)
+          ];
       end
-      dat = dat | mri.(fn{i});
-    end
-    dat = double(dat);
-  else
-    ft_error('cannot determine the format of the segmentation in cfg.mri');
-  end
-  
-  % determine for each voxel whether it belongs to the grey matter
-  fprintf('thresholding MRI data at a relative value of %f\n', cfg.threshold);
-  head = dat./max(dat(:)) > cfg.threshold;
-  
-  % convert the source/functional data into the same units as the anatomical MRI
-  scale = ft_scalingfactor(cfg.unit, mri.unit);
-  
-  ind                 = find(head(:));
-  fprintf('%d from %d voxels in the segmentation are marked as ''inside'' (%.0f%%)\n', length(ind), numel(head), 100*length(ind)/numel(head));
-  [X,Y,Z]             = ndgrid(1:mri.dim(1), 1:mri.dim(2), 1:mri.dim(3));             % create the grid in MRI-coordinates
-  posmri              = [X(ind) Y(ind) Z(ind)];                                       % take only the inside voxels
-  poshead             = ft_warp_apply(mri.transform, posmri);                         % transform to head coordinates
-  resolution          = cfg.resolution*scale;                                         % source and mri can be expressed in different units (e.g. cm and mm)
-  xgrid               = floor(min(poshead(:,1))):resolution:ceil(max(poshead(:,1)));  % create the grid in head-coordinates
-  ygrid               = floor(min(poshead(:,2))):resolution:ceil(max(poshead(:,2)));  % with 'consistent' x,y,z definitions
-  zgrid               = floor(min(poshead(:,3))):resolution:ceil(max(poshead(:,3)));
-  [X,Y,Z]             = ndgrid(xgrid,ygrid,zgrid);
-  pos2head            = [X(:) Y(:) Z(:)];
-  pos2mri             = ft_warp_apply(inv(mri.transform), pos2head);                  % transform to MRI voxel coordinates
-  pos2mri             = round(pos2mri);
-  inside              = getinside(pos2mri, head);                                     % use helper subfunction
-  
-  sourcemodel.pos     = pos2head/scale;                                               % convert to source units
-  sourcemodel.dim     = [length(xgrid) length(ygrid) length(zgrid)];
-  sourcemodel.inside  = inside(:);
-  sourcemodel.unit    = cfg.unit;
-  
-  if issegmentation
-    % pass on the segmentation information on the grid points, the
-    % individual masks have been smoothed above
-    fn = booleanfields(mri);
-    for i=1:numel(fn)
-      sourcemodel.(fn{i}) = getinside(pos2mri, mri.(fn{i}));
-    end
-    % convert back is not in general possible because the masks can be
-    % overlapping due to smoothing
-    % sourcemodel = ft_datatype_segmentation(sourcemodel, 'segmentationstyle', segstyle);
-  end
-  fprintf('the full grid contains %d points\n', numel(sourcemodel.inside));
-  fprintf('%d grid points are marked as inside the brain\n',  sum(sourcemodel.inside));
-end
-
-if basedoncortex
-  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-  % read it from a *.fif file that was created using Freesurfer and MNE
-  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-  if iscell(cfg.headshape)
-    % FIXME loop over all files, this should be two hemispheres
-    keyboard
-  else
-    shape = ft_read_headshape(cfg.headshape);
-  end
-  % ensure that the headshape is in the same units as the source
-  shape     = ft_convert_units(shape, cfg.unit);
-  % return both the vertices and triangles from the cortical sheet
-  sourcemodel.pos  = shape.pos;
-  sourcemodel.tri  = shape.tri;
-  sourcemodel.unit = shape.unit;
-end
-
-if basedonshape
-  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-  % use the headshape  to make a superficial dipole layer (e.g.
-  % for megrealign). Assume that all points are inside the volume.
-  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-  % get the surface describing the head shape
-  [headshape.pos, headshape.tri] = headsurface([], [], 'headshape', cfg.headshape);
-  
-  % ensure that the headshape is in the same units as the source model
-  headshape = ft_convert_units(headshape, cfg.unit);
-  
-  % note that cfg.inwardshift should be expressed in the units consistent with cfg.unit
-  sourcemodel.pos     = headsurface([], [], 'headshape', headshape, 'inwardshift', cfg.inwardshift, 'npnt', cfg.spheremesh);
-  sourcemodel.tri     = headshape.tri;
-  sourcemodel.unit    = headshape.unit;
-  sourcemodel.inside  = true(size(sourcemodel.pos,1),1);
-end
-
-if basedonvol
-  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-  % use the volume conduction model to make a superficial dipole layer (e.g.
-  % for megrealign). Assume that all points are inside the volume.
-  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-  % please note that cfg.inwardshift should be expressed in the units consistent with cfg.unit
-  sourcemodel.pos     = headsurface(headmodel, sens, 'inwardshift', cfg.inwardshift, 'npnt', cfg.spheremesh);
-  sourcemodel.unit    = cfg.unit;
-  sourcemodel.inside  = true(size(sourcemodel.pos,1),1);
-end
-
-if basedonmni
-  if ~isfield(cfg, 'template') && ~isfield(cfg, 'resolution')
-    ft_error('you either need to specify the filename of a template grid in cfg.template, or a resolution in cfg.resolution');
-  elseif isfield(cfg, 'template')
-    % let the template filename prevail
-    fname = cfg.template;
-  elseif isfield(cfg, 'resolution')
-    % use one of the templates that are in Fieldtrip, this requires a resolution
-    if isequal(cfg.resolution, round(cfg.resolution))
-      fname = sprintf('standard_sourcemodel3d%dmm.mat', cfg.resolution);
+      minpos = min(pos,[],1);
+      maxpos = max(pos,[],1);
+      % add a few percent on either side
+      minpos(minpos<0) = minpos(minpos<0).*1.08;
+      maxpos(maxpos>0) = maxpos(maxpos>0).*1.08;
+      minpos(minpos>0) = minpos(minpos>0).*0.92;
+      maxpos(maxpos<0) = maxpos(maxpos<0).*0.92;
     else
-      fname = sprintf('standard_sourcemodel3d%dpoint%dmm.mat', floor(cfg.resolution), round(10*(cfg.resolution-floor(cfg.resolution))));
+      ft_error('creating a 3D grid based on resolution requires either sensor positions or a headmodel to estimate the extent');
     end
-  end
-  
-  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-  % check whether the mni template grid exists for the specified resolution
-  % if not create it: FIXME (this needs to be done still)
-  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-  
-  % get the mri
-  if ischar(cfg.mri)
-    if ~exist(fname, 'file')
-      ft_error('the MNI template grid based on the specified resolution does not exist');
+    
+    fprintf('creating 3D grid with %g %s resolution\n', cfg.resolution, cfg.unit);
+    
+    % round the bounding box limits to the nearest cm
+    switch cfg.unit
+      case 'm'
+        minpos = floor(minpos*100)/100;
+        maxpos = ceil(maxpos*100)/100;
+      case 'cm'
+        minpos = floor(minpos);
+        maxpos = ceil(maxpos);
+      case 'mm'
+        minpos = floor(minpos/10)*10;
+        maxpos = ceil(maxpos/10)*10;
     end
-    mri = ft_read_mri(cfg.mri);
-  else
-    mri = cfg.mri;
-  end
-  
-  % get the template grid
-  if ischar(fname)
-    mnigrid = load(fname, 'sourcemodel');
-    mnigrid = mnigrid.sourcemodel;
-  else
-    mnigrid = cfg.template;
-  end
-  
-  % ensure these to have units in mm, the conversion of the source model is done further down
-  mri     = ft_convert_units(mri,     'mm');
-  mnigrid = ft_convert_units(mnigrid, 'mm');
-  
-  % ensure that it is specified with logical inside
-  mnigrid = fixinside(mnigrid);
-  
-  % spatial normalisation of mri and construction of subject specific sourcemodel positions
-  tmpcfg           = keepfields(cfg, {'spmversion', 'spmmethod'});
-  tmpcfg.nonlinear = cfg.nonlinear;
-  if isfield(cfg, 'templatemri')
-    tmpcfg.template = cfg.templatemri;
-  end
-  normalise = ft_volumenormalise(tmpcfg, mri);
-  
-  if ~isfield(normalise, 'params') && ~isfield(normalise, 'initial')
-    fprintf('applying an inverse warp based on a linear transformation only\n');
-    sourcemodel.pos = ft_warp_apply(inv(normalise.cfg.final), mnigrid.pos);
-  else
-    sourcemodel.pos = ft_warp_apply(inv(normalise.initial), ft_warp_apply(normalise.params, mnigrid.pos, 'sn2individual'));
-  end
-  if isfield(mnigrid, 'dim')
-    sourcemodel.dim   = mnigrid.dim;
-  end
-  if isfield(mnigrid, 'tri')
-    sourcemodel.tri   = mnigrid.tri;
-  end
-  sourcemodel.unit    = mnigrid.unit;
-  sourcemodel.inside  = mnigrid.inside;
-  sourcemodel.params  = normalise.params;
-  sourcemodel.initial = normalise.initial;
-  if ft_datatype(mnigrid, 'parcellation')
-    % copy the boolean fields over
-    sourcemodel = copyfields(mnigrid, sourcemodel, booleanfields(mnigrid));
-  end
-  
+    
+    if ischar(cfg.xgrid) && strcmp(cfg.xgrid, 'auto')
+      xgrid = minpos(1):cfg.resolution:maxpos(1);
+    end
+    if ischar(cfg.ygrid) && strcmp(cfg.ygrid, 'auto')
+      ygrid = minpos(2):cfg.resolution:maxpos(2);
+    end
+    if ischar(cfg.zgrid) && strcmp(cfg.zgrid, 'auto')
+      zgrid = minpos(3):cfg.resolution:maxpos(3);
+    end
+    sourcemodel.dim   = [length(xgrid) length(ygrid) length(zgrid)];
+    [X, Y, Z]  = ndgrid(xgrid, ygrid, zgrid);
+    sourcemodel.pos   = [X(:) Y(:) Z(:)];
+    sourcemodel.unit  = cfg.unit;
+    fprintf('initial 3D grid dimensions are [%d %d %d]\n', sourcemodel.dim(1), sourcemodel.dim(2), sourcemodel.dim(3));
+    
+  case 'basedongrid'
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    % a detailed xgrid/ygrid/zgrid has been specified, the other details
+    % still need to be determined
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    sourcemodel.dim   = [length(cfg.xgrid) length(cfg.ygrid) length(cfg.zgrid)];
+    [X, Y, Z]  = ndgrid(cfg.xgrid, cfg.ygrid, cfg.zgrid);
+    sourcemodel.pos   = [X(:) Y(:) Z(:)];
+    sourcemodel.unit  = cfg.unit;
+    
+  case 'basedonpos'
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    % source positions are already specified in the configuration, reuse as much of the
+    % prespecified model as possible (but only known objects)
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    sourcemodel = keepfields(cfg.sourcemodel, {'pos', 'unit', 'xgrid', 'ygrid', 'zgrid', 'mom', 'tri', 'dim', 'transform', 'inside', 'lbex', 'subspace', 'leadfield', 'filter', 'label', 'leadfielddimord'});
+    
+  case 'basedonmri'
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    % construct a grid based on the segmented MRI that is provided in the
+    % configuration, only voxels in gray matter will be used
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    
+    if ischar(cfg.mri)
+      mri = ft_read_mri(cfg.mri);
+    else
+      mri = cfg.mri;
+    end
+    
+    % ensure the mri to have units
+    if ~isfield(mri, 'unit')
+      mri = ft_determine_units(mri);
+    end
+    
+    if ~isfield(cfg, 'resolution')
+      switch cfg.unit
+        case 'mm'
+          cfg.resolution = 10;
+        case 'cm'
+          cfg.resolution = 1;
+        case 'dm'
+          cfg.resolution = 0.1;
+        case 'm'
+          cfg.resolution = 0.01;
+      end
+    end
+    
+    issegmentation = false;
+    if isfield(mri, 'gray')
+      % this is not a boolean segmentation, but based on tissue probability
+      % maps, being the original implementation here.
+      dat = double(mri.gray);
+      
+      % apply a smoothing of a certain amount of voxels
+      if ~strcmp(cfg.smooth, 'no')
+        dat = volumesmooth(dat, cfg.smooth, 'MRI gray matter');
+      end
+      
+    elseif isfield(mri, 'anatomy')
+      % this could be a tpm stored on disk, i.e. the result of
+      % ft_volumesegment. Reading it in always leads to the field 'anatomy'.
+      % Note this could be any anatomical mask
+      dat = double(mri.anatomy);
+      
+      % apply a smoothing of a certain amount of voxels
+      if ~strcmp(cfg.smooth, 'no')
+        dat = volumesmooth(dat, cfg.smooth, 'anatomy');
+      end
+      
+    elseif ft_datatype(mri, 'segmentation')
+      % this is a proper segmentation, where a set of boolean masks is in the
+      % input, or and indexed volume, along with labels. FIXME for now still
+      % only works for boolean volumes.
+      issegmentation = true;
+      fn = booleanfields(mri);
+      if isempty(fn)
+        % convert indexed segmentation into probabilistic
+        mri = ft_datatype_segmentation(mri, 'segmentationstyle', 'probabilistic');
+        fn  = booleanfields(mri);
+      end
+      
+      dat = false(mri.dim);
+      for i=1:numel(fn)
+        if ~strcmp(cfg.smooth, 'no')
+          mri.(fn{i}) = volumesmooth(double(mri.(fn{i})), cfg.smooth, fn{i}) > cfg.threshold;
+        end
+        dat = dat | mri.(fn{i});
+      end
+      dat = double(dat);
+    else
+      ft_error('cannot determine the format of the segmentation in cfg.mri');
+    end
+    
+    % determine for each voxel whether it belongs to the grey matter
+    fprintf('thresholding MRI data at a relative value of %f\n', cfg.threshold);
+    head = dat./max(dat(:)) > cfg.threshold;
+    
+    % convert the source/functional data into the same units as the anatomical MRI
+    scale = ft_scalingfactor(cfg.unit, mri.unit);
+    
+    ind                 = find(head(:));
+    fprintf('%d from %d voxels in the segmentation are marked as ''inside'' (%.0f%%)\n', length(ind), numel(head), 100*length(ind)/numel(head));
+    [X,Y,Z]             = ndgrid(1:mri.dim(1), 1:mri.dim(2), 1:mri.dim(3));             % create the grid in MRI-coordinates
+    posmri              = [X(ind) Y(ind) Z(ind)];                                       % take only the inside voxels
+    poshead             = ft_warp_apply(mri.transform, posmri);                         % transform to head coordinates
+    resolution          = cfg.resolution*scale;                                         % source and mri can be expressed in different units (e.g. cm and mm)
+    xgrid               = floor(min(poshead(:,1))):resolution:ceil(max(poshead(:,1)));  % create the grid in head-coordinates
+    ygrid               = floor(min(poshead(:,2))):resolution:ceil(max(poshead(:,2)));  % with 'consistent' x,y,z definitions
+    zgrid               = floor(min(poshead(:,3))):resolution:ceil(max(poshead(:,3)));
+    [X,Y,Z]             = ndgrid(xgrid,ygrid,zgrid);
+    pos2head            = [X(:) Y(:) Z(:)];
+    pos2mri             = ft_warp_apply(inv(mri.transform), pos2head);                  % transform to MRI voxel coordinates
+    pos2mri             = round(pos2mri);
+    inside              = getinside(pos2mri, head);                                     % use helper subfunction
+    
+    sourcemodel.pos     = pos2head/scale;                                               % convert to source units
+    sourcemodel.dim     = [length(xgrid) length(ygrid) length(zgrid)];
+    sourcemodel.inside  = inside(:);
+    sourcemodel.unit    = cfg.unit;
+    
+    if issegmentation
+      % pass on the segmentation information on the grid points, the
+      % individual masks have been smoothed above
+      fn = booleanfields(mri);
+      for i=1:numel(fn)
+        sourcemodel.(fn{i}) = getinside(pos2mri, mri.(fn{i}));
+      end
+      % convert back is not in general possible because the masks can be
+      % overlapping due to smoothing
+      % sourcemodel = ft_datatype_segmentation(sourcemodel, 'segmentationstyle', segstyle);
+    end
+    fprintf('the full grid contains %d points\n', numel(sourcemodel.inside));
+    fprintf('%d grid points are marked as inside the brain\n',  sum(sourcemodel.inside));
+    
+  case 'basedoncortex'
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    % read it from a *.fif file that was created using Freesurfer and MNE
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    if iscell(cfg.headshape)
+      % FIXME loop over all files, this should be two hemispheres
+      keyboard
+    else
+      shape = ft_read_headshape(cfg.headshape);
+    end
+    % ensure that the headshape is in the same units as the source
+    shape     = ft_convert_units(shape, cfg.unit);
+    % return both the vertices and triangles from the cortical sheet
+    sourcemodel.pos  = shape.pos;
+    sourcemodel.tri  = shape.tri;
+    sourcemodel.unit = shape.unit;
+    
+  case 'basedonshape'
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    % use the headshape  to make a superficial dipole layer (e.g.
+    % for megrealign). Assume that all points are inside the volume.
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    % get the surface describing the head shape
+    [headshape.pos, headshape.tri] = headsurface([], [], 'headshape', cfg.headshape);
+    
+    % ensure that the headshape is in the same units as the source model
+    headshape = ft_convert_units(headshape, cfg.unit);
+    
+    % note that cfg.inwardshift should be expressed in the units consistent with cfg.unit
+    sourcemodel.pos     = headsurface([], [], 'headshape', headshape, 'inwardshift', cfg.inwardshift, 'npnt', cfg.spheremesh);
+    sourcemodel.tri     = headshape.tri;
+    sourcemodel.unit    = headshape.unit;
+    sourcemodel.inside  = true(size(sourcemodel.pos,1),1);
+    
+  case 'basedonvol'
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    % use the volume conduction model to make a superficial dipole layer (e.g.
+    % for megrealign). Assume that all points are inside the volume.
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    % please note that cfg.inwardshift should be expressed in the units consistent with cfg.unit
+    sourcemodel.pos     = headsurface(headmodel, sens, 'inwardshift', cfg.inwardshift, 'npnt', cfg.spheremesh);
+    sourcemodel.unit    = cfg.unit;
+    sourcemodel.inside  = true(size(sourcemodel.pos,1),1);
+    
+  case 'basedonmni'
+    if ~isfield(cfg, 'template') && ~isfield(cfg, 'resolution')
+      ft_error('you either need to specify the filename of a template grid in cfg.template, or a resolution in cfg.resolution');
+    elseif isfield(cfg, 'template')
+      % let the template filename prevail
+      fname = cfg.template;
+    elseif isfield(cfg, 'resolution')
+      % use one of the templates that are in Fieldtrip, this requires a resolution
+      if isequal(cfg.resolution, round(cfg.resolution))
+        fname = sprintf('standard_sourcemodel3d%dmm.mat', cfg.resolution);
+      else
+        fname = sprintf('standard_sourcemodel3d%dpoint%dmm.mat', floor(cfg.resolution), round(10*(cfg.resolution-floor(cfg.resolution))));
+      end
+    end
+    
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    % check whether the mni template grid exists for the specified resolution
+    % if not create it: FIXME (this needs to be done still)
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    
+    % get the mri
+    if ischar(cfg.mri)
+      if ~exist(fname, 'file')
+        ft_error('the MNI template grid based on the specified resolution does not exist');
+      end
+      mri = ft_read_mri(cfg.mri);
+    else
+      mri = cfg.mri;
+    end
+    
+    % get the template grid
+    if ischar(fname)
+      mnigrid = load(fname, 'sourcemodel');
+      mnigrid = mnigrid.sourcemodel;
+    else
+      mnigrid = cfg.template;
+    end
+    
+    % ensure these to have units in mm, the conversion of the source model is done further down
+    mri     = ft_convert_units(mri,     'mm');
+    mnigrid = ft_convert_units(mnigrid, 'mm');
+    
+    % ensure that it is specified with logical inside
+    mnigrid = fixinside(mnigrid);
+    
+    % spatial normalisation of mri and construction of subject specific sourcemodel positions
+    tmpcfg           = keepfields(cfg, {'spmversion', 'spmmethod'});
+    tmpcfg.nonlinear = cfg.nonlinear;
+    if isfield(cfg, 'templatemri')
+      tmpcfg.template = cfg.templatemri;
+    end
+    normalise = ft_volumenormalise(tmpcfg, mri);
+    
+    if ~isfield(normalise, 'params') && ~isfield(normalise, 'initial')
+      fprintf('applying an inverse warp based on a linear transformation only\n');
+      sourcemodel.pos = ft_warp_apply(inv(normalise.cfg.final), mnigrid.pos);
+    else
+      sourcemodel.pos = ft_warp_apply(inv(normalise.initial), ft_warp_apply(normalise.params, mnigrid.pos, 'sn2individual'));
+    end
+    if isfield(mnigrid, 'dim')
+      sourcemodel.dim   = mnigrid.dim;
+    end
+    if isfield(mnigrid, 'tri')
+      sourcemodel.tri   = mnigrid.tri;
+    end
+    sourcemodel.unit    = mnigrid.unit;
+    sourcemodel.inside  = mnigrid.inside;
+    sourcemodel.params  = normalise.params;
+    sourcemodel.initial = normalise.initial;
+    if ft_datatype(mnigrid, 'parcellation')
+      % copy the boolean fields over
+      sourcemodel = copyfields(mnigrid, sourcemodel, booleanfields(mnigrid));
+    end
 end
 
 if isfield(sourcemodel, 'unit')

--- a/ft_prepare_sourcemodel.m
+++ b/ft_prepare_sourcemodel.m
@@ -183,7 +183,7 @@ if ~isfield(cfg, 'method') || isempty(cfg.method)
     cfg.method = 'basedonmni'; % regular 3D grid, based on warped MNI template
   elseif isfield(cfg, 'headshape') && (iscell(cfg.headshape) || any(ft_filetype(cfg.headshape, {'neuromag_fif', 'freesurfer_triangle_binary', 'caret_surf', 'gifti'})))
     cfg.method = 'basedoncortex'; % cortical sheet from external software such as Caret or FreeSurfer, can also be two separate hemispheres
-  elseif isfield(cfg, 'resolution') && ~basedonmri && ~basedonmni
+  elseif isfield(cfg, 'resolution')
     cfg.method = 'basedonresolution'; % regular 3D grid with specification of the resolution
   elseif isfield(cfg, 'mode') && isempty(cfg.method) && ~isempty(cfg.headmodel)
     cfg.method = 'basedonvol'; % surface mesh based on inward shifted brain surface from volume conductor

--- a/ft_prepare_sourcemodel.m
+++ b/ft_prepare_sourcemodel.m
@@ -167,7 +167,6 @@ end
 
 % the source model can be constructed in a number of ways
 basedongrid       = isfield(cfg, 'xgrid') && ~ischar(cfg.xgrid);                              % regular 3D grid with explicit specification
-basedonpos        = isfield(cfg.sourcemodel, 'pos');                                          % using user-supplied positions, which can be regular or irregular
 basedonshape      = ~isempty(cfg.headshape);                                                  % surface mesh based on inward shifted head surface from external file
 basedonmri        = isfield(cfg, 'mri') && ~(isfield(cfg, 'warpmni') && istrue(cfg.warpmni)); % regular 3D grid, based on segmented MRI, restricted to gray matter
 basedonmni        = isfield(cfg, 'mri') &&  (isfield(cfg, 'warpmni') && istrue(cfg.warpmni)); % regular 3D grid, based on warped MNI template
@@ -175,6 +174,7 @@ basedonvol        = false;                                                      
 basedoncortex     = isfield(cfg, 'headshape') && (iscell(cfg.headshape) || any(ft_filetype(cfg.headshape, {'neuromag_fif', 'freesurfer_triangle_binary', 'caret_surf', 'gifti'}))); % cortical sheet from external software such as Caret or FreeSurfer, can also be two separate hemispheres
 basedonresolution = isfield(cfg, 'resolution') && ~basedonmri && ~basedonmni;                 % regular 3D grid with specification of the resolution
 basedonfile       = isfield(cfg, 'sourcemodel') && ischar(cfg.sourcemodel);
+basedonpos        = isfield(cfg.sourcemodel, 'pos') || basedonfile;                           % using user-supplied positions, which can be regular or irregular
 
 if basedonshape && basedoncortex
   % treating it as cortical sheet has preference
@@ -251,7 +251,7 @@ if basedonmni
 end
 
 % these are mutually exclusive
-if sum([basedonresolution basedongrid basedonpos basedonshape basedonmri basedonvol basedoncortex basedonmni])~=1
+if sum([basedonresolution basedongrid (basedonpos||basedonfile) basedonshape basedonmri basedonvol basedoncortex basedonmni])~=1
   ft_error('incorrect cfg specification for constructing a sourcemodel');
 end
 
@@ -283,7 +283,8 @@ if basedonfile
   % read the source model from a MATLAB file
   % this needs to be done prior to determining the default units
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-  sourcemodel = loadvar(cfg.sourcemodel, 'sourcemodel');
+  cfg.sourcemodel = loadvar(cfg.sourcemodel, 'sourcemodel');
+  sourcemodel = cfg.sourcemodel;
 end
 
 if isempty(cfg.unit)

--- a/ft_prepare_sourcemodel.m
+++ b/ft_prepare_sourcemodel.m
@@ -170,7 +170,7 @@ if isfield(cfg, 'resolution') && isfield(cfg, 'zgrid') && ~ischar(cfg.zgrid)
 end
 
 % the source model can be constructed in a number of ways
-if ~isfield(cfg, 'mode') || isempty(cfg.method)
+if ~isfield(cfg, 'method') || isempty(cfg.method)
   if isfield(cfg, 'xgrid') && ~ischar(cfg.xgrid)
     cfg.method = 'basedongrid'; % regular 3D grid with explicit specification
   elseif isfield(cfg.sourcemodel, 'pos')


### PR DESCRIPTION
if cfg.sourcemodel is based on a file, it is not mutually exclusive with the other options for constructing a sourcemodel.