### PR TITLE
Speedup for rejectvisual_trial

### DIFF
--- a/private/rejectvisual_channel.m
+++ b/private/rejectvisual_channel.m
@@ -177,18 +177,16 @@ dd = sqrt(dx.^2 + dy.^2);
 [d, i] = min(dd);
 threshold = median(sqrt(info.layout.width.^2 + info.layout.height.^2)/2);
 if d<threshold && i<=info.ntrl
-  % Get current amplitude scale
-  [old_ymin, old_ymax] = get_ylim(info);
-  
   % Toggle
   info.trlsel(i) = ~info.trlsel(i); % toggle
   info.trlop = i;
+  guidata(h,info);
   
   % Print to command window
   fprintf(description_trial(info));
   
   % Update plots
-  update_plots(info, old_ymin, old_ymax);
+  update_plots(info);
   
   % Update trial color
   if strcmp(info.h_trial(i).Color, 'none') % channel is toggled to include
@@ -196,7 +194,6 @@ if d<threshold && i<=info.ntrl
   else % channel is toggled to exclude
     info.h_trial(i).Color = 'none';
   end
-  guidata(h,info);
 else
   fprintf('button clicked\n');
 end
@@ -310,13 +307,11 @@ else
 end
 end
 
-function update_plots(info, old_ymin, old_ymax)
+function update_plots(info)
 % Updates the trial plots after inclusion/exclusion of trials
 %
 % Input:
 % info     - info struct with all the data attched to the GUI
-% old_ymin - the minimum of the data before trial exclusion/inclusion
-% old_ymax - the maximum of the data before trial exclusion/inclusion
 
 [ymin, ymax] = get_ylim(info);
 
@@ -326,15 +321,7 @@ heights   = info.layout.height;
 
 for trlindx = find(info.trlsel)
   % Shift the vertical axis to zero
-  vdat = info.h_trial(trlindx).YData - v_centers(trlindx);
-  % Scale back by availabe plot area
-  vdat = vdat ./ heights(trlindx);
-  % Scale back to length 1
-  vdat = vdat .* (old_ymax - old_ymin);
-  % Shift back the vertical axis to zero
-  vdat = vdat + (old_ymin + old_ymax)/2;
-  % Shift back the vertical axis to new zero
-  vdat = vdat - (ymin + ymax)/2;
+  vdat = info.data.trial{trlindx}(info.chanlop, :) - v_centers(trlindx);
   % Scale to length 1 of the new data
   vdat = vdat ./ (ymax - ymin);
   % Scale by availabe plot area

--- a/private/rejectvisual_trial.m
+++ b/private/rejectvisual_trial.m
@@ -38,18 +38,17 @@ if (isfield(cfg, 'preproc') && ~isempty(cfg.preproc))
   ft_progress('close');
 end
 
+% select the specified latency window from the data
+% this is done AFTER the filtering to prevent edge artifacts
 if ischar(cfg.latency)
   cfg.latency(1) = min(cellfun(@min, data.time));
   cfg.latency(2) = max(cellfun(@max, data.time));
 end
 
-
 % the info structure will be attached to the figure
 % and passed around between the callback functions
-info         = [];
-info.chanlop = 1;
 info.trlop   = 1;
-info.ltrlop  = 0;
+info.chanlop = 1;
 info.quit    = 0;
 info.ntrl    = ntrl;
 info.nchan   = nchan;
@@ -73,132 +72,101 @@ maxx = max(info.layout.pos(:,1) + info.layout.width/2);
 miny = min(info.layout.pos(:,2) - info.layout.height/2);
 maxy = max(info.layout.pos(:,2) + info.layout.height/2);
 
-h = figure;
-axis off
-axis([minx maxx miny maxy]);
+h = create_figure([minx maxx miny maxy], info);
 
-info.ui.quit        = uicontrol(h,'units','pixels','position',[  5 5 40 18],'String','quit','Callback',@stop);
-info.ui.prev        = uicontrol(h,'units','pixels','position',[ 50 5 25 18],'String','<','Callback',@prev);
-info.ui.next        = uicontrol(h,'units','pixels','position',[ 75 5 25 18],'String','>','Callback',@next);
-info.ui.prev10      = uicontrol(h,'units','pixels','position',[105 5 25 18],'String','<<','Callback',@prev10);
-info.ui.next10      = uicontrol(h,'units','pixels','position',[130 5 25 18],'String','>>','Callback',@next10);
-info.ui.exclude     = uicontrol(h,'units','pixels','position',[160 5 70 18],'String','exclude','Callback',@markexclude);
-info.ui.include     = uicontrol(h,'units','pixels','position',[230 5 70 18],'String','include','Callback',@markinclude);
-info.ui.excludenext = uicontrol(h,'units','pixels','position',[310 5 70 18],'String','exclude >','Callback',@markexclude_next);
-info.ui.includenext = uicontrol(h,'units','pixels','position',[380 5 70 18],'String','include >','Callback',@markinclude_next);
-set(gcf, 'WindowButtonUpFcn', @button);
-set(gcf, 'KeyPressFcn', @key);
-
-guidata(h,info);
-
-interactive = 1;
-while interactive && ishandle(h)
-  redraw(h);
+% Maintain focus while GUI is open
+while ishandle(h)
+  drawnow
   info = guidata(h);
   if info.quit == 0
-    uiwait(h);
+    uiwait;
   else
     chansel = info.chansel;
     trlsel = info.trlsel;
     delete(h);
     break
   end
-end % while interactive
+end % while ishandle(h)
+end
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % SUBFUNCTIONS
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-function varargout = markexclude_next(varargin)
-markexclude(varargin{:});
-next(varargin{:});
-
-function varargout = markinclude_next(varargin)
-markinclude(varargin{:});
-next(varargin{:});
-
-function varargout = next(h, eventdata, handles, varargin)
-info = guidata(h);
-info.ltrlop = info.trlop;
-if info.trlop < info.ntrl
-  info.trlop = info.trlop + 1;
+function markexclude_next(h, event)
+markexclude(h, event);
+step_trial(h, event, 1);
 end
-guidata(h,info);
-uiresume;
 
-function varargout = prev(h, eventdata, handles, varargin)
-info = guidata(h);
-info.ltrlop = info.trlop;
-if info.trlop > 1
-  info.trlop = info.trlop - 1;
+function markinclude_next(h, event)
+markinclude(h, event);
+step_trial(h, event, 1);
 end
-guidata(h,info);
-uiresume;
 
-function varargout = next10(h, eventdata, handles, varargin)
+function step_trial(h, event, step)
 info = guidata(h);
-info.ltrlop = info.trlop;
-if info.trlop < info.ntrl - 10
-  info.trlop = info.trlop + 10;
+if info.trlop == 1 && step < 0
+  fprintf('At first trial\n');
+elseif info.trlop == info.ntrl && step > 0
+  fprintf('At last trial\n');
 else
-  info.trlop = info.ntrl;
+  trls = (1:info.ntrl);
+  info.trlop = trls(nearest(trls, info.trlop + step));  
+  % Update plots
+  new_plots(info);
 end
-guidata(h,info);
+guidata(h, info);
 uiresume;
-
-function varargout = prev10(h, eventdata, handles, varargin)
-info = guidata(h);
-info.ltrlop = info.trlop;
-if info.trlop > 10
-  info.trlop = info.trlop - 10;
-else
-  info.trlop = 1;
 end
-guidata(h,info);
-uiresume;
 
-function varargout = markinclude(h, eventdata, handles, varargin)
+function markinclude(h, event)
 info = guidata(h);
-info.trlsel(info.trlop) = 1;
-fprintf(description_trial(info));
-title(description_trial(info));
-guidata(h,info);
+% Include trial if it's not already included
+if ~info.trlsel(info.trlop)
+  info.trlsel(info.trlop) = 1;
+  fprintf(description_trial(info));
+  title(description_trial(info));
+  % Color in black all channels that are included (excluded remain blank)
+  set(info.h_chan(info.chansel), 'Color', 'k');
+  guidata(h,info);
+end
 uiresume;
+end
 
-function varargout = markexclude(h, eventdata, handles, varargin)
+function markexclude(h, event)
 info = guidata(h);
-info.trlsel(info.trlop) = 0;
-fprintf(description_trial(info));
-title(description_trial(info));
-guidata(h,info);
+% Exclude channel if it's not already excluded
+if info.trlsel(info.trlop)
+  info.trlsel(info.trlop) = 0;
+  fprintf(description_trial(info));
+  title(description_trial(info));
+  % Blank all channels
+  set(info.h_chan(info.chansel), 'Color', 'none');
+  guidata(h,info);
+end
 uiresume;
+end
 
-function varargout = key(h, eventdata, handles, varargin)
-info = guidata(h);
-switch lower(eventdata.Key)
+function key(h, event)
+
+switch lower(event.Key)
   case 'rightarrow'
-    if info.trlop ~= info.ntrl
-      next(h);
-    else
-      fprintf('at last trial\n');
-    end
+    step_trial(h, event, 1);
   case 'leftarrow'
-    if info.trlop ~= 1
-      prev(h);
-    else
-      fprintf('at first trial\n');
-    end
+    step_trial(h, event, -1);
   case 'g'
-    markinclude(h);
+    markinclude(h, event);
   case 'b'
-    markexclude(h);
+    markexclude(h, event);
   case 'q'
     stop(h);
   otherwise
     fprintf('unknown key pressed\n');
 end
+end
 
-function varargout = button(h, eventdata, handles, varargin)
+function button(h, event)
+% Find selected trial
 pos = get(gca, 'CurrentPoint');
 x = pos(1,1);
 y = pos(1,2);
@@ -209,27 +177,42 @@ dd = sqrt(dx.^2 + dy.^2);
 [d, i] = min(dd);
 threshold = median(sqrt(info.layout.width.^2 + info.layout.height.^2)/2);
 if d<threshold && i<=info.nchan
+  % Toggle
   info.chansel(i) = ~info.chansel(i); % toggle
   info.chanlop = i;
-  fprintf(description_channel(info));
   guidata(h,info);
-  uiresume;
+    
+  % Print to command window
+  fprintf(description_channel(info));
+  
+  % Update plots
+  update_plots(info);
+  
+  % Update trial color
+  if strcmp(info.h_chan(i).Color, 'none') % channel is toggled to include
+    info.h_chan(i).Color = 'k';
+  else % channel is toggled to exclude
+    info.h_chan(i).Color = 'none';
+  end
 else
   fprintf('button clicked\n');
-  return
+end
+uiresume;
 end
 
-function varargout = stop(h, eventdata, handles, varargin)
+function stop(h, event)
 info = guidata(h);
 info.quit = 1;
 guidata(h,info);
 uiresume;
+end
 
 function str = description_channel(info)
 if info.chansel(info.chanlop)
   str = sprintf('channel %s marked to INCLUDE\n', info.data.label{info.chanlop});
 else
   str = sprintf('channel %s marked to EXCLUDE\n', info.data.label{info.chanlop});
+end
 end
 
 function str = description_trial(info)
@@ -238,25 +221,72 @@ if info.trlsel(info.trlop)
 else
   str = sprintf('trial %d marked to EXCLUDE\n', info.trlop);
 end
-
-function redraw(h)
-if ~ishandle(h)
-  return
 end
-info = guidata(h);
-cla;
-title('');
-drawnow
-hold on
+
+function h = create_figure(limits, info)
+% Creates the GUI and plots the data for the first time.
+% All additional changes are done by manipulating the properties of the
+% specific graphical objects
+%
+% Input:
+% limits - limits of the area where the trials are plotted
+% info   - the struct that is attched to figure using guidata
+
+% Create figure
+h = figure();
+axis('off')
+axis(limits);
+
+% Set buttons and callback functions
+info.ui.quit        = uicontrol(h,'units','pixels','position',[  5 5 40 18],'String','quit','Callback',@stop);
+info.ui.prev        = uicontrol(h,'units','pixels','position',[ 50 5 25 18],'String','<','Callback',{@step_trial, -1});
+info.ui.next        = uicontrol(h,'units','pixels','position',[ 75 5 25 18],'String','>','Callback',{@step_trial, 1});
+info.ui.prev10      = uicontrol(h,'units','pixels','position',[105 5 25 18],'String','<<','Callback',{@step_trial, -10});
+info.ui.next10      = uicontrol(h,'units','pixels','position',[130 5 25 18],'String','>>','Callback',{@step_trial, 10});
+info.ui.exclude     = uicontrol(h,'units','pixels','position',[160 5 70 18],'String','exclude','Callback',@markexclude);
+info.ui.include     = uicontrol(h,'units','pixels','position',[230 5 70 18],'String','include','Callback',@markinclude);
+info.ui.excludenext = uicontrol(h,'units','pixels','position',[310 5 70 18],'String','exclude >','Callback',@markexclude_next);
+info.ui.includenext = uicontrol(h,'units','pixels','position',[380 5 70 18],'String','include >','Callback',@markinclude_next);
+set(h, 'WindowButtonUpFcn', @button);
+set(h, 'KeyPressFcn', @key);
+
+% Determine the y-axis limits for this channel for all included trials
+[ymin, ymax] = get_ylim(info);
+
+% Plot individual channels
+hold('on')
+color = 'k';
+tim = info.data.time{info.trlop};
+for chanindx=1:info.nchan  
+  dat = info.data.trial{info.trlop}(chanindx,:);
+  info.h_chan(chanindx) = ft_plot_vector(tim, dat, 'hpos', info.layout.pos(chanindx,1), 'vpos', info.layout.pos(chanindx,2), 'width', info.layout.width(chanindx), 'height', info.layout.height(chanindx), 'vlim', [ymin ymax], 'box', istrue(info.cfg.box), 'color', color, 'label', info.layout.label{chanindx}, 'labelpos', 'lowerleft');
+end
+
+% Only blank excluded channels if the trial is included
+if info.trlsel(info.trlop)
+  set(info.h_chan(~info.chansel), 'Color', 'none');
+else % If channel is excluded blank out everything
+  set(info.h_chan, 'Color', 'none');
+end
+hold('off')
+
+% Enable or disable buttons as appropriate
+check_buttons_status(info);
+
+% Add title
+title(description_trial(info),'interpreter','none');
+
+% Update the GUI
+guidata(h, info);
+end
+
+function [ymin, ymax] = get_ylim(info)
+% Determines the y-axis limits for one trial for all included channels
 
 if ~isnumeric(info.cfg.ylim)
   ymin = nan(1,info.nchan);
   ymax = nan(1,info.nchan);
-  for chanindx=1:info.nchan
-    if ~info.chansel(chanindx)
-      % do not consider excluded channels in vertical scaling estimate
-      continue
-    end
+  for chanindx = find(info.chansel)
     dat = info.data.trial{info.trlop}(chanindx,:);
     ymin(chanindx) = min(dat);
     ymax(chanindx) = max(dat);
@@ -275,39 +305,113 @@ else
   ymin = info.cfg.ylim(1);
   ymax = info.cfg.ylim(2);
 end
-
-for chanindx=1:info.nchan
-  tim = info.data.time{info.trlop};
-  dat = info.data.trial{info.trlop}(chanindx,:);
-  if info.chansel(chanindx) && info.trlsel(info.trlop)
-    color = 'k';
-  else
-    color = 'none';
-  end
-  ft_plot_vector(tim, dat, 'hpos', info.layout.pos(chanindx,1), 'vpos', info.layout.pos(chanindx,2), 'width', info.layout.width(chanindx), 'height', info.layout.height(chanindx), 'vlim', [ymin ymax], 'box', istrue(info.cfg.box), 'color', color, 'label', info.layout.label{chanindx}, 'labelpos', 'lowerleft');
 end
 
-% enable or disable buttons as appropriate
+function update_plots(info)
+% Updates the trial plots after inclusion/exclusion of trials
+%
+% Input:
+% info     - info struct with all the data attched to the GUI
+
+[ymin, ymax] = get_ylim(info);
+
+% Get positions and heights
+v_centers = info.layout.pos(:, 2);
+heights   = info.layout.height;
+
+for chanindx = find(info.chansel)
+  % Shift the vertical axis to zero
+  vdat = info.data.trial{info.trlop}(chanindx, :) - v_centers(chanindx);
+  % Scale to length 1 of the new data
+  vdat = vdat ./ (ymax - ymin);
+  % Scale by availabe plot area
+  vdat = vdat .* heights(chanindx);
+  % Shift to the vertical position
+  vdat = vdat + v_centers(chanindx);
+  % Update
+  info.h_chan(chanindx).YData = vdat;
+end
+end
+
+function new_plots(info)
+% Updates the trial plots after channel change
+%
+% Input:
+% info - info struct with all the data attched to the GUI
+
+[ymin, ymax] = get_ylim(info);
+
+% Get positions and heights
+v_centers = info.layout.pos(:, 2);
+h_centers = info.layout.pos(:, 1);
+heights   = info.layout.height;
+widths    = info.layout.width;
+
+% Update data of ALL channels, also excluded channels
+xmin = min(info.data.time{info.trlop});
+xmax = max(info.data.time{info.trlop});
+for chanindx = 1:info.nchan
+  % Shift the horizontal axis to zero
+  hdat = info.data.time{info.trlop} - (xmin + xmax)/2;
+  % Scale to length 1 of the new data
+  hdat = hdat ./ (xmax - xmin);
+  % Scale by availabe plot area
+  hdat = hdat .* widths(chanindx);
+  % Shift to the horizontal position
+  hdat = hdat + h_centers(chanindx);
+
+  % Shift the vertical axis to zero
+  vdat = info.data.trial{info.trlop}(chanindx, :) - v_centers(chanindx);
+  % Scale to length 1 of the new data
+  vdat = vdat ./ (ymax - ymin);
+  % Scale by availabe plot area
+  vdat = vdat .* heights(chanindx);
+  % Shift to the vertical position
+  vdat = vdat + v_centers(chanindx);
+  % Update
+  set(info.h_chan(chanindx), {'XData', 'YData'}, {hdat, vdat});
+end
+
+% Blank excluded channels
+if info.trlsel(info.trlop) % channel is included
+  set(info.h_chan(info.chansel), 'Color', 'k');
+  set(info.h_chan(~info.chansel), 'Color', 'none');
+else % if channel is excluded blank out everything
+  set(info.h_chan, 'Color', 'none');
+end
+
+% Enable or disable buttons as appropriate
+check_buttons_status(info);
+
+% Update title
+title(description_trial(info),'interpreter','none');
+end
+
+function check_buttons_status(info)
+% Updates buttons status if required
+%
+% Input:
+% info - info struct with all the data attched to the GUI
+
 if info.trlop == 1
-  set(info.ui.prev,   'Enable', 'off');
-  set(info.ui.prev10, 'Enable', 'off');
+  info.ui.prev.Enable   = 'off';
+  info.ui.prev10.Enable = 'off';
 else
-  set(info.ui.prev,   'Enable', 'on');
-  set(info.ui.prev10, 'Enable', 'on');
+  info.ui.prev.Enable   = 'on';
+  info.ui.prev10.Enable = 'on';
 end
 if info.trlop == info.ntrl
-  set(info.ui.next,   'Enable', 'off');
-  set(info.ui.next10, 'Enable', 'off');
+  info.ui.next.Enable   = 'off';
+  info.ui.next10.Enable = 'off';
 else
-  set(info.ui.next,   'Enable', 'on');
-  set(info.ui.next10, 'Enable', 'on');
+  info.ui.next.Enable   = 'on';
+  info.ui.next10.Enable = 'on';
 end
-if info.ltrlop == info.trlop && info.trlop == info.ntrl
-  set(info.ui.excludenext,'Enable', 'off');
-  set(info.ui.includenext,'Enable', 'off');
+if info.trlop == info.ntrl
+  info.ui.excludenext.Enable = 'off';
+  info.ui.includenext.Enable = 'off';
 else
-  set(info.ui.excludenext,'Enable', 'on');
-  set(info.ui.includenext,'Enable', 'on');
+  info.ui.excludenext.Enable = 'on';
+  info.ui.includenext.Enable = 'on';
 end
-title(description_trial(info));
-hold off
+end


### PR DESCRIPTION
The same logic as in rejectvisual_channel: Use plot() at the beginning once and save the handles, then modify objects' properties as needed (see #1499).
I also made a small change in rejectvisual_channel to get rid of a redundancy I introduced in the previous fix there.