### PR TITLE
FIX: qsub: fix checking for finished torque jobs

### DIFF
--- a/qsub/qsublist.m
+++ b/qsub/qsublist.m
@@ -170,6 +170,7 @@ switch cmd
             retval = 1;
           else
             retval = strcmp(strtrim(jobstatus) ,'C');
+            retval = retval | ~isempty(strfind(jobstatus, 'Unknown Job Id'));
           end
         case 'lsf'
           [dum, jobstatus] = system(['bjobs ' pbsid ' | awk ''NR==2'' | awk ''{print $3}'' ']);


### PR DESCRIPTION
Our legacy system is  Torque 6.x and `qsubfeval` is broken here, because the check of a completed pbsid.
This trivial patch amends the check as apparently there are torque systems out there where `qstat -f` behaves differently.