### PR TITLE
Streamlining trial selection workaround of PR #442

### DIFF
--- a/private/rejectvisual_summary.m
+++ b/private/rejectvisual_summary.m
@@ -628,8 +628,6 @@ for n = 1:length(trls)
   % that bug is hard to fix, hence it is solved here with a work-around
   cfg_sd = [];
   cfg_sd.trials = trls(n);
-  cfg_sd.avgoverrpt = 'yes';
-  cfg_sd.keeprpt = 'no';
   tmpdata = ft_selectdata(cfg_sd, info.data);
   
   figure()


### PR DESCRIPTION
The workaround works also without asking ft_selectdata to average over the single selected files, so it can be made shorter. See discussion in issue https://github.com/fieldtrip/fieldtrip/issues/1400.