### PR TITLE
implemented neighbcorr method for summary mode in rejectvisual

### DIFF
--- a/ft_interpolatenan.m
+++ b/ft_interpolatenan.m
@@ -18,8 +18,7 @@ function [dataout] = ft_interpolatenan(cfg, datain)
 % interpolate using spatial information, e.g. using neighbouring channels, you should
 % use FT_CHANNELREPAIR.
 %
-% To facilitate data-handling and distributed computing with the peer-to-peer
-% module, this function has the following options:
+% To facilitate data-handling and distributed computing, you can use
 %   cfg.inputfile   =  ...
 %   cfg.outputfile  =  ...
 % If you specify one of these (or both) the input data will be read from a *.mat

--- a/ft_prepare_neighbours.m
+++ b/ft_prepare_neighbours.m
@@ -254,22 +254,32 @@ switch cfg.method
 end
 
 % only select those channels that are in the data
-neighb_chans = {neighbours(:).label};
 if isfield(cfg, 'channel') && ~isempty(cfg.channel)
   if hasdata
     desired = ft_channelselection(cfg.channel, data.label);
   else
-    desired = ft_channelselection(cfg.channel, neighb_chans);
+    desired = ft_channelselection(cfg.channel, {neighbours(:).label});
   end
 elseif (hasdata)
   desired = data.label;
 else
-  desired = neighb_chans;
+  desired = {neighbours(:).label};
 end
 
 if ~isempty(desired)
-  neighb_idx = ismember(neighb_chans, desired);
-  neighbours = neighbours(neighb_idx);
+  complete = struct;
+  for i=1:numel(desired)
+    complete(i).label = desired{i};
+    sel = find(strcmp({neighbours(:).label}, desired{i}));
+    if numel(sel)==1
+      % take the set of neighbours from the definition
+      complete(i).neighblabel = neighbours(sel).neighblabel;
+    else
+      % there are no neighbours defined for this channel
+      complete(i).neighblabel = {};
+    end
+  end
+  neighbours = complete;
 end
 
 k = 0;

--- a/private/rejectvisual_summary.m
+++ b/private/rejectvisual_summary.m
@@ -61,8 +61,8 @@ if isfield(cfg, 'neighbours')
   % prepare the neighbours, load from disk, make channel selection, etc.
   tmpcfg = keepfields(cfg, {'neighbours'});
   info.cfg.neighbours = ft_prepare_neighbours(tmpcfg, data);
-  % creates a NxN matrix that describes whether channels are connected as neighbours
-  info.cfg.connectivity = channelconnectivity(info.cfg);
+  % creates a NxN Boolean matrix that describes whether channels are connected as neighbours
+  info.cfg.connectivity = channelconnectivity(info.cfg, data);
 end
 
 h = figure();

--- a/private/rejectvisual_summary.m
+++ b/private/rejectvisual_summary.m
@@ -216,10 +216,17 @@ for i=1:info.ntrl
           % Compute the residual using the GLM
           %   y = beta * x + residual
           % where y is a row vector, not a column vector as common with fMRI
-          y = dat(j,:);
           x = dat(nb, :);
-          residual = y - y / x * x;
-          level(j,i) = 1 - sum(residual.^2) / sum(y.^2);
+          y = dat(j,:);
+          % remove the mean and divide by the standard deviation
+          x = ft_preproc_standardize(x);
+          y = ft_preproc_standardize(y);
+          if all(x(:) == 0) || all(y(:) == 0)
+            level(j,i) = 0;
+          else
+            residual = y - y / x * x;
+            level(j,i) = 1 - sum(residual.^2) / sum(y.^2);
+          end
         end
       end
     otherwise

--- a/test/inspect_pull1413.m
+++ b/test/inspect_pull1413.m
@@ -1,0 +1,76 @@
+function inspect_pull1413
+
+
+% WALLTIME 00:10:00
+% MEM 2gb
+% DEPENDENCY ft_rejectvisual rejectvisual_summary
+
+cd(dccnpath('/home/common/matlab/fieldtrip/data/test/pull1413'));
+
+%%
+
+load datameg
+
+%%
+
+cfg = [];
+% cfg.channel = 'MEG';
+cfg.method = 'summary';
+cfg.layout = 'ctf151_helmet.mat';
+cfg.neighbours = 'ctf151_neighb.mat';
+data_clean = ft_rejectvisual(cfg, data);
+
+%%
+
+load datanirs
+
+%%
+
+clear allrx alltx wavelength
+
+for i=1:numel(data.label)
+  tok = strsplit(data.label{i}, {'-', ' '});
+  if numel(tok)==3
+    allrx{i} = tok{1};
+    alltx{i} = tok{2};
+    wavelength{i} = tok{3};
+  else
+    allrx{i} = nan;
+    alltx{i} = nan;
+    wavelength{i} = nan;
+  end
+end
+
+
+%%
+
+clear neighbours
+
+for i=1:numel(data.label)
+  % see ft_prepare_neighbours
+  
+  % search for the same Rx and Tx optode
+  thisrx = allrx{i};
+  thistx = alltx{i};
+  labrx = data.label(strcmp(allrx, thisrx));
+  labtx = data.label(strcmp(alltx, thistx));
+  labsame = data.label(strcmp(allrx, thisrx) & strcmp(alltx, thistx));
+  
+  
+  % neighbours(i).neighblabel = [labrx; labtx];
+  neighbours(i).neighblabel = labsame;
+  % neighbours(i).neighblabel = setdiff([labrx; labtx], labsame);
+  
+  neighbours(i).label = data.label{i};
+  % do not include the channel itself
+  neighbours(i).neighblabel = setdiff(neighbours(i).neighblabel, neighbours(i).label);
+  
+end
+
+%%
+
+cfg = [];
+cfg.method = 'summary';
+cfg.neighbours = neighbours;
+data_clean = ft_rejectvisual(cfg, data);
+


### PR DESCRIPTION
this computes for every channel in every trial the squared correlation (R2) with the neighbouring channels. If the squared correlation is low, the channel has a timecourse that is very different from its neighbours, potentially indicating an artifact.

You can test this with

```
%%

cfg = [];
cfg.dataset = 'Subject01.ds';
cfg.channel = 'all';
% cfg.channel = 'MEG';
cfg.demean = 'yes';
cfg.baselinewindow = [-inf inf];
data = ft_preprocessing(cfg);

%%

cfg = [];
cfg.method = 'summary';
cfg.neighbours = 'ctf151_neighb.mat';
data_clean = ft_rejectvisual(cfg, data);

```
and subsequently clicking the neighbcorr option.

<img width="1012" alt="image" src="https://user-images.githubusercontent.com/899043/83350107-09703280-a33a-11ea-922a-7aa8eb21846e.png">

In the test MEG dataset above there are reference channels (the first ~35) and a trigger channel (the last) that don't have neighbours and hence a value of 0. All MEG channels have a squared correlation of >0.95 with their neighbours. 
