### PR TITLE
simple fix to print in ft_checkdata getting stuck for atlas

### DIFF
--- a/compat/matlablt2016b/pad.m
+++ b/compat/matlablt2016b/pad.m
@@ -82,9 +82,7 @@ else
   assert(numel(c)==1);
   assert(ischar(c));
 
-  if length(s)>=n
-    return
-  else
+  if length(s)<n
     c = repmat(c, 1, n-length(s));
     switch (side)
       case 'left'

--- a/utilities/ft_checkdata.m
+++ b/utilities/ft_checkdata.m
@@ -1829,7 +1829,7 @@ if all(indexed)
     end
     tissuelabel = segmentation.([fn{k} 'label']);
     tissueindex = segmentation.(fn{k});
-    width = max(cellfun(@length, tissuelabel))+1; width = max(width, 15)+1;
+    width = max(cellfun(@length, tissuelabel)); width = max(width, 15);
     summedvolume = 0;
     for m = 1:numel(tissuelabel)
       volume = sum(tissueindex(:)==m)*voxelvolume;

--- a/utilities/ft_checkdata.m
+++ b/utilities/ft_checkdata.m
@@ -1829,7 +1829,7 @@ if all(indexed)
     end
     tissuelabel = segmentation.([fn{k} 'label']);
     tissueindex = segmentation.(fn{k});
-    width = max(cellfun(@length, tissuelabel)); width = max(width, 15);
+    width = max(cellfun(@length, tissuelabel))+1; width = max(width, 15)+1;
     summedvolume = 0;
     for m = 1:numel(tissuelabel)
       volume = sum(tissueindex(:)==m)*voxelvolume;


### PR DESCRIPTION
`ft_checkdata` would not read labels from an atlas (MATLAB R2016a). `ft_info` in `line 1837` would throw an error when the name of the label was the maximum label length because `pad(tissuelabel{m}, width)` would return empty for reasons. Adding +1 to width fixed the issue.