### PR TITLE
FIX - define empty variable outside loop

### DIFF
--- a/ft_freqanalysis.m
+++ b/ft_freqanalysis.m
@@ -491,6 +491,7 @@ end
 % this is done on trial basis to save memory
 
 ft_progress('init', cfg.feedback, 'processing trials');
+trlcnt = []; % only some methods need this variable, but it needs to be defined outside the trial loop
 for itrial = 1:ntrials
   
   fbopt.i = itrial;
@@ -500,8 +501,7 @@ for itrial = 1:ntrials
   time = data.time{itrial};
   
   clear spectrum % in case of very large trials, this lowers peak mem usage a bit
-  trlcnt = []; % only some methods need this variable
-
+  
   % Perform specest call and set some specifics
   switch cfg.method
     


### PR DESCRIPTION
This fixes a regression error that was introduced by f23cec877c05acfa9d8011f495153350d50a4ebe and 59c3a9e11b2f757f1636470f494f05e859dd06c4
