### PR TITLE
use isnumeric() to test if cfg.events is a trl matrix

### DIFF
--- a/data2bids.m
+++ b/data2bids.m
@@ -1415,7 +1415,7 @@ if need_events_tsv
     else
       events_tsv = event2table([], cfg.events);
     end
-  elseif ismatrix(cfg.events) && ~isempty(cfg.events)
+  elseif isnumeric(cfg.events) && ~isempty(cfg.events)
     % it is a "trl" matrix formatted as numeric array, convert it to an events table
     begsample = cfg.events(:,1);
     endsample = cfg.events(:,2);


### PR DESCRIPTION
Relates to #1396 and #1398. 

If `cfg.events` is a struct with no fields, `ismatrix(cfg.events) && ~isempty(cfg.events)` in `l.1418` evaluates to true and leads the script into the chunk which assumes `cfg.events` to be a matrix.

The proposal here is to use `isnumeric()` to test for matrix, as for some reason `ismatrix(struct())` evaluates to true. ("everything is a matrix" in a matrix laboratory I guess).

Note, the test runs OK past the problematic line for me, but `test_data2bids` doesn't go through all the way due to write permissions.