### PR TITLE
fixed the scaling of channels or trials in ft_rejectvisual trial/channel mode

### DIFF
--- a/private/rejectvisual_channel.m
+++ b/private/rejectvisual_channel.m
@@ -260,17 +260,19 @@ end
 
 
 if ~isnumeric(info.cfg.ylim)
-  ymin = [];
-  ymax = [];
+  ymin = nan(1,info.ntrl);
+  ymax = nan(1,info.ntrl);
   for trlindx=1:info.ntrl
     if ~info.trlsel(trlindx)
       % do not consider excluded trials in vertical scaling estimate
       continue
     end
     dat = info.data.trial{trlindx}(info.chanlop,:);
-    ymin = min(ymin, min(dat));
-    ymax = max(ymax, max(dat));
+    ymin(trlindx) = min(dat);
+    ymax(trlindx) = max(dat);
   end
+  ymin = min(ymin);
+  ymax = max(ymax);
   if strcmp(info.cfg.ylim, 'maxabs') % handle maxabs, make y-axis center on 0
     ymax = max(abs(ymax), abs(ymin));
     ymin = -ymax;

--- a/private/rejectvisual_trial.m
+++ b/private/rejectvisual_trial.m
@@ -250,17 +250,19 @@ drawnow
 hold on
 
 if ~isnumeric(info.cfg.ylim)
-  ymin = [];
-  ymax = [];
+  ymin = nan(1,info.nchan);
+  ymax = nan(1,info.nchan);
   for chanindx=1:info.nchan
     if ~info.chansel(chanindx)
       % do not consider excluded channels in vertical scaling estimate
       continue
     end
     dat = info.data.trial{info.trlop}(chanindx,:);
-    ymin = min(ymin, min(dat));
-    ymax = max(ymax, max(dat));
+    ymin(chanindx) = min(dat);
+    ymax(chanindx) = max(dat);
   end
+  ymin = min(ymin);
+  ymax = max(ymax);
   if strcmp(info.cfg.ylim, 'maxabs') % handle maxabs, make y-axis center on 0
     ymax = max(abs(ymax), abs(ymin));
     ymin = -ymax;


### PR DESCRIPTION
the scaling was automatic for each individual channel/trial (i.e. they all showed with an automatic vertical scale) but the vertical should be the same over all so that the deviant ones stand out