### PR TITLE
implement "cfg.movetocentroids" in ft_prepare_sourcemodel  

### DIFF
--- a/ft_prepare_sourcemodel.m
+++ b/ft_prepare_sourcemodel.m
@@ -719,7 +719,11 @@ if ~isempty(cfg.movetocentroid) && strcmp(cfg.movetocentroid, 'yes')
     % eliminate duplicates (if, e.g., cfg.resolution is smaller than the
     % mesh resolution)
     sourcemodel.pos = unique(grid_shifted,'rows','stable');
-    cfg.tight       = ft_getopt(cfg.sourcemodel, 'tight',       'no');
+    if isfield(sourcemodel,'dim')
+        sourcemodel = rmfield(sourcemodel,'dim');
+    end
+
+%     cfg.tight       = ft_getopt(cfg.sourcemodel, 'tight',       'no');
 
 end
 

--- a/ft_prepare_sourcemodel.m
+++ b/ft_prepare_sourcemodel.m
@@ -658,11 +658,12 @@ switch cfg.method
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     % compute the centroids of each volume element of a FEM mesh
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    % this will also copy some fields from the headmodel, such as tissue, tissuelabel, unit, coordsys
     sourcemodel = compute_centroids(headmodel);
 end
 
 if isfield(sourcemodel, 'unit')
-% in most cases the source model will already be in the desired units, but e.g. for "basedonmni" it will be in 'mm'
+  % in most cases the source model will already be in the desired units, but e.g. for "basedonmni" it will be in 'mm'
   sourcemodel = ft_convert_units(sourcemodel, cfg.unit);
 else
   % the units were specified by the user or determined automatically, assign them to the source model


### PR DESCRIPTION
this is linked to #1466.
tested with:
```
cfg = [];
cfg.resolution = 1; 
cfg.headmodel = mesh;
cfg.headmodel.type = 'simbio';
cfg.movetocentroid = 'yes';
reg_grid = ft_prepare_sourcemodel(cfg);
```
the regular 1cm source grid is shifted to the closest centroids of the volumetric mesh