### PR TITLE
Fix qsub slurm support

### DIFF
--- a/qsub/qsubfeval.m
+++ b/qsub/qsubfeval.m
@@ -378,11 +378,11 @@ switch backend
     end
 
     if ~isempty(timreq) && ~isnan(timreq) && ~isinf(timreq)
-      submitoptions = [submitoptions sprintf('--time=%d ', round((timreq+timoverhead)/60))];
+      submitoptions = [submitoptions sprintf(' --time=%d ', round((timreq+timoverhead)/60))];
     end
 
     if ~isempty(memreq) && ~isnan(memreq) && ~isinf(memreq)
-      submitoptions = [submitoptions sprintf('--mem=%.0f ', round((memreq+memoverhead)./1024^2))];
+      submitoptions = [submitoptions sprintf(' --mem=%.0f ', round((memreq+memoverhead)./1024^2))];
     end
 
     % specifying the o and e names might be useful for the others as well

--- a/qsub/qsubfeval.m
+++ b/qsub/qsubfeval.m
@@ -395,15 +395,10 @@ switch backend
       % create the command line for the compiled application
       cmdline = sprintf('%s %s %s', compiledfun, matlabroot, jobid);
     else
-      % create the shell commands to execute matlab
-      % we decided to use srun instead of sbatch since handling job paramters is easier this way
-      %
-      % nohup was found to signficantly speed up the submission. Due to the existing error handling its safe to detach to the init, but debugging
-      % gets harder since output will be redirected to nohpu.out and thus overwritten everytime qsubfeval is launched. Using nohup only makes sense
-      % if you intend to sumbit jobs which compute in less than a minute since the difference in submit time is about 3-4 seconds per job only!
-      % cmdline = sprintf('nohup srun --job-name=%s %s --output=%s --error=%s %s -r "%s" & ', jobid, submitoptions, logout, logerr, matlabcmd, matlabscript);
-      cmdline = sprintf('srun --job-name=%s %s --output=%s --error=%s %s -r "%s" ', jobid, submitoptions, logout, logerr, matlabcmd, matlabscript);
+      cmdline = sprintf('%s -r \\"%s\\"', matlabcmd, matlabscript);
     end
+    cmdline = sprintf('sbatch --parsable --job-name=%s %s --output=%s --error=%s --wrap "%s"', ...
+                       jobid, submitoptions, logout, logerr, cmdline);
 
   case 'condor'
     % this is highly experimental and contains some first ideas following the discussion with Rhodri
@@ -491,10 +486,6 @@ else
 end
 
 switch backend
-  case 'slurm'
-    % srun will not return a jobid (besides in verbose mode) we decided to use jobname=jobid instead to identify processes
-    % since the jobid is a uniq identifier for every job!
-    result = jobid;
   case 'local'
     % the job was executed by a local feval call, but the results will still be written in a job file
     result = jobid;

--- a/qsub/qsubfeval.m
+++ b/qsub/qsubfeval.m
@@ -378,13 +378,11 @@ switch backend
     end
 
     if ~isempty(timreq) && ~isnan(timreq) && ~isinf(timreq)
-      % TESTME this is experimental and needs more testing!
-      % submitoptions = [submitoptions sprintf('--time=%d ', timreq+timoverhead)];
+      submitoptions = [submitoptions sprintf('--time=%d ', round((timreq+timoverhead)/60))];
     end
 
     if ~isempty(memreq) && ~isnan(memreq) && ~isinf(memreq)
-      % TESTME this is experimental and needs more testing!
-      % submitoptions = [submitoptions sprintf('--mem-per-cpu=%.0f ', round((memreq+memoverhead)./1024^2))];
+      submitoptions = [submitoptions sprintf('--mem=%.0f ', round((memreq+memoverhead)./1024^2))];
     end
 
     % specifying the o and e names might be useful for the others as well

--- a/qsub/qsublist.m
+++ b/qsub/qsublist.m
@@ -178,9 +178,16 @@ switch cmd
           [dum, jobstatus] = system(['qstat -s z | grep ' pbsid ' | awk ''{print $5}''']);
           retval = strcmp(strtrim(jobstatus), 'z') | strcmp(strtrim(jobstatus), 'qw');
         case 'slurm'
-          % only return the status based on the presence of the output files
-          % FIXME it would be good to implement a proper check for slurm as well
-          retval = 1;
+          if ~isfile(outputfile)
+            % with Slurm log output and error are created upon job submission
+            % and are not a viable test to see if the job completed, so we
+            % check for the outputfile first
+            retval = 0;
+          else
+            % if the file is there, we can use squeue to verify that the job really left the queue
+            [dum, jobstatus] = system(['squeue -j ' pbsid ' -h -o %T']);
+            retval = isempty(jobstatus);
+          end
         case {'local','system'}
           % only return the status based on the presence of the output files
           % there is no way polling the batch execution system


### PR DESCRIPTION
We migrated to Slurm (16.x) and this PR adds three basic changes to make things work (at all)

1. I believe using `srun` or worse `nohup srun` is conceptually broken, since `qsubfeval` should be non-blocking, right?
2. Use a proper check for a completed slurm job
3. actually make use of the `timreq` and `memreq` options