### PR TITLE
deal with incorrect specification of cfg.method

### DIFF
--- a/ft_prepare_sourcemodel.m
+++ b/ft_prepare_sourcemodel.m
@@ -169,6 +169,14 @@ if isfield(cfg, 'resolution') && isfield(cfg, 'zgrid') && ~ischar(cfg.zgrid)
   ft_error('You cannot specify cfg.resolution and an explicit cfg.zgrid simultaneously');
 end
 
+% is the user has specified a method, verify it and remove if incorrect.
+if isfield(cfg, 'method') && ~isempty(cfg.method)
+  if ~any(match_str(cfg.method, {'xgrid', 'basedongrid', 'basedonpos', 'basedonshape', 'basedonmri', 'basedonmni', 'basedoncortex', 'basedonresolution', 'basedonvol', 'basedonfile'}))
+    ft_warning('incorrect specification of cfg.method. Determining method automatically.')
+    cfg.method = [];
+  end
+end
+
 % the source model can be constructed in a number of ways
 if ~isfield(cfg, 'method') || isempty(cfg.method)
   if isfield(cfg, 'xgrid') && ~ischar(cfg.xgrid)

--- a/ft_prepare_sourcemodel.m
+++ b/ft_prepare_sourcemodel.m
@@ -134,7 +134,9 @@ cfg = ft_checkconfig(cfg, 'renamedval', {'unit', 'auto', []});
 
 cfg = ft_checkconfig(cfg, 'renamed', {'tightgrid', 'tight'});  % this is moved to cfg.sourcemodel.tight by the subsequent createsubcfg
 cfg = ft_checkconfig(cfg, 'renamed', {'sourceunits', 'unit'}); % this is moved to cfg.unit by the subsequent createsubcfg
-
+cfg = ft_checkconfig(cfg, 'allowedval', {'method', 'basedongrid', 'basedonpos', 'basedonshape', ...
+        'basedonmri', 'basedonmni', 'basedoncortex', 'basedonresolution', 'basedonvol', 'basedonfile'});
+        
 % put the low-level options pertaining to the sourcemodel in their own field
 cfg = ft_checkconfig(cfg, 'createsubcfg', {'sourcemodel'});
 % move some fields from cfg.sourcemodel back to the top-level configuration
@@ -149,6 +151,7 @@ cfg.spmversion        = ft_getopt(cfg, 'spmversion', 'spm8');
 cfg.headmodel         = ft_getopt(cfg, 'headmodel');
 cfg.sourcemodel       = ft_getopt(cfg, 'sourcemodel');
 cfg.unit              = ft_getopt(cfg, 'unit');
+cfg.method            = ft_getopt(cfg, 'method'); % empty will lead to attempted automatic detection
 
 % this code expects the inside to be represented as a logical array
 cfg = ft_checkconfig(cfg, 'inside2logical', 'yes');
@@ -169,16 +172,8 @@ if isfield(cfg, 'resolution') && isfield(cfg, 'zgrid') && ~ischar(cfg.zgrid)
   ft_error('You cannot specify cfg.resolution and an explicit cfg.zgrid simultaneously');
 end
 
-% is the user has specified a method, verify it and remove if incorrect.
-if isfield(cfg, 'method') && ~isempty(cfg.method)
-  if ~any(match_str(cfg.method, {'xgrid', 'basedongrid', 'basedonpos', 'basedonshape', 'basedonmri', 'basedonmni', 'basedoncortex', 'basedonresolution', 'basedonvol', 'basedonfile'}))
-    ft_warning('incorrect specification of cfg.method. Determining method automatically.')
-    cfg.method = [];
-  end
-end
-
 % the source model can be constructed in a number of ways
-if ~isfield(cfg, 'method') || isempty(cfg.method)
+if isempty(cfg.method)
   if isfield(cfg, 'xgrid') && ~ischar(cfg.xgrid)
     cfg.method = 'basedongrid'; % regular 3D grid with explicit specification
   elseif isfield(cfg.sourcemodel, 'pos')

--- a/test/test_tutorial_beamformingextended.m
+++ b/test/test_tutorial_beamformingextended.m
@@ -82,7 +82,8 @@ hdm = ft_prepare_headmodel(cfg, segmentedmri);
 
 
 template = load(fullfile(templatedir, 'standard_sourcemodel3d8mm'));
-% inverse-warp the subject specific grid to the template grid cfg = [];
+% inverse-warp the subject specific grid to the template grid 
+cfg = [];
 cfg.sourcemodel.warpmni   = 'yes';
 cfg.sourcemodel.template  = template.sourcemodel;
 cfg.sourcemodel.nonlinear = 'yes'; % use non-linear normalization


### PR DESCRIPTION
If the method is unsopported, remove it from the cfg and determine the method automatically, based on the rest of the input.