### PR TITLE
ENH - replace occurrences of colormap with ft_colormaps, allows for d…

### DIFF
--- a/ft_multiplotTFR.m
+++ b/ft_multiplotTFR.m
@@ -230,7 +230,7 @@ end
 % set colormap
 if isfield(cfg,'colormap')
   if ~isnumeric(cfg.colormap)
-    cfg.colormap = colormap(cfg.colormap);
+    cfg.colormap = ft_colormap(cfg.colormap);
   end
   if size(cfg.colormap,2)~=3
     ft_error('colormap must be a n x 3 matrix');

--- a/ft_singleplotTFR.m
+++ b/ft_singleplotTFR.m
@@ -410,7 +410,7 @@ end
 % set colormap
 if isfield(cfg, 'colormap')
   if ~isnumeric(cfg.colormap)
-    cfg.colormap = colormap(cfg.colormap);
+    cfg.colormap = ft_colormap(cfg.colormap);
   end
   if size(cfg.colormap,2)~=3
     ft_error('colormap must be a Nx3 matrix');

--- a/ft_sliceinterp.m
+++ b/ft_sliceinterp.m
@@ -370,7 +370,7 @@ end
 fprintf('constructing overlay...');
 if ischar(cfg.colormap)
   % replace string by colormap using standard MATLAB function
-  cfg.colormap = colormap(cfg.colormap);
+  cfg.colormap = ft_colormap(cfg.colormap);
 end
 cmap = cfg.colormap;
 cmaplength = size(cmap,1);

--- a/ft_sourceplot.m
+++ b/ft_sourceplot.m
@@ -723,10 +723,10 @@ end
 %% set color and opacity mapping for this figure
 if hasfun
   if ischar(cfg.funcolormap) && ~strcmp(cfg.funcolormap, 'rgb')
-    colormap(cfg.funcolormap);
+    ft_colormap(cfg.funcolormap);
     cfg.funcolormap = colormap;
   elseif ~ischar(cfg.funcolormap)
-    colormap(cfg.funcolormap);
+    ft_colormap(cfg.funcolormap);
     cfg.funcolormap = colormap;
   end
 end
@@ -1474,7 +1474,7 @@ switch cfg.method
       end
       
       % color settings
-      colormap(cmap);
+      ft_colormap(cmap);
       if ~isempty(clim) && clim(2)>clim(1)
         caxis(gca, clim);
       end
@@ -1778,7 +1778,7 @@ elseif opt.hastime && opt.hasfun
 elseif strcmp(opt.colorbar,  'yes') && ~isfield(opt, 'hc')
   if opt.hasfun
     % vectorcolorbar = linspace(fscolmin, fcolmax,length(cfg.funcolormap));
-    % imagesc(vectorcolorbar,1,vectorcolorbar);colormap(cfg.funcolormap);
+    % imagesc(vectorcolorbar,1,vectorcolorbar);ft_colormap(cfg.funcolormap);
     % use a normal MATLAB colorbar, attach it to the invisible 4th subplot
     try
       caxis([opt.fcolmin opt.fcolmax]);

--- a/plotting/ft_colormap.m
+++ b/plotting/ft_colormap.m
@@ -1,0 +1,53 @@
+function cmap = ft_colormap(varargin)
+
+% FT_COLORMAP is a wrapper around the MATLAB COLORMAP function. It has the same
+% usage as COLORMAP, but also knows about the colormaps returned by BREWERMAP.
+% The latter can be specified as a string, e.g. 'RdBu', or as a 2-element cell,
+% e.g. {'RdBu', 15} or {'*RdBu', 15}, where the second element specifies the number of colors. See BREWERMAP for more information.
+
+switch nargin
+  case 0
+    cmap = colormap;
+  case 1
+    if ishandle(varargin{1})
+      cmap = colormap(varargin{1});
+    else
+      if iscell(varargin{1})
+        assert(numel(varargin{1})==2&&ischar(varargin{1}{1})&&isscalar(varargin{1}{2}));
+         
+        % this is assumed to be a pair of arguments, where the first one specifies the brewermap scheme,
+        % and the second scalar the number of colors
+        ft_hastoolbox('brewermap', 1);
+        cmap = brewermap(varargin{1}{2}, varargin{1}{1});
+      elseif ischar(varargin{1})
+        % this can be a situation, where the string argument is either a permitted string for MATLAB's colormap, 
+        % or for the brewermap, explicitly check the brewermap ones, assume a permitted string for colormap otherwise
+        ft_hastoolbox('brewermap', 1);
+        list = repmat(brewermap('list'), [2 1]);
+        for k = 1:numel(list)/2, list{k} = sprintf('*%s',list{k}); end
+                
+        if any(strcmp(list, varargin{1}))
+          cmap = brewermap(64, varargin{1});
+        else    
+          cmap = colormap(varargin{1});
+        end
+      else
+        cmap = colormap(varargin{1});
+      end
+    end
+  case 2
+    if ishandle(varargin{1}) 
+      cmap = ft_colormap(varargin{2});
+    else
+      ft_error('unexpected input to ft_colormap');
+    end
+  otherwise
+    ft_error('wrong number of input arguments for ft_colormap');
+end
+
+if nargin==2
+  colormap(varargin{1}, cmap);
+else
+  colormap(cmap);
+end
+

--- a/plotting/ft_plot_cloud.m
+++ b/plotting/ft_plot_cloud.m
@@ -587,7 +587,7 @@ if strcmp(sli, '2d')
     zsmax(s) = max(zcmax); zsmin(s) = min(zcmin);
     
     % color settings
-    colormap(cmap);
+    ft_colormap(cmap);
     if ~isempty(clim) && clim(2)>clim(1)
       caxis(gca, clim);
     end
@@ -748,7 +748,7 @@ else % plot 3d cloud
   axis equal
   
   % color settings
-  colormap(cmap);
+  ft_colormap(cmap);
   if ~isempty(clim) && clim(2)>clim(1)
     caxis(gca, clim);
   end

--- a/plotting/ft_plot_mesh.m
+++ b/plotting/ft_plot_mesh.m
@@ -286,13 +286,13 @@ switch maskstyle
       set(hs, 'FaceVertexCData', vertexcolor, 'FaceColor', 'interp');
       if numel(vertexcolor)==size(pos,1)
         if ~isempty(clim), set(gca, 'clim', clim); end
-        if ~isempty(cmap), colormap(cmap); end
+        if ~isempty(cmap), ft_colormap(cmap); end
       end
     elseif facepotential
       set(hs, 'FaceVertexCData', facecolor, 'FaceColor', 'flat');
       if numel(facecolor)==size(tri,1)
         if ~isempty(clim), set(gca, 'clim', clim); end
-        if ~isempty(cmap), colormap(cmap); end
+        if ~isempty(cmap), ft_colormap(cmap); end
       end
     else
       % the color is indicated as a single character or as a single RGB triplet

--- a/plotting/ft_plot_mesh_interactive.m
+++ b/plotting/ft_plot_mesh_interactive.m
@@ -108,7 +108,7 @@ classdef ft_plot_mesh_interactive<handle
       % INIT_SURFACE_PLOTS initializes a single figure that displays
       % surface plots for all the functional data at a single time point.
       self.fig_surface = figure('Color', 'w');
-      colormap(self.fig_surface, self.colourmap);
+      ft_colormap(self.fig_surface, self.colourmap);
       for k = 1:self.ncond
         % initialize axes and surface
         self.axes_surface(k) = subtightplot(1, numel(self.data), k);        
@@ -132,7 +132,7 @@ classdef ft_plot_mesh_interactive<handle
           tmp = self.data{k};
           lims = max(tmp(:)) * 0.75;
           set(self.axes_surface(k), 'CLim', [-lims lims]);
-          colormap(self.axes_surface(k), brewermap(64, '*RdBu'));
+          ft_colormap(self.axes_surface(k), brewermap(64, '*RdBu'));
         end
         
         title(self.axes_surface(k), self.data_labels{k});

--- a/plotting/ft_plot_slice.m
+++ b/plotting/ft_plot_slice.m
@@ -513,7 +513,7 @@ if dointersect
 end
 
 if ~isempty(cmap) && ~isequal(cmap, 'rgb')
-  colormap(cmap);
+  ft_colormap(cmap);
   if ~isempty(clim)
     caxis(clim);
   end

--- a/private/bg_rgba2rgb.m
+++ b/private/bg_rgba2rgb.m
@@ -42,7 +42,7 @@ else
   % colormap handling
   cmap = varargin{1};
   if ischar(cmap)
-    cmap = colormap(cmap);
+    cmap = ft_colormap(cmap);
   elseif size(cmap,2)~=3
     error('invalid specification of colormap, should be nx3');
   end

--- a/private/moviefunction.m
+++ b/private/moviefunction.m
@@ -1010,11 +1010,11 @@ cmap = feval(maps{val}, size(colormap, 1));
 % elseif strcmp(maps{val}, 'kelvin')
 %   cmap = kelvin(size(colormap, 1));
 % else  
-%   cmap = colormap(opt.handles.axes.movie, maps{val});
+%   cmap = ft_colormap(opt.handles.axes.movie, maps{val});
 % end
 
 if get(opt.handles.checkbox.automatic, 'Value')
-  colormap(opt.handles.axes.movie_subplot{1}, cmap);
+  ft_colormap(opt.handles.axes.movie_subplot{1}, cmap);
 end
 
 adjust_colorbar(opt);
@@ -1127,7 +1127,7 @@ end % incr, decr, automatic, else
 maps = get(opt.handles.menu.colormap, 'String');
 cmap = feval(maps{get(opt.handles.menu.colormap, 'Value')}, size(colormap, 1));
 for i=1:numel(opt.dat)
-  colormap(opt.handles.axes.movie_subplot{i}, cmap);
+  ft_colormap(opt.handles.axes.movie_subplot{i}, cmap);
 end
 
 adjust_colorbar(opt);
@@ -1293,7 +1293,7 @@ function adjust_colorbar(opt)
   cmap = feval(maps{get(opt.handles.menu.colormap, 'Value')}, size(colormap, 1));
   cmap(round(lower(1)):round(upper(1)), :) = repmat(cmap(round(lower(1)), :), 1+round(upper(1))-round(lower(1)), 1);
   for i=1:numel(opt.dat)
-    colormap(opt.handles.axes.movie_subplot{i}, cmap);
+    ft_colormap(opt.handles.axes.movie_subplot{i}, cmap);
   end
 end
 

--- a/private/topoplot_common.m
+++ b/private/topoplot_common.m
@@ -240,12 +240,12 @@ end
 % check colormap is proper format and set it
 if isfield(cfg, 'colormap')
   if ~isnumeric(cfg.colormap)
-    cfg.colormap = colormap(cfg.colormap);
+    cfg.colormap = ft_colormap(cfg.colormap);
   end
   if size(cfg.colormap,2)~=3
     ft_error('cfg.colormap must be Nx3');
   end
-  colormap(cfg.colormap);
+  ft_colormap(cfg.colormap);
   ncolors = size(cfg.colormap,1);
 else
   ncolors = []; % let the low-level function deal with this

--- a/test/test_bug1556.m
+++ b/test/test_bug1556.m
@@ -109,7 +109,7 @@ nb_conditions =3;
 Subjects = repmat(eye(nb_subjects),nb_conditions,1); % error
 x = kron(eye(nb_conditions),ones(nb_subjects,1));  % effect
 X = [x Subjects]; % no more ones for the grand mean but a subject specific mean
-figure; imagesc(X); colormap('gray'); title('Repearted measure design','Fontsize',14)
+figure; imagesc(X); ft_colormap('gray'); title('Repearted measure design','Fontsize',14)
 
 % Compute as usual
 df  = nb_conditions -1;

--- a/test/test_issue714.m
+++ b/test/test_issue714.m
@@ -74,7 +74,7 @@ ft_plot_layout(layout)
 cfg = [];
 cfg.checkconfig = 'loose'; % this uses an old option
 cfg.viewmode = 'vertical';
-cfg.channelcolormap = colormap('lines');
+cfg.channelcolormap = ft_colormap('lines');
 
 cfg.colorgroups = 'sequential';
 ft_databrowser(cfg, data);
@@ -103,7 +103,7 @@ cfg.colorgroups = 'sequential';
 cfg.linewidth = 2;
 cfg.linestyle = '-';
 
-% cfg.linecolor = colormap('lines');
+% cfg.linecolor = ft_colormap('lines');
 ft_databrowser(cfg, data);
 
 cfg.linecolor = 'brgymc';


### PR DESCRIPTION
…irect brewermap functionality

The first PR of this day implements an overloaded colormap function (ft_colormap), that allows the user to specify at the highest level (i.e. cfg.colormap) things like 'RdBu' or '*RdBu', i.e. directly using brewermaps, without the need of externally calling brewermap, and then inputting the Nx3 matrix into the cfg.