### PR TITLE
improve reading of NIRS data

### DIFF
--- a/bin/synchronize-private.sh
+++ b/bin/synchronize-private.sh
@@ -758,6 +758,14 @@ ARRAY+=(utilities/ft_fetch_header.m)
 sync ${ARRAY[*]}
 
 ################################################################################
+# ft_fetch_sens.m
+
+ARRAY=()
+ARRAY+=(private/ft_fetch_sens.m)
+ARRAY+=(test/private/ft_fetch_sens.m)
+sync ${ARRAY[*]}
+
+################################################################################
 # ft_findcfg.m
 
 ARRAY=()

--- a/external/artinis/ft_nirs_prepare_ODtransformation.m
+++ b/external/artinis/ft_nirs_prepare_ODtransformation.m
@@ -157,8 +157,7 @@ illegalidx = cellfun(@isempty, typeidx);
 cfg.channel(illegalidx) = [];
 
 if isempty(cfg.channel)
-  warning('no valid NIRS channels found')
-  return;
+  ft_error('no valid NIRS channels found')
 end
 
 % channel indices wrt optode structure

--- a/external/artinis/ft_nirs_prepare_ODtransformation.m
+++ b/external/artinis/ft_nirs_prepare_ODtransformation.m
@@ -185,14 +185,14 @@ chromophoreName = {'O2Hb' 'HHb'};
 fid = fopen(fullfile(fileparts(mfilename('fullpath')), 'private', 'Cope_ext_coeff_table.txt'));
 coefs = cell2mat(textscan(fid, '%f %f %f %f %f'));
 
-% extract all transmit combinations that are relevant here
-transmits      = sens.transmits(chanidx, :);
-transmitteridx = transmits>0;
-receiveridx    = transmits<0;
+% extract all optode combinations that are relevant here
+tra            = sens.tra(chanidx, :);
+transmitteridx = tra>0;
+receiveridx    = tra<0;
 optodeidx      = transmitteridx | receiveridx;
 
 % extract the wavelengths
-wavelengths  = sens.wavelength(transmits(transmitteridx));
+wavelengths  = sens.wavelength(tra(transmitteridx));
 wlidx = bsxfun(@minus, coefs(:, 1), wavelengths);
 
 % find the relevant channel combinations

--- a/external/artinis/read_artinis_oxy3.m
+++ b/external/artinis/read_artinis_oxy3.m
@@ -1,17 +1,17 @@
 function data = read_artinis_oxy3(filename, header, begsample, endsample, chanindx)
 % reads Artinix oxy3-files into FieldTrip format
+%
 % use as
 %   header = read_artinis_oxy3(filename)
 % or 
 %   event  = read_artinis_oxy3(filename, read_event)
-% where read_event is a boolean. If 'true', the function returns events. 
-% If 'false' the function returns the header. 
-% or 
+% where read_event is a Boolean with the value true, or  
 %   data   = read_artinis_oxy3(filename, header, [begsample], [endsample], [chanindx])
-% where begsample, endsample and chanindx are optional. The returned
-% variables will be in FieldTrip style. 
+% where begsample, endsample and chanindx are optional.
 %
-% See also FT_READ_HEADER, FT_READ_DATA
+% The returned variables will be in FieldTrip style. 
+%
+% See also FT_READ_HEADER, FT_READ_DATA, READ_ARTINIS_OXY4
 
 % You are using the FieldTrip NIRS toolbox developed and maintained by 
 % Artinis Medical Systems (http://www.artinis.com). For more information
@@ -63,6 +63,10 @@ end
 
 if nargin == 1 || nargin == 2 && islogical(header) && ~header    
   data = read_oxy3_header(filename);
+  if isfield(data, 'opto')
+    % ensure that the optode definition is according to the latest standards
+    data.opto = ft_datatype_sens(data.opto);
+  end
 elseif nargin == 2  && islogical(header) && header
   data = read_oxy3_event(filename);
 else % nargin > 1 && ~islogical(header)

--- a/external/artinis/read_artinis_oxy4.m
+++ b/external/artinis/read_artinis_oxy4.m
@@ -1,17 +1,17 @@
 function data = read_artinis_oxy4(filename, header, begsample, endsample, chanindx)
 % reads Artinix oxy4-files into FieldTrip format
-% use as
-%   header = read_artinis_oxy4(filename)
-% or 
-%   event  = read_artinis_oxy4(filename, read_event)
-% where read_event is a boolean. If 'true', the function returns events. 
-% If 'false' the function returns the header. 
-% or 
-%   data   = read_artinis_oxy4(filename, header, [begsample], [endsample], [chanindx])
-% where begsample, endsample and chanindx are optional. The returned
-% variables will be in FieldTrip style. 
 %
-% See also FT_READ_HEADER, FT_READ_DATA
+% use as
+%   header = read_artinis_oxy3(filename)
+% or 
+%   event  = read_artinis_oxy3(filename, read_event)
+% where read_event is a Boolean with the value true, or  
+%   data   = read_artinis_oxy3(filename, header, [begsample], [endsample], [chanindx])
+% where begsample, endsample and chanindx are optional.
+%
+% The returned variables will be in FieldTrip style. 
+%
+% See also FT_READ_HEADER, FT_READ_DATA, READ_ARTINIS_OXY3
 
 % You are using the FieldTrip NIRS toolbox developed and maintained by 
 % Artinis Medical Systems (http://www.artinis.com). For more information
@@ -63,6 +63,10 @@ end
 
 if nargin == 1 || nargin == 2 && islogical(header) && ~header    
   data = read_oxy4_header(filename);
+  if isfield(data, 'opto')
+    % ensure that the optode definition is according to the latest standards
+    data.opto = ft_datatype_sens(data.opto);
+  end
 elseif nargin == 2  && islogical(header) && header
   data = read_oxy3_event(filename);
 else % nargin > 1 && ~islogical(header)  

--- a/fileio/ft_chantype.m
+++ b/fileio/ft_chantype.m
@@ -67,9 +67,10 @@ isheader = isa(input, 'struct')  && isfield(input, 'label') && isfield(input, 'F
 isdata   = isa(input, 'struct')  && ~isheader && (isfield(input, 'hdr') || isfield(input, 'grad') || isfield(input, 'elec') || isfield(input, 'opto'));
 isgrad   = isa(input, 'struct')  && isfield(input, 'label') && isfield(input, 'pnt')  &&  isfield(input, 'ori'); % old style
 iselec   = isa(input, 'struct')  && isfield(input, 'label') && isfield(input, 'pnt')  && ~isfield(input, 'ori'); % old style
-isgrad   = (isa(input, 'struct') && isfield(input, 'label') && isfield(input, 'coilpos')) || isgrad;             % new style
-iselec   = (isa(input, 'struct') && isfield(input, 'label') && isfield(input, 'elecpos')) || iselec;             % new style
-isopto   = isa(input, 'struct')  && isfield(input, 'label') && isfield(input, 'transceiver');
+isnirs   = isa(input, 'struct')  && isfield(input, 'label') && isfield(input, 'fiberpos');                       % old style
+isgrad   = (isa(input, 'struct') && isfield(input, 'label') && isfield(input, 'coilpos'))  || isgrad;            % new style
+iselec   = (isa(input, 'struct') && isfield(input, 'label') && isfield(input, 'elecpos'))  || iselec;            % new style
+isnirs   = (isa(input, 'struct')  && isfield(input, 'label') && isfield(input, 'optopos')) || isnirs;            % new style
 islabel  = isa(input, 'cell')    && ~isempty(input) && isa(input{1}, 'char');
 
 if isheader

--- a/fileio/ft_filetype.m
+++ b/fileio/ft_filetype.m
@@ -1328,6 +1328,10 @@ elseif filetype_check_extension(filename, '.txt') && filetype_check_header(filen
   type = 'openbci_txt';
   manufacturer = 'OpenBCI';
   content = 'raw EEG data';
+elseif filetype_check_extension(filename, '.txt') && filetype_check_header(filename, '# Version:')
+  type = 'brainsight_txt';
+  manufacturer = 'Rogue Research';
+  content = '3D positions';
 elseif filetype_check_extension(filename, '.txt')
   type = 'ascii_txt';
   manufacturer = '';

--- a/fileio/ft_read_data.m
+++ b/fileio/ft_read_data.m
@@ -919,13 +919,19 @@ switch dataformat
     
   case {'homer_nirs'}
     % Homer files are MATLAB files in disguise
+    % see https://www.nitrc.org/plugins/mwiki/index.php/homer2:Homer_Input_Files#NIRS_data_file_format
     orig = load(filename, '-mat');
+    % copy the data from the raw intensity time courses
+    dat = orig.d;
     if isfield(orig, 'aux')
       % concatenate the AUX channel at the end, consistent with FT_READ_HEADER
-      dat = [orig.d orig.aux];
-    else
-      dat = orig.d;
+      dat = [dat orig.aux];
     end
+    if isfield(orig, 's')
+      % concatenate the stimulus channel at the end, consistent with FT_READ_HEADER
+      dat = [dat orig.s];
+    end
+    
     dat = dat(begsample:endsample, chanindx);
     dimord = 'samples_chans';
     

--- a/fileio/ft_read_data.m
+++ b/fileio/ft_read_data.m
@@ -920,7 +920,13 @@ switch dataformat
   case {'homer_nirs'}
     % Homer files are MATLAB files in disguise
     orig = load(filename, '-mat');
-    dat = orig.d(begsample:endsample, chanindx);
+    if isfield(orig, 'aux')
+      % concatenate the AUX channel at the end, consistent with FT_READ_HEADER
+      dat = [orig.d orig.aux];
+    else
+      dat = orig.d;
+    end
+    dat = dat(begsample:endsample, chanindx);
     dimord = 'samples_chans';
     
   case 'itab_raw'

--- a/fileio/ft_read_event.m
+++ b/fileio/ft_read_event.m
@@ -1309,39 +1309,26 @@ switch eventformat
     event = read_trigger(filename, 'header', hdr, 'dataformat', dataformat, 'begsample', flt_minsample, 'endsample', flt_maxsample, 'chanindx', chanindx, 'detectflank', detectflank, 'denoise', denoise, 'trigshift', trigshift);
     
   case {'homer_nirs'}
-    % Homer files are MATLAB files in disguise, see https://www.nitrc.org/plugins/mwiki/index.php/homer2:Homer_Input_Files#NIRS_data_file_format
-    orig = load(filename, '-mat');
-    % each of the columns of orig.s represents an event type, 1 means on, 0 means off
-    % negative values have been editted in Homer and should be ignored
-    event = [];
-    if isfield(orig, 's')
-      % each column is a condition
-      for i=1:size(orig.s,2)
-        onset  = find(diff([0 orig.s(:,i)'])==+1); % rising flank
-        offset = find(diff([orig.s(:,i)' 0])==-1); % falling flank
-        for j=1:numel(onset)
-          event(end+1).type     = 'trigger';
-          event(end  ).value    = i;
-          event(end  ).sample   = onset(j);
-          event(end  ).duration = offset(j)-onset(j)+1;
-          event(end  ).offset   = [];
-        end
-      end
+    % Homer files are MATLAB files in disguise
+    % see https://www.nitrc.org/plugins/mwiki/index.php/homer2:Homer_Input_Files#NIRS_data_file_format
+    if isempty(hdr)
+      hdr = ft_read_header(filename);
     end
-    
-    if isempty(event) && isfield(orig, 'aux')
-      ft_warning('no events found in the stimulus onsets table, parsing the AUX channel for triggers');
-      
-      if isempty(hdr)
-        hdr = ft_read_header(filename);
+    if isempty(chanindx)
+      % look in nirs.s for events, this corresponds to the stimulus channels
+      chanindx = find(ft_chantype(hdr, 'stimulus'));
+      trigger = read_trigger(filename, 'header', hdr, 'dataformat', dataformat, 'begsample', flt_minsample, 'endsample', flt_maxsample, 'chanindx', chanindx, 'detectflank', detectflank, 'denoise', denoise, 'trigshift', trigshift, 'threshold', threshold, 'denoise', denoise, 'fixhomer', true);
+      event = appendstruct(event, trigger);
+      if isempty(event)
+        % also look in nirs.aux for channels with analog TTL values
+        chanindx = find(ft_chantype(hdr, 'aux'));
+        trigger = read_trigger(filename, 'header', hdr, 'dataformat', dataformat, 'begsample', flt_minsample, 'endsample', flt_maxsample, 'chanindx', chanindx, 'detectflank', detectflank, 'denoise', denoise, 'trigshift', trigshift, 'threshold', threshold, 'denoise', denoise, 'fixhomer', true);
+        event = appendstruct(event, trigger);
       end
-      
-      % override the user specified settings (or defaults, which are probably empty)
-      chanindx = match_str(hdr.label, 'AUX');
-      threshold = 'nanmean';
-      
-      trigger = read_trigger(filename, 'header', hdr, 'dataformat', dataformat, 'begsample', flt_minsample, 'endsample', flt_maxsample, 'chanindx', chanindx, 'detectflank', detectflank, 'denoise', denoise, 'trigshift', trigshift, 'threshold', threshold);
-      event   = appendstruct(event, trigger);
+    else
+      % use the user-supplied list of channels
+      trigger = read_trigger(filename, 'header', hdr, 'dataformat', dataformat, 'begsample', flt_minsample, 'endsample', flt_maxsample, 'chanindx', chanindx, 'detectflank', detectflank, 'denoise', denoise, 'trigshift', trigshift, 'threshold', threshold, 'denoise', denoise, 'fixhomer', true);
+      event = appendstruct(event, trigger);
     end
     
   case {'itab_raw' 'itab_mhd'}
@@ -1361,7 +1348,7 @@ switch eventformat
         % auto-detect the trigger channels
         chanindx = find(ft_chantype(hdr, 'flag'));
       end
-      trigger = read_trigger(filename, 'header', hdr, 'dataformat', dataformat, 'begsample', flt_minsample, 'endsample', flt_maxsample, 'chanindx', chanindx, 'detectflank', detectflank, 'denoise', denoise, 'trigshift', trigshift);
+      trigger = read_trigger(filename, 'header', hdr, 'dataformat', dataformat, 'begsample', flt_minsample, 'endsample', flt_maxsample, 'chanindx', chanindx, 'detectflank', detectflank, 'denoise', denoise, 'trigshift', trigshift, 'threshold', threshold, 'denoise', denoise);
       event   = appendstruct(event, trigger);
     end
     

--- a/fileio/ft_read_header.m
+++ b/fileio/ft_read_header.m
@@ -1524,45 +1524,57 @@ switch headerformat
     
   case {'homer_nirs'}
     % Homer files are MATLAB files in disguise
-    orig = load(filename, '-mat');
+    % see https://www.nitrc.org/plugins/mwiki/index.php/homer2:Homer_Input_Files#NIRS_data_file_format
+    nirs = load(filename, '-mat');
     
     hdr.label       = {};
-    hdr.nChans      = size(orig.d,2);
-    hdr.nSamples    = size(orig.d,1);
+    hdr.nChans      = size(nirs.d,2);
+    hdr.nSamples    = size(nirs.d,1);
     hdr.nSamplesPre = 0;
     hdr.nTrials     = 1; % assume continuous data, not epoched
-    hdr.Fs          = 1/median(diff(orig.t));
-
+    hdr.Fs          = 1/median(diff(nirs.t));
     
     % number of wavelengths times sources times detectors
-    if ~isfield(orig.SD, 'nSrcs')
-      orig.SD.nSrcs = size(orig.SD.SrcPos,1);
-    end      
-    if ~isfield(orig.SD, 'nDets')
-      orig.SD.nDets = size(orig.SD.DetPos,1);
+    if ~isfield(nirs.SD, 'nSrcs')
+      nirs.SD.nSrcs = size(nirs.SD.SrcPos,1);
     end
-    assert(numel(orig.SD.Lambda)*orig.SD.nSrcs*orig.SD.nDets >= hdr.nChans);
+    if ~isfield(nirs.SD, 'nDets')
+      nirs.SD.nDets = size(nirs.SD.DetPos,1);
+    end
+    assert(numel(nirs.SD.Lambda)*nirs.SD.nSrcs*nirs.SD.nDets >= hdr.nChans);
     
-    for i=1:hdr.nChans
-      hdr.label{i} = num2str(i);
+    try
+      % use the transmitter and receiver numbers and the wavelength to form the the channel names
+      for i=1:hdr.nChans
+        tx = nirs.ml(i,1); % transmitter
+        rx = nirs.ml(i,2); % receiver
+        wl = nirs.SD.Lambda(nirs.ml(i,4)); % wavelength in nm
+        hdr.label{i} = sprintf('Rx%d-Tx%d [%dnm]', rx, tx, round(wl));
+      end
+    catch
+      ft_warning('creating default channel names');
+      for i=1:hdr.nChans
+        hdr.label{i} = num2str(i);
+      end
     end
     
     hdr.chantype = repmat({'nirs'}, hdr.nChans, 1);
     hdr.chanunit = repmat({'unknown'}, hdr.nChans, 1);
     
-    if isfield(orig, 'aux')
+    if isfield(nirs, 'aux')
       % concatenate the AUX channel at the end, consistent with FT_READ_DATA
       hdr.nChans = hdr.nChans + 1;
       hdr.label{end+1} = 'AUX';
       hdr.chantype{end+1} = 'aux';
       hdr.chanunit{end+1} = 'unknown';
     end
-
-    % convert the measurement configuration details to an optode structure
-    hdr.opto = homer2opto(orig.SD);
     
-    % keep the header details
-    hdr.orig.SD = orig.SD;
+    % convert the measurement configuration details to an optode structure
+    hdr.opto = homer2opto(nirs.SD);
+    
+    % keep some of the original header details
+    hdr.orig.ml = nirs.ml;
+    hdr.orig.SD = nirs.SD;
     
   case {'itab_raw' 'itab_mhd'}
     % read the full header information frtom the binary header structure
@@ -2333,12 +2345,12 @@ switch headerformat
   case 'nwb'
     ft_hastoolbox('MatNWB', 1);	% when I run this locally outside of ft_read_header it does not work for me
     try
-        c = load('namespaces/core.mat');
-        nwb_version = c.version;
-        nwb_fileversion = util.getSchemaVersion(filename);
-        if ~strcmp(nwb_version, nwb_fileversion)
-            warning(['Installed NWB:N schema version (' nwb_version ') does not match the file''s schema (' nwb_fileversion{1} '). This might result in an error. If so, try to install the matching schema from here: https://github.com/NeurodataWithoutBorders/nwb-schema/releases'])
-        end
+      c = load('namespaces/core.mat');
+      nwb_version = c.version;
+      nwb_fileversion = util.getSchemaVersion(filename);
+      if ~strcmp(nwb_version, nwb_fileversion)
+        warning(['Installed NWB:N schema version (' nwb_version ') does not match the file''s schema (' nwb_fileversion{1} '). This might result in an error. If so, try to install the matching schema from here: https://github.com/NeurodataWithoutBorders/nwb-schema/releases'])
+      end
     catch
       warning('Something might not be alright with your MatNWB path. Will try anyways.')
     end
@@ -2818,7 +2830,7 @@ if isfield(hdr, 'opto')
     hdr.opto = ft_datatype_sens(hdr.opto);
   catch
     % the NIRS optode structure is incomplete when reading/converting it from Homer files
-    ft_warning('optode structure is not compliant with FT_DATATPE_SENS');
+    ft_warning('optode structure is not compliant with FT_DATATYPE_SENS');
   end
 end
 

--- a/fileio/ft_read_header.m
+++ b/fileio/ft_read_header.m
@@ -1546,9 +1546,9 @@ switch headerformat
     try
       % use the transmitter and receiver numbers and the wavelength to form the the channel names
       for i=1:hdr.nChans
-        tx = nirs.ml(i,1); % transmitter
-        rx = nirs.ml(i,2); % receiver
-        wl = nirs.SD.Lambda(nirs.ml(i,4)); % wavelength in nm
+        tx = nirs.SD.MeasList(i,1); % transmitter
+        rx = nirs.SD.MeasList(i,2); % receiver
+        wl = nirs.SD.Lambda(nirs.SD.MeasList(i,4)); % wavelength in nm
         hdr.label{i} = sprintf('Rx%d-Tx%d [%dnm]', rx, tx, round(wl));
       end
     catch
@@ -1560,21 +1560,46 @@ switch headerformat
     
     hdr.chantype = repmat({'nirs'}, hdr.nChans, 1);
     hdr.chanunit = repmat({'unknown'}, hdr.nChans, 1);
-    
+
     if isfield(nirs, 'aux')
-      % concatenate the AUX channel at the end, consistent with FT_READ_DATA
-      hdr.nChans = hdr.nChans + 1;
-      hdr.label{end+1} = 'AUX';
-      hdr.chantype{end+1} = 'aux';
-      hdr.chanunit{end+1} = 'unknown';
-    end
+      % concatenate the AUX channel(s) at the end, consistent with FT_READ_DATA
+      if size(nirs.aux,2)==1
+        hdr.nChans = hdr.nChans + 1;
+        hdr.label{end+1} = 'aux';
+        hdr.chantype{end+1} = 'aux';
+        hdr.chanunit{end+1} = 'unknown';
+      else
+        for i=1:size(nirs.aux,2)
+          hdr.nChans = hdr.nChans + 1;
+          hdr.label{end+1} = sprintf('aux%d', i);
+          hdr.chantype{end+1} = 'aux';
+          hdr.chanunit{end+1} = 'unknown';
+        end
+      end % if single or multiple
+    end % if aux channels present
+    
+    if isfield(nirs, 's')
+      % concatenate the stimulus channel(s) at the end, consistent with FT_READ_DATA
+      if size(nirs.s,2)==1
+        hdr.nChans = hdr.nChans + 1;
+        hdr.label{end+1} = 's';
+        hdr.chantype{end+1} = 'stimulus';
+        hdr.chanunit{end+1} = 'unknown';
+      else
+        for i=1:size(nirs.s,2)
+          hdr.nChans = hdr.nChans + 1;
+          hdr.label{end+1} = sprintf('s%d', i);
+          hdr.chantype{end+1} = 'stimulus';
+          hdr.chanunit{end+1} = 'unknown';
+        end
+      end % if single or multiple
+    end % if stimulus channels present
     
     % convert the measurement configuration details to an optode structure
     hdr.opto = homer2opto(nirs.SD);
     
-    % keep some of the original header details
-    hdr.orig.ml = nirs.ml;
-    hdr.orig.SD = nirs.SD;
+    % keep all details except the data
+    hdr.orig = removefields(nirs, {'d', 't', 's', 'aux'});
     
   case {'itab_raw' 'itab_mhd'}
     % read the full header information frtom the binary header structure

--- a/fileio/ft_read_header.m
+++ b/fileio/ft_read_header.m
@@ -1532,6 +1532,7 @@ switch headerformat
     hdr.nSamplesPre = 0;
     hdr.nTrials     = 1; % assume continuous data, not epoched
     hdr.Fs          = 1/median(diff(orig.t));
+
     
     % number of wavelengths times sources times detectors
     if ~isfield(orig.SD, 'nSrcs')
@@ -1539,7 +1540,7 @@ switch headerformat
     end      
     if ~isfield(orig.SD, 'nDets')
       orig.SD.nDets = size(orig.SD.DetPos,1);
-    end      
+    end
     assert(numel(orig.SD.Lambda)*orig.SD.nSrcs*orig.SD.nDets >= hdr.nChans);
     
     for i=1:hdr.nChans
@@ -1549,6 +1550,14 @@ switch headerformat
     hdr.chantype = repmat({'nirs'}, hdr.nChans, 1);
     hdr.chanunit = repmat({'unknown'}, hdr.nChans, 1);
     
+    if isfield(orig, 'aux')
+      % concatenate the AUX channel at the end, consistent with FT_READ_DATA
+      hdr.nChans = hdr.nChans + 1;
+      hdr.label{end+1} = 'AUX';
+      hdr.chantype{end+1} = 'aux';
+      hdr.chanunit{end+1} = 'unknown';
+    end
+
     % convert the measurement configuration details to an optode structure
     hdr.opto = homer2opto(orig.SD);
     

--- a/fileio/ft_read_headshape.m
+++ b/fileio/ft_read_headshape.m
@@ -265,9 +265,9 @@ switch fileformat
     orig = read_ctf_shape(filename);
     shape.pos = orig.pos;
     
-    % The file also contains fiducial information, but those are in MRI voxels and 
+    % The file also contains fiducial information, but those are in MRI voxels and
     % inconsistent with the headshape itself.
-    % 
+    %
     % shape.fid.label = {'NASION', 'LEFT_EAR', 'RIGHT_EAR'};
     % shape.fid.pos = zeros(0,3); % start with an empty array
     % for i = 1:numel(shape.fid.label)
@@ -352,7 +352,7 @@ switch fileformat
     filename    = strrep(filename, '.surf.', '.shape.');
     filename    = strrep(filename, '.topo.', '.shape.');
     filename    = strrep(filename, '.coord.', '.shape.');
-
+    
     [p,f,e]     = fileparts(filename);
     tok         = tokenize(f, '.');
     if length(tok)>2
@@ -390,7 +390,7 @@ switch fileformat
     else
       seltopo = 1;
     end
-      
+    
     % recursively call ft_read_headshape
     tmp1 = ft_read_headshape(coordfiles{selcoord});
     tmp2 = ft_read_headshape(topofiles{seltopo});
@@ -978,24 +978,24 @@ switch fileformat
       [vertex, faces] = remove_vertices(vertex, faces, remove);
     end
     
-%     if fixtexture
-%       texture_old = texture;
-%       texture     = zeros(size(vertex,1), size(texture_old,2));
-%       
-%       % create the vertex-based texture as an average across the faces that
-%       % contain the vertex
-%       for k = 1:size(vertex,1)
-%         sel = textureIdx(faces==k);
-%         texture(k,:) = mean(texture_old(mode(sel),:));
-%       end
-%     end
+    %     if fixtexture
+    %       texture_old = texture;
+    %       texture     = zeros(size(vertex,1), size(texture_old,2));
+    %
+    %       % create the vertex-based texture as an average across the faces that
+    %       % contain the vertex
+    %       for k = 1:size(vertex,1)
+    %         sel = textureIdx(faces==k);
+    %         texture(k,:) = mean(texture_old(mode(sel),:));
+    %       end
+    %     end
     
     shape.pos   = vertex;
     shape.pos   = shape.pos - repmat(sum(shape.pos)/length(shape.pos),...
-        [length(shape.pos),1]); %centering vertices
+      [length(shape.pos),1]); %centering vertices
     shape.tri   = faces; % remove the last row which is zeros
     
-    if hasimage      
+    if hasimage
       if texture_per_vert
         % Refines the mesh and textures to increase resolution of the colormapping
         [shape.pos, shape.tri, texture] = refine(shape.pos, shape.tri,...
@@ -1020,7 +1020,7 @@ switch fileformat
         end
         [uniq_vert, ix] = unique(shape.tri);
         texture_ix = textureIdx(ix);
-
+        
         % get the indices into the image
         x   = abs(round(texture(:,1)*(sx-1)))+1;
         y   = abs(round(texture(:,2)*(sy-1)))+1;
@@ -1032,11 +1032,11 @@ switch fileformat
       % If color is specified as 0-255 rather than 0-1 correct by dividing
       % by 255
       if range(color(:)) > 1
-          color = color./255;
+        color = color./255;
       end
       
       shape.color = color;
-
+      
     elseif size(vertex,2)==6
       % the vertices also contain RGB colors
       
@@ -1044,7 +1044,7 @@ switch fileformat
       % If color is specified as 0-255 rather than 0-1 correct by dividing
       % by 255
       if range(color(:)) > 1
-          color = color./255;
+        color = color./255;
       end
       
       shape.color = color;
@@ -1054,7 +1054,7 @@ switch fileformat
     [pos, tri] = read_vtk(filename);
     shape.pos = pos;
     shape.tri = tri;
-  
+    
   case 'vtk_xml'
     data = read_vtk_xml(filename);
     shape.orig = data;
@@ -1062,14 +1062,14 @@ switch fileformat
     if isfield(data, 'Lines')
       shape.line = data.Lines;
     end
-  
+    
   case 'mrtrix_tck'
     ft_hastoolbox('mrtrix', 1);
     shape = read_tck(filename);
-  
+    
   case 'trackvis_trk'
     shape = read_trk(filename);
-  
+    
   case 'off'
     [pos, plc] = read_off(filename);
     shape.pos  = pos;
@@ -1278,10 +1278,9 @@ switch fileformat
     success = false;
     
     if ~success
-      % try reading it as electrode positions
-      % and treat those as fiducials
+      % try reading it as electrode positions and treat those as fiducials
       try
-        elec = ft_read_sens(filename);
+        elec = ft_read_sens(filename, 'senstype', 'eeg');
         if ~ft_senstype(elec, 'eeg')
           ft_error('headshape information can not be read from MEG gradiometer file');
         else
@@ -1344,4 +1343,3 @@ shape = fixpos(shape);
 
 % ensure that the numerical arrays are represented in double precision and not as integers
 shape = ft_struct2double(shape);
-end

--- a/fileio/ft_read_sens.m
+++ b/fileio/ft_read_sens.m
@@ -14,7 +14,7 @@ function [sens] = ft_read_sens(filename, varargin)
 %   'coordsys'       = string, 'head' or 'dewar' (default = 'head')
 %   'coilaccuracy'   = scalar, can be empty or a number (0, 1 or 2) to specify the accuracy (default = [])
 %
-% The electrode, gradiometer and optode structures are defined in more detail 
+% The electrode, gradiometer and optode structures are defined in more detail
 % in FT_DATATYPE_SENS.
 %
 % Files from the following acquisition systems and analysis platforms file formats
@@ -75,22 +75,22 @@ switch fileformat
     
   case 'artinis_oxy3'
     ft_hastoolbox('artinis', 1);
-    hdr = read_artinis_oxy3(filename, false);    
+    hdr = read_artinis_oxy3(filename, false);
     sens = hdr.opto;
     
   case 'artinis_oxy4'
     ft_hastoolbox('artinis', 1);
-    hdr = read_artinis_oxy4(filename, false);    
+    hdr = read_artinis_oxy4(filename, false);
     sens = hdr.opto;
     
   case 'artinis_oxyproj'
     ft_hastoolbox('artinis', 1);
-    hdr = read_artinis_oxyproj(filename); 
+    hdr = read_artinis_oxyproj(filename);
     sens = hdr.opto;
-
+    
   case 'polhemus_pos'
     sens = read_polhemus_pos(filename);
-
+    
   case 'besa_elp'
     ft_error('unknown fileformat for electrodes or gradiometers');
     % the code below does not yet work
@@ -105,7 +105,7 @@ switch fileformat
     r  = ones(size(el));
     [x, y, z] = sph2cart(az, el, r);
     sens.chanpos = [x y z];
-
+    
   case 'besa_pos'
     tmp = importdata(filename);
     if ~isnumeric(tmp)
@@ -146,7 +146,7 @@ switch fileformat
         sens.label{i} = sprintf('%03d', i);
       end
     end
-
+    
   case 'besa_sfh'
     sfh = readBESAsfh(filename);
     sens.label   = sfh.SurfacePointsLabels(:);
@@ -159,15 +159,15 @@ switch fileformat
     end
     sens.label   = sens.label(sel);
     sens.elecpos = sens.elecpos(sel,:);
-  
+    
   case 'besa_sfp'
     [lab, pos] = read_besa_sfp(filename);
     sens.label   = lab;
     sens.elecpos = pos;
-
+    
   case 'bioimage_mgrid'
     sens = read_bioimage_mgrid(filename);
-
+    
   case {'ctf_ds', 'ctf_res4', 'ctf_old', 'neuromag_fif', 'neuromag_mne', '4d', '4d_pdf', '4d_m4d', '4d_xyz', 'yokogawa_ave', 'yokogawa_con', 'yokogawa_raw', 'ricoh_ave', 'ricoh_con', 'itab_raw' 'itab_mhd', 'netmeg'}
     % gradiometer information is always stored in the header of the MEG dataset, hence uses the standard fieldtrip/fileio ft_read_header function
     hdr = ft_read_header(filename, 'headerformat', fileformat, 'coordsys', coordsys, 'coilaccuracy', coilaccuracy);
@@ -193,15 +193,13 @@ switch fileformat
     else
       ft_error('neither electrode nor gradiometer information is present');
     end
-
-  case {'curry_dat', 'curry_cdt'}  
     
+  case {'curry_dat', 'curry_cdt'}
     hdr = ft_read_header(filename);
-    
     if ~isempty(hdr.orig.sensorpos)
       sens.elecpos = hdr.orig.sensorpos';
       sens.label   = hdr.label(1:size(sens.elecpos, 1));
-    end  
+    end
     
   case 'fcdc_buffer'
     % the online header should have a binary blob with the sensor information
@@ -225,19 +223,19 @@ switch fileformat
       otherwise
         ft_error('incorrect specification of senstype');
     end
-
+    
   case 'neuromag_mne_grad'
     % the file can contain both, force reading the gradiometer info
     % note that this functionality overlaps with senstype=eeg/meg
     hdr = ft_read_header(filename, 'headerformat', 'neuromag_mne', 'coordsys', coordsys, 'coilaccuracy', coilaccuracy);
     sens = hdr.grad;
-
+    
   case 'neuromag_mne_elec'
     % the file can contain both, force reading the electrode info
     % note that this functionality overlaps with senstype=eeg/meg
     hdr = ft_read_header(filename, 'headerformat', 'neuromag_mne', 'coordsys', coordsys, 'coilaccuracy', coilaccuracy);
     sens = hdr.elec;
-
+    
   case {'spmeeg_mat', 'eeglab_set'}
     % this is for EEG formats where electrode positions can be stored with the data
     hdr = ft_read_header(filename, 'coordsys', coordsys, 'coilaccuracy', coilaccuracy);
@@ -248,7 +246,7 @@ switch fileformat
     else
       ft_error('no electrodes or gradiometers found in the file')
     end
-
+    
   case 'polhemus_fil'
     % these are created at the FIL in London with a polhemus tracker
     [sens.fid.pnt, sens.pnt, sens.fid.label] = read_polhemus_fil(filename, 0);
@@ -257,7 +255,7 @@ switch fileformat
     for i=1:size(sens.pnt, 1)
       sens.label{i} = sprintf('%03d', i);
     end
-
+    
   case 'matlab'
     % MATLAB files can contain all sensor arrays
     matfile = filename;   % this solves a problem with the MATLAB compiler v3
@@ -270,14 +268,14 @@ switch fileformat
       % read whatever variable is in the file, this will error if the file contains multiple variables
       sens = loadvar(matfile);
     end
-
+    
   case 'zebris_sfp'
     % these are created by a Zebris tracker, at CRC in Liege at least.
     [sens.fid.pnt, sens.chanpos, sens.fid.label, sens.label] = read_zebris(filename, 0);
     % convert to columns
     sens.label = sens.label(:);
     sens.fid.label = sens.fid.label(:);
-
+    
   case '4d_el_ascii'
     fid = fopen_or_error(filename, 'rt');
     c = textscan(fid, '%s%s%f%f%f');
@@ -308,53 +306,53 @@ switch fileformat
       sens.fid.label  = l(sel);
       sens.fid.pnt    = [x(sel) y(sel) z(sel)];
     end
-
-  case {'localite_pos','localite_ins'}
+    
+  case {'localite_pos', 'localite_ins'}
     if ~usejava('jvm') % Using xml2struct requires java
       fid = fopen_or_error(filename);
-
+      
       % Read marker-file and store contents in cells of strings
       tmp = textscan(fid,'%s');
-
+      
       fclose(fid);
-
+      
       % Search for cells that contain coordinates
       selx = strncmp('data0',tmp{1},5);
       sely = strncmp('data1',tmp{1},5);
       selz = strncmp('data2',tmp{1},5);
       sellab = strncmp('description',tmp{1},5);
-
+      
       % Extract cells that contain coordinates
       xtemp  = tmp{1}(selx);
       ytemp  = tmp{1}(sely);
       ztemp  = tmp{1}(selz);
       labtemp = tmp{1}(sellab);
-
+      
       % Determine which channels are set. In localite channels that are not set
       % automatically receive coordinates [0, 0, 0] and should therefore
       % be discarded.
       settemp = tmp{1}(strncmp('set',tmp{1},3));
       selset = strncmp('set="f',settemp,6);
-
+      
       % Remove channels that are not set
       xtemp(selset) = [];
       ytemp(selset) = [];
       ztemp(selset) = [];
       labtemp(selset) = [];
-
+      
       % Convert cells that contain coordinates from string to double
       x = [];
       y = [];
       z = [];
       lbl = [];
-
+      
       for i=1:numel(xtemp)
         x(i,1) = str2double(xtemp{i}(8:end-1));
         y(i,1) = str2double(ytemp{i}(8:end-1));
         z(i,1) = str2double(ztemp{i}(8:end-3));
         lbl{i,1} = labtemp{i}(14:end-1);
       end
-
+      
       % Create and fill sens structure
       sens = [];
       sens.elecpos = [x y z];
@@ -362,9 +360,9 @@ switch fileformat
       sens.label = lbl;
     else
       tmp = xml2struct(filename);
-
+      
       sens = [];
-
+      
       % Loop through structure obtained from xml-file and store
       % coordinate information into sens structure of channels that are
       % set.
@@ -376,16 +374,16 @@ switch fileformat
           sens.label{i} = tmp(i).Marker.description;
         end
       end
-
+      
       sens.chanpos = sens.elecpos;
     end
-
+    
   case 'easycap_txt'
     % Read the file and store all contents in cells of strings
     fid = fopen_or_error(filename);
     tmp = textscan(fid,'%s%s%s%s');
     fclose(fid);
-
+    
     sens = [];
     if all(cellfun(@isempty, tmp{4}))
       % it contains theta and phi
@@ -409,7 +407,7 @@ switch fileformat
       sens.elecpos = [x y z];
       sens.chanpos = [x y z];
     end
-
+    
   case 'neuromag_iso'
     ft_hastoolbox('mne', 1);
     FIFF = fiff_define_constants();
@@ -427,7 +425,7 @@ switch fileformat
       coordsys(i)       = tag.data.coord_frame;
     end
     fclose(fid);
-
+    
     if all(coordsys==FIFF.FIFFV_COORD_DEVICE)
       sens.coordsys = 'device';
     elseif all(coordsys==FIFF.FIFFV_COORD_ISOTRAK)
@@ -439,12 +437,12 @@ switch fileformat
     else
       sens.coordsys = 'unknown';
     end
-
+    
     ft_warning('creating fake channel names for neuromag_iso');
     for i=1:size(sens.chanpos,1)
       sens.label{i} = sprintf('%d', i);
     end
-
+    
   case 'neuromag_cal'
     dat = cell(1,14);
     [dat{:}] = textread(filename, '%s%f%f%f%f%f%f%f%f%f%f%f%f%f');
@@ -464,8 +462,14 @@ switch fileformat
     csvData = readtable(filename,'FileType','text');
     sens.label = csvData.label;
     sens.elecpos = [csvData.x,csvData.y,csvData.z];
-
-
+    
+  case 'brainsight_txt'
+    ws = warning('off', 'MATLAB:table:ModifiedAndSavedVarnames');
+    txtData = readtable(filename, 'FileType', 'text', 'Delimiter', '\t', 'ReadVariableNames', true);
+    warning(ws); % revert to the previous warning state
+    sens.label   = txtData{:,1};
+    sens.elecpos = [txtData.Loc_X txtData.Loc_Y txtData.Loc_Z];
+        
   otherwise
     ft_error('unknown fileformat for electrodes or gradiometers');
 end % switch fileformat

--- a/fileio/private/channelposition.m
+++ b/fileio/private/channelposition.m
@@ -1,11 +1,11 @@
 function [pnt, ori, lab] = channelposition(sens)
 
 % CHANNELPOSITION computes the channel positions and orientations from the
-% coils or electrodes
+% MEG coils, EEG electrodes or NIRS optodes
 %
 % Use as
 %   [pos, ori, lab] = channelposition(sens)
-% where sens is an electrode,  gradiometer or optode array.
+% where sens is an gradiometer, electrode, or optode array.
 %
 % See also FT_DATATYPE_SENS
 
@@ -42,6 +42,12 @@ end
 if isfield(sens, 'pnt')
   sens.coilpos = sens.pnt;
   sens = rmfield(sens, 'pnt');
+end
+
+if isfield(sens, 'transmits') && ~isfield(sens, 'tra')
+  % this applies to optode definitions, the transmits matrix also codes for the wavelengths
+  % make a tra matrix where each optode weights in with the same amount
+  sens.tra = (sens.transmits~=0);
 end
 
 % treat all sensor arrays similar, i.e. as gradiometer systems

--- a/fileio/private/channelposition.m
+++ b/fileio/private/channelposition.m
@@ -44,12 +44,6 @@ if isfield(sens, 'pnt')
   sens = rmfield(sens, 'pnt');
 end
 
-if isfield(sens, 'transmits') && ~isfield(sens, 'tra')
-  % this applies to optode definitions, the transmits matrix also codes for the wavelengths
-  % make a tra matrix where each optode weights in with the same amount
-  sens.tra = (sens.transmits~=0);
-end
-
 % treat all sensor arrays similar, i.e. as gradiometer systems
 if     ~isfield(sens, 'coilori') && isfield(sens, 'coilpos')
   sens.coilori = nan(size(sens.coilpos));

--- a/fileio/private/ft_datatype_sens.m
+++ b/fileio/private/ft_datatype_sens.m
@@ -1,13 +1,15 @@
 function [sens] = ft_datatype_sens(sens, varargin)
 
-% FT_DATATYPE_SENS describes the FieldTrip structure that represents an EEG, ECoG, or
-% MEG sensor array. This structure is commonly called "elec" for EEG, "grad" for MEG,
-% "opto" for NIRS, or general "sens" for either one.
+% FT_DATATYPE_SENS describes the FieldTrip structure that represents an MEG, EEG,
+% sEEG, ECoG, or NIRS sensor array. This structure is commonly called "grad" for MEG,
+% "elec" for EEG and intranial EEG, "opto" for NIRS, or in general "sens" if it could
+% be any one.
 %
 % For all sensor types a distinction should be made between the channel (i.e. the
 % output of the transducer that is A/D converted) and the sensor, which may have some
-% spatial extent. E.g. with EEG you can have a bipolar channel, where the position of
-% the channel can be represented as in between the position of the two electrodes.
+% spatial extent. For example in MEG gradiometers are comprised of multiple coils and
+% with EEG you can have a bipolar channel, where the position of the channel can be
+% represented as in between the position of the two electrodes.
 %
 % The structure for MEG gradiometers and/or magnetometers contains
 %    sens.label      = Mx1 cell-array with channel labels
@@ -18,9 +20,7 @@ function [sens] = ft_datatype_sens(sens, varargin)
 %    sens.tra        = MxN matrix to combine coils into channels
 %    sens.balance    = structure containing info about the balancing, See FT_APPLY_MONTAGE
 % and optionally
-%    sens.chanposold = Mx3 matrix with original channel positions (in case
-%                      sens.chanpos has been updated to contain NaNs, e.g.
-%                      after ft_componentanalysis)
+%    sens.chanposold = Mx3 matrix with original channel positions (in case sens.chanpos has been updated to contain NaNs, e.g. after FT_COMPONENTANALYSIS)
 %    sens.chanoriold = Mx3 matrix with original channel orientations
 %    sens.labelold   = Mx1 cell-array with original channel labels
 %
@@ -39,8 +39,7 @@ function [sens] = ft_datatype_sens(sens, varargin)
 %    sens.optotype      = Nx1 cell-array with information about the type of optode (receiver or transmitter)
 %    sens.optolabel     = Nx1 cell-array with optode labels
 %    sens.wavelength    = 1xK vector of all wavelengths that were used
-%    sens.laserstrength = 1xK vector of the strength of the emitted light of the lasers
-%    sens.transmits     = MxN matrix, specifies for each of the M channels at which wavelength each of the N optodes transmits (positive integer from 1 to K), or receives (negative ingeger from 1 to K), or does not contribute at all (zeros)
+%    sens.tra           = MxN matrix that specifies for each of the M channels which of the N optodes transmits at which wavelength (positive integer from 1 to K), or receives (negative ingeger from 1 to K)
 %
 % The following fields apply to MEG, EEG, sEEG and ECoG
 %    sens.chantype = Mx1 cell-array with the type of the channel, see FT_CHANTYPE
@@ -51,9 +50,12 @@ function [sens] = ft_datatype_sens(sens, varargin)
 %    sens.fid  = structure with fiducial information
 %
 % Historical fields:
-%    pnt, pos, ori, pnt1, pnt2, fiberpos, fibertype, fiberlabel, transceiver
+%    pnt, pos, ori, pnt1, pnt2, fiberpos, fibertype, fiberlabel, transceiver, transmits, laserstrength
 %
 % Revision history:
+% (2020/latest) Updated the specification of the NIRS sensor definition.
+%   Dropped the laserstrength and renamed transmits into tra for consistency.
+%
 % (2019/latest) Updated the specification of the NIRS sensor definition.
 %   Use "opto" instead of "fibers", see http://bit.ly/33WaqWU for details.
 %
@@ -141,7 +143,7 @@ if ~isempty(distance) && ~any(strcmp(distance, {'m' 'dm' 'cm' 'mm'}))
 end
 
 if strcmp(version, 'latest')
-  version = '2019';
+  version = '2020';
 end
 
 if isempty(sens)
@@ -151,17 +153,30 @@ end
 % this is needed further down
 nchan = length(sens.label);
 
-% there are many cases which deal with either eeg or meg
-ismeg = ft_senstype(sens, 'meg');
+% there are many cases which are MEG, EEG or NIRS specific
+ismeg  = ft_senstype(sens, 'meg');
+iseeg  = ft_senstype(sens, 'eeg');
+isnirs = ft_senstype(sens, 'nirs');
 
 switch version
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  case '2020'
+    % update it to the previous standard version
+    new_argin = ft_setopt(varargin, 'version', '2019');
+    sens      = ft_datatype_sens(sens, new_argin{:});
+    
+    if isnirs
+      sens = renamefields(sens, 'transmits', 'tra'); % this makes it more consistent with EEG and MEG
+      sens = removefields(sens, {'laserstrength'});
+    end
+    
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   case '2019'
     % update it to the previous standard version
     new_argin = ft_setopt(varargin, 'version', '2016');
     sens      = ft_datatype_sens(sens, new_argin{:});
     
-    if isfield(sens, 'fiberpos') || isfield(sens, 'optopos')
+    if isnirs
       % rename some NIRS field names
       sens = renamefields(sens, 'fiberpos', 'optopos');
       sens = renamefields(sens, 'fibertype', 'optotype');
@@ -172,7 +187,7 @@ switch version
       % especially the chanunit field needs some careful thought when converting between optical densities and chromophore concentrations.
       sens = removefields(sens, {'chantype', 'chanunit'});
     end
-
+    
     % ensure all positions are represented as 3D, not 2D
     fn = {'chanpos', 'optopos', 'elecpos', 'coilpos'};
     for i=1:numel(fn)
@@ -190,27 +205,27 @@ switch version
     
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   case '2016'
-
     % update it to the previous standard version
-    sens = ft_datatype_sens(sens, 'version', '2011v2');
-
+    new_argin = ft_setopt(varargin, 'version', '2011v2');
+    sens      = ft_datatype_sens(sens, new_argin{:});
+    
     % rename from org to old (reverse = false)
     sens = fixoldorg(sens, false);
-
+    
     % ensure that all numbers are represented in double precision
     % this only affects the top-level fields and does not recurse
     sens = ft_struct2double(sens, 1);
-
+    
     % in version 2011v2 this was optional, now it is required
     if ~isfield(sens, 'chantype') || all(strcmp(sens.chantype, 'unknown'))
       sens.chantype = ft_chantype(sens);
     end
-
+    
     % in version 2011v2 this was optional, now it is required
     if ~isfield(sens, 'chanunit') || all(strcmp(sens.chanunit, 'unknown'))
       sens.chanunit = ft_chanunit(sens);
     end
-
+    
     if ~isempty(distance)
       % update the units of distance, this also updates the tra matrix
       sens = ft_convert_units(sens, distance);
@@ -218,7 +233,7 @@ switch version
       % determine the default, this may be needed to set the scaling
       distance = sens.unit;
     end
-
+    
     if ~isempty(amplitude) && isfield(sens, 'tra')
       % update the tra matrix for the units of amplitude, this ensures that
       % the leadfield values remain consistent with the units
@@ -254,14 +269,14 @@ switch version
         amplitude = 'unknown';
       end
     end
-
+    
     % perform some sanity checks
     if ismeg
       sel_m  = ~cellfun(@isempty, regexp(sens.chanunit, '/m$'));
       sel_dm = ~cellfun(@isempty, regexp(sens.chanunit, '/dm$'));
       sel_cm = ~cellfun(@isempty, regexp(sens.chanunit, '/cm$'));
       sel_mm = ~cellfun(@isempty, regexp(sens.chanunit, '/mm$'));
-
+      
       if     strcmp(sens.unit, 'm') && (any(sel_dm) || any(sel_cm) || any(sel_mm))
         ft_error('inconsistent units in input gradiometer');
       elseif strcmp(sens.unit, 'dm') && (any(sel_m) || any(sel_cm) || any(sel_mm))
@@ -271,9 +286,9 @@ switch version
       elseif strcmp(sens.unit, 'mm') && (any(sel_m) || any(sel_dm) || any(sel_cm))
         ft_error('inconsistent units in input gradiometer');
       end
-
+      
       if ~strcmp(amplitude, 'unknown') && ~strcmp(distance, 'unknown')
-
+        
         % the default should be "amplitude/distance" for neuromag and "amplitude" for all others
         if isempty(scaling)
           if ft_senstype(sens, 'neuromag') && ~any(contains(sens.chanunit, '/'))
@@ -284,7 +299,7 @@ switch version
             scaling = 'amplitude';
           end
         end
-
+        
         % update the gradiometer scaling
         if strcmp(scaling, 'amplitude') && isfield(sens, 'tra')
           for i=1:nchan
@@ -308,7 +323,7 @@ switch version
               ft_warning('unexpected channel unit "%s" in channel %d', sens.chanunit{i}, i);
             end % if
           end % for nchan
-
+          
         elseif strcmp(scaling, 'amplitude/distance') && isfield(sens, 'tra')
           for i=1:nchan
             if strcmp(sens.chanunit{i}, amplitude)
@@ -330,10 +345,10 @@ switch version
               ft_warning('unexpected channel unit "%s" in channel %d', sens.chanunit{i}, i);
             end % if
           end % for nchan
-
+          
         end % if strcmp scaling
       end % if amplitude and scaling are not unknown
-
+      
     else
       sel_m  = ~cellfun(@isempty, regexp(sens.chanunit, '/m$'));
       sel_dm = ~cellfun(@isempty, regexp(sens.chanunit, '/dm$'));
@@ -342,26 +357,26 @@ switch version
       if any(sel_m | sel_dm | sel_cm | sel_mm)
         ft_error('scaling of amplitude/distance has not been considered yet for EEG');
       end
-
+      
     end % if iseeg or ismeg
-
+    
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   case '2011v2'
-
+    
     % rename from old to org (reverse = true)
     sens = fixoldorg(sens, true);
-
+    
     if ~isempty(amplitude) || ~isempty(distance) || ~isempty(scaling)
       ft_warning('amplitude, distance and scaling are not supported for version "%s"', version);
     end
-
+    
     % This speeds up subsequent calls to ft_senstype and channelposition.
     % However, if it is not more precise than MEG or EEG, don't keep it in
     % the output (see further down).
     if ~isfield(sens, 'type')
       sens.type = ft_senstype(sens);
     end
-
+    
     if isfield(sens, 'pnt')
       if ismeg
         % sensor description is a MEG sensor-array, containing oriented coils
@@ -372,7 +387,7 @@ switch version
         sens.elecpos = sens.pnt; sens = rmfield(sens, 'pnt');
       end
     end
-
+    
     if ~isfield(sens, 'chanpos')
       if ismeg
         % sensor description is a MEG sensor-array, containing oriented coils
@@ -401,7 +416,7 @@ switch version
         end
       end
     end
-
+    
     if ~isfield(sens, 'chantype') || all(strcmp(sens.chantype, 'unknown'))
       if ismeg
         sens.chantype = ft_chantype(sens);
@@ -409,12 +424,12 @@ switch version
         % for EEG it is not required
       end
     end
-
+    
     if ~isfield(sens, 'unit')
       % this should be done prior to calling ft_chanunit, since ft_chanunit uses this for planar neuromag channels
       sens = ft_determine_units(sens);
     end
-
+    
     if ~isfield(sens, 'chanunit') || all(strcmp(sens.chanunit, 'unknown'))
       if ismeg
         sens.chanunit = ft_chanunit(sens);
@@ -422,13 +437,13 @@ switch version
         % for EEG it is not required
       end
     end
-
+    
     if any(strcmp(sens.type, {'meg', 'eeg', 'magnetometer', 'electrode', 'unknown'}))
       % this is not sufficiently informative, so better remove it
       % see also http://bugzilla.fieldtriptoolbox.org/show_bug.cgi?id=1806
       sens = rmfield(sens, 'type');
     end
-
+    
     if size(sens.chanpos,1)~=length(sens.label) || ...
         isfield(sens, 'tra') && size(sens.tra,1)~=length(sens.label) || ...
         isfield(sens, 'tra') && isfield(sens, 'elecpos') && size(sens.tra,2)~=size(sens.elecpos,1) || ...
@@ -438,13 +453,13 @@ switch version
         isfield(sens, 'chanori') && size(sens.chanori,1)~=length(sens.label)
       ft_error('inconsistent number of channels in sensor description');
     end
-
+    
     if ismeg
       % ensure that the magnetometer/gradiometer balancing is specified
       if ~isfield(sens, 'balance') || ~isfield(sens.balance, 'current')
         sens.balance.current = 'none';
       end
-
+      
       % try to add the chantype and chanunit to the CTF G1BR montage
       if isfield(sens, 'balance') && isfield(sens.balance, 'G1BR') && ~isfield(sens.balance.G1BR, 'chantype')
         sens.balance.G1BR.chantypeorg = repmat({'unknown'}, size(sens.balance.G1BR.labelorg));
@@ -459,7 +474,7 @@ switch version
         sens.balance.G1BR.chantypenew(sel1) = sens.chantype(sel2);
         sens.balance.G1BR.chanunitnew(sel1) = sens.chanunit(sel2);
       end
-
+      
       % idem for G2BR
       if isfield(sens, 'balance') && isfield(sens.balance, 'G2BR') && ~isfield(sens.balance.G2BR, 'chantype')
         sens.balance.G2BR.chantypeorg = repmat({'unknown'}, size(sens.balance.G2BR.labelorg));
@@ -474,7 +489,7 @@ switch version
         sens.balance.G2BR.chantypenew(sel1) = sens.chantype(sel2);
         sens.balance.G2BR.chanunitnew(sel1) = sens.chanunit(sel2);
       end
-
+      
       % idem for G3BR
       if isfield(sens, 'balance') && isfield(sens.balance, 'G3BR') && ~isfield(sens.balance.G3BR, 'chantype')
         sens.balance.G3BR.chantypeorg = repmat({'unknown'}, size(sens.balance.G3BR.labelorg));
@@ -490,11 +505,11 @@ switch version
         sens.balance.G3BR.chanunitnew(sel1) = sens.chanunit(sel2);
       end
     end
-
+    
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   otherwise
     ft_error('converting to version %s is not supported', version);
-
+    
 end % switch
 
 % this makes the display with the "disp" command look better

--- a/fileio/private/ft_datatype_sens.m
+++ b/fileio/private/ft_datatype_sens.m
@@ -38,10 +38,9 @@ function [sens] = ft_datatype_sens(sens, varargin)
 %    sens.optopos       = Nx3 matrix with the position of individual optodes
 %    sens.optotype      = Nx1 cell-array with information about the type of optode (receiver or transmitter)
 %    sens.optolabel     = Nx1 cell-array with optode labels
-%    sens.transmits     = NxK matrix, boolean, where N is the number of optodes and K the number of wavelengths. Specifies what optode is transmitting at what wavelength (or nothing at all, which indicates that it is a receiver).
 %    sens.wavelength    = 1xK vector of all wavelengths that were used
 %    sens.laserstrength = 1xK vector of the strength of the emitted light of the lasers
-%    sens.tra           = MxN matrix, boolean, contains information about how receiver and transmitter are combined to form channels
+%    sens.transmits     = MxN matrix, specifies for each of the M channels at which wavelength each of the N optodes transmits (positive integer from 1 to K), or receives (negative ingeger from 1 to K), or does not contribute at all (zeros)
 %
 % The following fields apply to MEG, EEG, sEEG and ECoG
 %    sens.chantype = Mx1 cell-array with the type of the channel, see FT_CHANTYPE
@@ -369,7 +368,7 @@ switch version
         sens.coilpos = sens.pnt; sens = rmfield(sens, 'pnt');
         sens.coilori = sens.ori; sens = rmfield(sens, 'ori');
       else
-        % sensor description is something else, EEG/ECoG etc
+        % sensor description is something else, EEG/ECoG/sEEG, etc
         sens.elecpos = sens.pnt; sens = rmfield(sens, 'pnt');
       end
     end

--- a/fileio/private/ft_senstype.m
+++ b/fileio/private/ft_senstype.m
@@ -152,11 +152,12 @@ isdata   = isa(input, 'struct')  && (isfield(input, 'hdr') || isfield(input, 'ti
 isheader = isa(input, 'struct')  && isfield(input, 'label') && isfield(input, 'Fs');
 isgrad   = isa(input, 'struct')  && isfield(input, 'label') && isfield(input, 'pnt')  &&  isfield(input, 'ori'); % old style
 iselec   = isa(input, 'struct')  && isfield(input, 'label') && isfield(input, 'pnt')  && ~isfield(input, 'ori'); % old style
-isgrad   = (isa(input, 'struct') && isfield(input, 'label') && isfield(input, 'coilpos')) || isgrad;             % new style
-iselec   = (isa(input, 'struct') && isfield(input, 'label') && isfield(input, 'elecpos')) || iselec;             % new style
-isnirs   = isa(input, 'struct')  && isfield(input, 'label') && isfield(input, 'optopos');
+isnirs   = isa(input, 'struct')  && isfield(input, 'label') && isfield(input, 'fiberpos');                       % old style
+isgrad   = (isa(input, 'struct') && isfield(input, 'label') && isfield(input, 'coilpos'))  || isgrad;            % new style
+iselec   = (isa(input, 'struct') && isfield(input, 'label') && isfield(input, 'elecpos'))  || iselec;            % new style
+isnirs   = (isa(input, 'struct')  && isfield(input, 'label') && isfield(input, 'optopos')) || isnirs;            % new style
 islabel  = isa(input, 'cell')    && ~isempty(input) && isa(input{1}, 'char');
-haslabel    = isa(input, 'struct')  && isfield(input, 'label');
+haslabel = isa(input, 'struct')  && isfield(input, 'label');
 
 if ~(isdata || isheader || isgrad || iselec || isnirs || islabel || haslabel) && isfield(input, 'hdr')
   input    = input.hdr;

--- a/fileio/private/read_bucn_nirshdr.m
+++ b/fileio/private/read_bucn_nirshdr.m
@@ -9,7 +9,7 @@ function [hdr] = read_bucn_nirshdr(filename)
 % Use as
 %   [hdr] = read_bucn_nirshdr(filename)
 %
-% See also read_bucn_nirsdata, READ_BUCN_NIRSEVENT
+% See also READ_BUCN_NIRSDATA, READ_BUCN_NIRSEVENT
 
 % Copyright (C) 2011, Jan-Mathijs Schoffelen
 %

--- a/forward/ft_senstype.m
+++ b/forward/ft_senstype.m
@@ -152,11 +152,12 @@ isdata   = isa(input, 'struct')  && (isfield(input, 'hdr') || isfield(input, 'ti
 isheader = isa(input, 'struct')  && isfield(input, 'label') && isfield(input, 'Fs');
 isgrad   = isa(input, 'struct')  && isfield(input, 'label') && isfield(input, 'pnt')  &&  isfield(input, 'ori'); % old style
 iselec   = isa(input, 'struct')  && isfield(input, 'label') && isfield(input, 'pnt')  && ~isfield(input, 'ori'); % old style
-isgrad   = (isa(input, 'struct') && isfield(input, 'label') && isfield(input, 'coilpos')) || isgrad;             % new style
-iselec   = (isa(input, 'struct') && isfield(input, 'label') && isfield(input, 'elecpos')) || iselec;             % new style
-isnirs   = isa(input, 'struct')  && isfield(input, 'label') && isfield(input, 'optopos');
+isnirs   = isa(input, 'struct')  && isfield(input, 'label') && isfield(input, 'fiberpos');                       % old style
+isgrad   = (isa(input, 'struct') && isfield(input, 'label') && isfield(input, 'coilpos'))  || isgrad;            % new style
+iselec   = (isa(input, 'struct') && isfield(input, 'label') && isfield(input, 'elecpos'))  || iselec;            % new style
+isnirs   = (isa(input, 'struct')  && isfield(input, 'label') && isfield(input, 'optopos')) || isnirs;            % new style
 islabel  = isa(input, 'cell')    && ~isempty(input) && isa(input{1}, 'char');
-haslabel    = isa(input, 'struct')  && isfield(input, 'label');
+haslabel = isa(input, 'struct')  && isfield(input, 'label');
 
 if ~(isdata || isheader || isgrad || iselec || isnirs || islabel || haslabel) && isfield(input, 'hdr')
   input    = input.hdr;

--- a/forward/private/channelposition.m
+++ b/forward/private/channelposition.m
@@ -1,11 +1,11 @@
 function [pnt, ori, lab] = channelposition(sens)
 
 % CHANNELPOSITION computes the channel positions and orientations from the
-% coils or electrodes
+% MEG coils, EEG electrodes or NIRS optodes
 %
 % Use as
 %   [pos, ori, lab] = channelposition(sens)
-% where sens is an electrode,  gradiometer or optode array.
+% where sens is an gradiometer, electrode, or optode array.
 %
 % See also FT_DATATYPE_SENS
 
@@ -42,6 +42,12 @@ end
 if isfield(sens, 'pnt')
   sens.coilpos = sens.pnt;
   sens = rmfield(sens, 'pnt');
+end
+
+if isfield(sens, 'transmits') && ~isfield(sens, 'tra')
+  % this applies to optode definitions, the transmits matrix also codes for the wavelengths
+  % make a tra matrix where each optode weights in with the same amount
+  sens.tra = (sens.transmits~=0);
 end
 
 % treat all sensor arrays similar, i.e. as gradiometer systems

--- a/forward/private/channelposition.m
+++ b/forward/private/channelposition.m
@@ -44,12 +44,6 @@ if isfield(sens, 'pnt')
   sens = rmfield(sens, 'pnt');
 end
 
-if isfield(sens, 'transmits') && ~isfield(sens, 'tra')
-  % this applies to optode definitions, the transmits matrix also codes for the wavelengths
-  % make a tra matrix where each optode weights in with the same amount
-  sens.tra = (sens.transmits~=0);
-end
-
 % treat all sensor arrays similar, i.e. as gradiometer systems
 if     ~isfield(sens, 'coilori') && isfield(sens, 'coilpos')
   sens.coilori = nan(size(sens.coilpos));

--- a/forward/private/ft_datatype_sens.m
+++ b/forward/private/ft_datatype_sens.m
@@ -1,13 +1,15 @@
 function [sens] = ft_datatype_sens(sens, varargin)
 
-% FT_DATATYPE_SENS describes the FieldTrip structure that represents an EEG, ECoG, or
-% MEG sensor array. This structure is commonly called "elec" for EEG, "grad" for MEG,
-% "opto" for NIRS, or general "sens" for either one.
+% FT_DATATYPE_SENS describes the FieldTrip structure that represents an MEG, EEG,
+% sEEG, ECoG, or NIRS sensor array. This structure is commonly called "grad" for MEG,
+% "elec" for EEG and intranial EEG, "opto" for NIRS, or in general "sens" if it could
+% be any one.
 %
 % For all sensor types a distinction should be made between the channel (i.e. the
 % output of the transducer that is A/D converted) and the sensor, which may have some
-% spatial extent. E.g. with EEG you can have a bipolar channel, where the position of
-% the channel can be represented as in between the position of the two electrodes.
+% spatial extent. For example in MEG gradiometers are comprised of multiple coils and
+% with EEG you can have a bipolar channel, where the position of the channel can be
+% represented as in between the position of the two electrodes.
 %
 % The structure for MEG gradiometers and/or magnetometers contains
 %    sens.label      = Mx1 cell-array with channel labels
@@ -18,9 +20,7 @@ function [sens] = ft_datatype_sens(sens, varargin)
 %    sens.tra        = MxN matrix to combine coils into channels
 %    sens.balance    = structure containing info about the balancing, See FT_APPLY_MONTAGE
 % and optionally
-%    sens.chanposold = Mx3 matrix with original channel positions (in case
-%                      sens.chanpos has been updated to contain NaNs, e.g.
-%                      after ft_componentanalysis)
+%    sens.chanposold = Mx3 matrix with original channel positions (in case sens.chanpos has been updated to contain NaNs, e.g. after FT_COMPONENTANALYSIS)
 %    sens.chanoriold = Mx3 matrix with original channel orientations
 %    sens.labelold   = Mx1 cell-array with original channel labels
 %
@@ -39,8 +39,7 @@ function [sens] = ft_datatype_sens(sens, varargin)
 %    sens.optotype      = Nx1 cell-array with information about the type of optode (receiver or transmitter)
 %    sens.optolabel     = Nx1 cell-array with optode labels
 %    sens.wavelength    = 1xK vector of all wavelengths that were used
-%    sens.laserstrength = 1xK vector of the strength of the emitted light of the lasers
-%    sens.transmits     = MxN matrix, specifies for each of the M channels at which wavelength each of the N optodes transmits (positive integer from 1 to K), or receives (negative ingeger from 1 to K), or does not contribute at all (zeros)
+%    sens.tra           = MxN matrix that specifies for each of the M channels which of the N optodes transmits at which wavelength (positive integer from 1 to K), or receives (negative ingeger from 1 to K)
 %
 % The following fields apply to MEG, EEG, sEEG and ECoG
 %    sens.chantype = Mx1 cell-array with the type of the channel, see FT_CHANTYPE
@@ -51,9 +50,12 @@ function [sens] = ft_datatype_sens(sens, varargin)
 %    sens.fid  = structure with fiducial information
 %
 % Historical fields:
-%    pnt, pos, ori, pnt1, pnt2, fiberpos, fibertype, fiberlabel, transceiver
+%    pnt, pos, ori, pnt1, pnt2, fiberpos, fibertype, fiberlabel, transceiver, transmits, laserstrength
 %
 % Revision history:
+% (2020/latest) Updated the specification of the NIRS sensor definition.
+%   Dropped the laserstrength and renamed transmits into tra for consistency.
+%
 % (2019/latest) Updated the specification of the NIRS sensor definition.
 %   Use "opto" instead of "fibers", see http://bit.ly/33WaqWU for details.
 %
@@ -141,7 +143,7 @@ if ~isempty(distance) && ~any(strcmp(distance, {'m' 'dm' 'cm' 'mm'}))
 end
 
 if strcmp(version, 'latest')
-  version = '2019';
+  version = '2020';
 end
 
 if isempty(sens)
@@ -151,17 +153,30 @@ end
 % this is needed further down
 nchan = length(sens.label);
 
-% there are many cases which deal with either eeg or meg
-ismeg = ft_senstype(sens, 'meg');
+% there are many cases which are MEG, EEG or NIRS specific
+ismeg  = ft_senstype(sens, 'meg');
+iseeg  = ft_senstype(sens, 'eeg');
+isnirs = ft_senstype(sens, 'nirs');
 
 switch version
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  case '2020'
+    % update it to the previous standard version
+    new_argin = ft_setopt(varargin, 'version', '2019');
+    sens      = ft_datatype_sens(sens, new_argin{:});
+    
+    if isnirs
+      sens = renamefields(sens, 'transmits', 'tra'); % this makes it more consistent with EEG and MEG
+      sens = removefields(sens, {'laserstrength'});
+    end
+    
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   case '2019'
     % update it to the previous standard version
     new_argin = ft_setopt(varargin, 'version', '2016');
     sens      = ft_datatype_sens(sens, new_argin{:});
     
-    if isfield(sens, 'fiberpos') || isfield(sens, 'optopos')
+    if isnirs
       % rename some NIRS field names
       sens = renamefields(sens, 'fiberpos', 'optopos');
       sens = renamefields(sens, 'fibertype', 'optotype');
@@ -172,7 +187,7 @@ switch version
       % especially the chanunit field needs some careful thought when converting between optical densities and chromophore concentrations.
       sens = removefields(sens, {'chantype', 'chanunit'});
     end
-
+    
     % ensure all positions are represented as 3D, not 2D
     fn = {'chanpos', 'optopos', 'elecpos', 'coilpos'};
     for i=1:numel(fn)
@@ -190,27 +205,27 @@ switch version
     
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   case '2016'
-
     % update it to the previous standard version
-    sens = ft_datatype_sens(sens, 'version', '2011v2');
-
+    new_argin = ft_setopt(varargin, 'version', '2011v2');
+    sens      = ft_datatype_sens(sens, new_argin{:});
+    
     % rename from org to old (reverse = false)
     sens = fixoldorg(sens, false);
-
+    
     % ensure that all numbers are represented in double precision
     % this only affects the top-level fields and does not recurse
     sens = ft_struct2double(sens, 1);
-
+    
     % in version 2011v2 this was optional, now it is required
     if ~isfield(sens, 'chantype') || all(strcmp(sens.chantype, 'unknown'))
       sens.chantype = ft_chantype(sens);
     end
-
+    
     % in version 2011v2 this was optional, now it is required
     if ~isfield(sens, 'chanunit') || all(strcmp(sens.chanunit, 'unknown'))
       sens.chanunit = ft_chanunit(sens);
     end
-
+    
     if ~isempty(distance)
       % update the units of distance, this also updates the tra matrix
       sens = ft_convert_units(sens, distance);
@@ -218,7 +233,7 @@ switch version
       % determine the default, this may be needed to set the scaling
       distance = sens.unit;
     end
-
+    
     if ~isempty(amplitude) && isfield(sens, 'tra')
       % update the tra matrix for the units of amplitude, this ensures that
       % the leadfield values remain consistent with the units
@@ -254,14 +269,14 @@ switch version
         amplitude = 'unknown';
       end
     end
-
+    
     % perform some sanity checks
     if ismeg
       sel_m  = ~cellfun(@isempty, regexp(sens.chanunit, '/m$'));
       sel_dm = ~cellfun(@isempty, regexp(sens.chanunit, '/dm$'));
       sel_cm = ~cellfun(@isempty, regexp(sens.chanunit, '/cm$'));
       sel_mm = ~cellfun(@isempty, regexp(sens.chanunit, '/mm$'));
-
+      
       if     strcmp(sens.unit, 'm') && (any(sel_dm) || any(sel_cm) || any(sel_mm))
         ft_error('inconsistent units in input gradiometer');
       elseif strcmp(sens.unit, 'dm') && (any(sel_m) || any(sel_cm) || any(sel_mm))
@@ -271,9 +286,9 @@ switch version
       elseif strcmp(sens.unit, 'mm') && (any(sel_m) || any(sel_dm) || any(sel_cm))
         ft_error('inconsistent units in input gradiometer');
       end
-
+      
       if ~strcmp(amplitude, 'unknown') && ~strcmp(distance, 'unknown')
-
+        
         % the default should be "amplitude/distance" for neuromag and "amplitude" for all others
         if isempty(scaling)
           if ft_senstype(sens, 'neuromag') && ~any(contains(sens.chanunit, '/'))
@@ -284,7 +299,7 @@ switch version
             scaling = 'amplitude';
           end
         end
-
+        
         % update the gradiometer scaling
         if strcmp(scaling, 'amplitude') && isfield(sens, 'tra')
           for i=1:nchan
@@ -308,7 +323,7 @@ switch version
               ft_warning('unexpected channel unit "%s" in channel %d', sens.chanunit{i}, i);
             end % if
           end % for nchan
-
+          
         elseif strcmp(scaling, 'amplitude/distance') && isfield(sens, 'tra')
           for i=1:nchan
             if strcmp(sens.chanunit{i}, amplitude)
@@ -330,10 +345,10 @@ switch version
               ft_warning('unexpected channel unit "%s" in channel %d', sens.chanunit{i}, i);
             end % if
           end % for nchan
-
+          
         end % if strcmp scaling
       end % if amplitude and scaling are not unknown
-
+      
     else
       sel_m  = ~cellfun(@isempty, regexp(sens.chanunit, '/m$'));
       sel_dm = ~cellfun(@isempty, regexp(sens.chanunit, '/dm$'));
@@ -342,26 +357,26 @@ switch version
       if any(sel_m | sel_dm | sel_cm | sel_mm)
         ft_error('scaling of amplitude/distance has not been considered yet for EEG');
       end
-
+      
     end % if iseeg or ismeg
-
+    
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   case '2011v2'
-
+    
     % rename from old to org (reverse = true)
     sens = fixoldorg(sens, true);
-
+    
     if ~isempty(amplitude) || ~isempty(distance) || ~isempty(scaling)
       ft_warning('amplitude, distance and scaling are not supported for version "%s"', version);
     end
-
+    
     % This speeds up subsequent calls to ft_senstype and channelposition.
     % However, if it is not more precise than MEG or EEG, don't keep it in
     % the output (see further down).
     if ~isfield(sens, 'type')
       sens.type = ft_senstype(sens);
     end
-
+    
     if isfield(sens, 'pnt')
       if ismeg
         % sensor description is a MEG sensor-array, containing oriented coils
@@ -372,7 +387,7 @@ switch version
         sens.elecpos = sens.pnt; sens = rmfield(sens, 'pnt');
       end
     end
-
+    
     if ~isfield(sens, 'chanpos')
       if ismeg
         % sensor description is a MEG sensor-array, containing oriented coils
@@ -401,7 +416,7 @@ switch version
         end
       end
     end
-
+    
     if ~isfield(sens, 'chantype') || all(strcmp(sens.chantype, 'unknown'))
       if ismeg
         sens.chantype = ft_chantype(sens);
@@ -409,12 +424,12 @@ switch version
         % for EEG it is not required
       end
     end
-
+    
     if ~isfield(sens, 'unit')
       % this should be done prior to calling ft_chanunit, since ft_chanunit uses this for planar neuromag channels
       sens = ft_determine_units(sens);
     end
-
+    
     if ~isfield(sens, 'chanunit') || all(strcmp(sens.chanunit, 'unknown'))
       if ismeg
         sens.chanunit = ft_chanunit(sens);
@@ -422,13 +437,13 @@ switch version
         % for EEG it is not required
       end
     end
-
+    
     if any(strcmp(sens.type, {'meg', 'eeg', 'magnetometer', 'electrode', 'unknown'}))
       % this is not sufficiently informative, so better remove it
       % see also http://bugzilla.fieldtriptoolbox.org/show_bug.cgi?id=1806
       sens = rmfield(sens, 'type');
     end
-
+    
     if size(sens.chanpos,1)~=length(sens.label) || ...
         isfield(sens, 'tra') && size(sens.tra,1)~=length(sens.label) || ...
         isfield(sens, 'tra') && isfield(sens, 'elecpos') && size(sens.tra,2)~=size(sens.elecpos,1) || ...
@@ -438,13 +453,13 @@ switch version
         isfield(sens, 'chanori') && size(sens.chanori,1)~=length(sens.label)
       ft_error('inconsistent number of channels in sensor description');
     end
-
+    
     if ismeg
       % ensure that the magnetometer/gradiometer balancing is specified
       if ~isfield(sens, 'balance') || ~isfield(sens.balance, 'current')
         sens.balance.current = 'none';
       end
-
+      
       % try to add the chantype and chanunit to the CTF G1BR montage
       if isfield(sens, 'balance') && isfield(sens.balance, 'G1BR') && ~isfield(sens.balance.G1BR, 'chantype')
         sens.balance.G1BR.chantypeorg = repmat({'unknown'}, size(sens.balance.G1BR.labelorg));
@@ -459,7 +474,7 @@ switch version
         sens.balance.G1BR.chantypenew(sel1) = sens.chantype(sel2);
         sens.balance.G1BR.chanunitnew(sel1) = sens.chanunit(sel2);
       end
-
+      
       % idem for G2BR
       if isfield(sens, 'balance') && isfield(sens.balance, 'G2BR') && ~isfield(sens.balance.G2BR, 'chantype')
         sens.balance.G2BR.chantypeorg = repmat({'unknown'}, size(sens.balance.G2BR.labelorg));
@@ -474,7 +489,7 @@ switch version
         sens.balance.G2BR.chantypenew(sel1) = sens.chantype(sel2);
         sens.balance.G2BR.chanunitnew(sel1) = sens.chanunit(sel2);
       end
-
+      
       % idem for G3BR
       if isfield(sens, 'balance') && isfield(sens.balance, 'G3BR') && ~isfield(sens.balance.G3BR, 'chantype')
         sens.balance.G3BR.chantypeorg = repmat({'unknown'}, size(sens.balance.G3BR.labelorg));
@@ -490,11 +505,11 @@ switch version
         sens.balance.G3BR.chanunitnew(sel1) = sens.chanunit(sel2);
       end
     end
-
+    
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   otherwise
     ft_error('converting to version %s is not supported', version);
-
+    
 end % switch
 
 % this makes the display with the "disp" command look better

--- a/forward/private/ft_datatype_sens.m
+++ b/forward/private/ft_datatype_sens.m
@@ -38,10 +38,9 @@ function [sens] = ft_datatype_sens(sens, varargin)
 %    sens.optopos       = Nx3 matrix with the position of individual optodes
 %    sens.optotype      = Nx1 cell-array with information about the type of optode (receiver or transmitter)
 %    sens.optolabel     = Nx1 cell-array with optode labels
-%    sens.transmits     = NxK matrix, boolean, where N is the number of optodes and K the number of wavelengths. Specifies what optode is transmitting at what wavelength (or nothing at all, which indicates that it is a receiver).
 %    sens.wavelength    = 1xK vector of all wavelengths that were used
 %    sens.laserstrength = 1xK vector of the strength of the emitted light of the lasers
-%    sens.tra           = MxN matrix, boolean, contains information about how receiver and transmitter are combined to form channels
+%    sens.transmits     = MxN matrix, specifies for each of the M channels at which wavelength each of the N optodes transmits (positive integer from 1 to K), or receives (negative ingeger from 1 to K), or does not contribute at all (zeros)
 %
 % The following fields apply to MEG, EEG, sEEG and ECoG
 %    sens.chantype = Mx1 cell-array with the type of the channel, see FT_CHANTYPE
@@ -369,7 +368,7 @@ switch version
         sens.coilpos = sens.pnt; sens = rmfield(sens, 'pnt');
         sens.coilori = sens.ori; sens = rmfield(sens, 'ori');
       else
-        % sensor description is something else, EEG/ECoG etc
+        % sensor description is something else, EEG/ECoG/sEEG, etc
         sens.elecpos = sens.pnt; sens = rmfield(sens, 'pnt');
       end
     end

--- a/ft_artifact_zvalue.m
+++ b/ft_artifact_zvalue.m
@@ -147,8 +147,6 @@ end
 
 % set default rejection parameters
 cfg.feedback                     = ft_getopt(cfg,                  'feedback',     'text');
-cfg.headerformat                 = ft_getopt(cfg,                  'headerformat', []);
-cfg.dataformat                   = ft_getopt(cfg,                  'dataformat',   []);
 cfg.memory                       = ft_getopt(cfg,                  'memory',       'high');
 cfg.artfctdef                    = ft_getopt(cfg,                  'artfctdef',    []);
 cfg.artfctdef.zvalue             = ft_getopt(cfg.artfctdef,        'zvalue',       []);

--- a/ft_interpolatenan.m
+++ b/ft_interpolatenan.m
@@ -9,7 +9,7 @@ function [dataout] = ft_interpolatenan(cfg, datain)
 % where cfg is a configuration structure and the input data is obtained from FT_PREPROCESSING.
 %
 % The configuration should contain
-%   cfg.method      = string, interpolation method, see HELP INTERP1 (default = 'linear')
+%   cfg.method      = string, interpolation method, see INTERP1 (default = 'linear')
 %   cfg.prewindow   = value, length of data prior to interpolation window, in seconds (default = 1)
 %   cfg.postwindow  = value, length of data after interpolation window, in seconds (default = 1)
 %   cfg.feedback    = string, 'no', 'text', 'textbar', 'gui' (default = 'text')

--- a/inverse/private/ft_senstype.m
+++ b/inverse/private/ft_senstype.m
@@ -152,11 +152,12 @@ isdata   = isa(input, 'struct')  && (isfield(input, 'hdr') || isfield(input, 'ti
 isheader = isa(input, 'struct')  && isfield(input, 'label') && isfield(input, 'Fs');
 isgrad   = isa(input, 'struct')  && isfield(input, 'label') && isfield(input, 'pnt')  &&  isfield(input, 'ori'); % old style
 iselec   = isa(input, 'struct')  && isfield(input, 'label') && isfield(input, 'pnt')  && ~isfield(input, 'ori'); % old style
-isgrad   = (isa(input, 'struct') && isfield(input, 'label') && isfield(input, 'coilpos')) || isgrad;             % new style
-iselec   = (isa(input, 'struct') && isfield(input, 'label') && isfield(input, 'elecpos')) || iselec;             % new style
-isnirs   = isa(input, 'struct')  && isfield(input, 'label') && isfield(input, 'optopos');
+isnirs   = isa(input, 'struct')  && isfield(input, 'label') && isfield(input, 'fiberpos');                       % old style
+isgrad   = (isa(input, 'struct') && isfield(input, 'label') && isfield(input, 'coilpos'))  || isgrad;            % new style
+iselec   = (isa(input, 'struct') && isfield(input, 'label') && isfield(input, 'elecpos'))  || iselec;            % new style
+isnirs   = (isa(input, 'struct')  && isfield(input, 'label') && isfield(input, 'optopos')) || isnirs;            % new style
 islabel  = isa(input, 'cell')    && ~isempty(input) && isa(input{1}, 'char');
-haslabel    = isa(input, 'struct')  && isfield(input, 'label');
+haslabel = isa(input, 'struct')  && isfield(input, 'label');
 
 if ~(isdata || isheader || isgrad || iselec || isnirs || islabel || haslabel) && isfield(input, 'hdr')
   input    = input.hdr;

--- a/plotting/private/channelposition.m
+++ b/plotting/private/channelposition.m
@@ -1,11 +1,11 @@
 function [pnt, ori, lab] = channelposition(sens)
 
 % CHANNELPOSITION computes the channel positions and orientations from the
-% coils or electrodes
+% MEG coils, EEG electrodes or NIRS optodes
 %
 % Use as
 %   [pos, ori, lab] = channelposition(sens)
-% where sens is an electrode,  gradiometer or optode array.
+% where sens is an gradiometer, electrode, or optode array.
 %
 % See also FT_DATATYPE_SENS
 
@@ -42,6 +42,12 @@ end
 if isfield(sens, 'pnt')
   sens.coilpos = sens.pnt;
   sens = rmfield(sens, 'pnt');
+end
+
+if isfield(sens, 'transmits') && ~isfield(sens, 'tra')
+  % this applies to optode definitions, the transmits matrix also codes for the wavelengths
+  % make a tra matrix where each optode weights in with the same amount
+  sens.tra = (sens.transmits~=0);
 end
 
 % treat all sensor arrays similar, i.e. as gradiometer systems

--- a/plotting/private/channelposition.m
+++ b/plotting/private/channelposition.m
@@ -44,12 +44,6 @@ if isfield(sens, 'pnt')
   sens = rmfield(sens, 'pnt');
 end
 
-if isfield(sens, 'transmits') && ~isfield(sens, 'tra')
-  % this applies to optode definitions, the transmits matrix also codes for the wavelengths
-  % make a tra matrix where each optode weights in with the same amount
-  sens.tra = (sens.transmits~=0);
-end
-
 % treat all sensor arrays similar, i.e. as gradiometer systems
 if     ~isfield(sens, 'coilori') && isfield(sens, 'coilpos')
   sens.coilori = nan(size(sens.coilpos));

--- a/plotting/private/ft_datatype_sens.m
+++ b/plotting/private/ft_datatype_sens.m
@@ -1,13 +1,15 @@
 function [sens] = ft_datatype_sens(sens, varargin)
 
-% FT_DATATYPE_SENS describes the FieldTrip structure that represents an EEG, ECoG, or
-% MEG sensor array. This structure is commonly called "elec" for EEG, "grad" for MEG,
-% "opto" for NIRS, or general "sens" for either one.
+% FT_DATATYPE_SENS describes the FieldTrip structure that represents an MEG, EEG,
+% sEEG, ECoG, or NIRS sensor array. This structure is commonly called "grad" for MEG,
+% "elec" for EEG and intranial EEG, "opto" for NIRS, or in general "sens" if it could
+% be any one.
 %
 % For all sensor types a distinction should be made between the channel (i.e. the
 % output of the transducer that is A/D converted) and the sensor, which may have some
-% spatial extent. E.g. with EEG you can have a bipolar channel, where the position of
-% the channel can be represented as in between the position of the two electrodes.
+% spatial extent. For example in MEG gradiometers are comprised of multiple coils and
+% with EEG you can have a bipolar channel, where the position of the channel can be
+% represented as in between the position of the two electrodes.
 %
 % The structure for MEG gradiometers and/or magnetometers contains
 %    sens.label      = Mx1 cell-array with channel labels
@@ -18,9 +20,7 @@ function [sens] = ft_datatype_sens(sens, varargin)
 %    sens.tra        = MxN matrix to combine coils into channels
 %    sens.balance    = structure containing info about the balancing, See FT_APPLY_MONTAGE
 % and optionally
-%    sens.chanposold = Mx3 matrix with original channel positions (in case
-%                      sens.chanpos has been updated to contain NaNs, e.g.
-%                      after ft_componentanalysis)
+%    sens.chanposold = Mx3 matrix with original channel positions (in case sens.chanpos has been updated to contain NaNs, e.g. after FT_COMPONENTANALYSIS)
 %    sens.chanoriold = Mx3 matrix with original channel orientations
 %    sens.labelold   = Mx1 cell-array with original channel labels
 %
@@ -39,8 +39,7 @@ function [sens] = ft_datatype_sens(sens, varargin)
 %    sens.optotype      = Nx1 cell-array with information about the type of optode (receiver or transmitter)
 %    sens.optolabel     = Nx1 cell-array with optode labels
 %    sens.wavelength    = 1xK vector of all wavelengths that were used
-%    sens.laserstrength = 1xK vector of the strength of the emitted light of the lasers
-%    sens.transmits     = MxN matrix, specifies for each of the M channels at which wavelength each of the N optodes transmits (positive integer from 1 to K), or receives (negative ingeger from 1 to K), or does not contribute at all (zeros)
+%    sens.tra           = MxN matrix that specifies for each of the M channels which of the N optodes transmits at which wavelength (positive integer from 1 to K), or receives (negative ingeger from 1 to K)
 %
 % The following fields apply to MEG, EEG, sEEG and ECoG
 %    sens.chantype = Mx1 cell-array with the type of the channel, see FT_CHANTYPE
@@ -51,9 +50,12 @@ function [sens] = ft_datatype_sens(sens, varargin)
 %    sens.fid  = structure with fiducial information
 %
 % Historical fields:
-%    pnt, pos, ori, pnt1, pnt2, fiberpos, fibertype, fiberlabel, transceiver
+%    pnt, pos, ori, pnt1, pnt2, fiberpos, fibertype, fiberlabel, transceiver, transmits, laserstrength
 %
 % Revision history:
+% (2020/latest) Updated the specification of the NIRS sensor definition.
+%   Dropped the laserstrength and renamed transmits into tra for consistency.
+%
 % (2019/latest) Updated the specification of the NIRS sensor definition.
 %   Use "opto" instead of "fibers", see http://bit.ly/33WaqWU for details.
 %
@@ -141,7 +143,7 @@ if ~isempty(distance) && ~any(strcmp(distance, {'m' 'dm' 'cm' 'mm'}))
 end
 
 if strcmp(version, 'latest')
-  version = '2019';
+  version = '2020';
 end
 
 if isempty(sens)
@@ -151,17 +153,30 @@ end
 % this is needed further down
 nchan = length(sens.label);
 
-% there are many cases which deal with either eeg or meg
-ismeg = ft_senstype(sens, 'meg');
+% there are many cases which are MEG, EEG or NIRS specific
+ismeg  = ft_senstype(sens, 'meg');
+iseeg  = ft_senstype(sens, 'eeg');
+isnirs = ft_senstype(sens, 'nirs');
 
 switch version
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  case '2020'
+    % update it to the previous standard version
+    new_argin = ft_setopt(varargin, 'version', '2019');
+    sens      = ft_datatype_sens(sens, new_argin{:});
+    
+    if isnirs
+      sens = renamefields(sens, 'transmits', 'tra'); % this makes it more consistent with EEG and MEG
+      sens = removefields(sens, {'laserstrength'});
+    end
+    
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   case '2019'
     % update it to the previous standard version
     new_argin = ft_setopt(varargin, 'version', '2016');
     sens      = ft_datatype_sens(sens, new_argin{:});
     
-    if isfield(sens, 'fiberpos') || isfield(sens, 'optopos')
+    if isnirs
       % rename some NIRS field names
       sens = renamefields(sens, 'fiberpos', 'optopos');
       sens = renamefields(sens, 'fibertype', 'optotype');
@@ -172,7 +187,7 @@ switch version
       % especially the chanunit field needs some careful thought when converting between optical densities and chromophore concentrations.
       sens = removefields(sens, {'chantype', 'chanunit'});
     end
-
+    
     % ensure all positions are represented as 3D, not 2D
     fn = {'chanpos', 'optopos', 'elecpos', 'coilpos'};
     for i=1:numel(fn)
@@ -190,27 +205,27 @@ switch version
     
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   case '2016'
-
     % update it to the previous standard version
-    sens = ft_datatype_sens(sens, 'version', '2011v2');
-
+    new_argin = ft_setopt(varargin, 'version', '2011v2');
+    sens      = ft_datatype_sens(sens, new_argin{:});
+    
     % rename from org to old (reverse = false)
     sens = fixoldorg(sens, false);
-
+    
     % ensure that all numbers are represented in double precision
     % this only affects the top-level fields and does not recurse
     sens = ft_struct2double(sens, 1);
-
+    
     % in version 2011v2 this was optional, now it is required
     if ~isfield(sens, 'chantype') || all(strcmp(sens.chantype, 'unknown'))
       sens.chantype = ft_chantype(sens);
     end
-
+    
     % in version 2011v2 this was optional, now it is required
     if ~isfield(sens, 'chanunit') || all(strcmp(sens.chanunit, 'unknown'))
       sens.chanunit = ft_chanunit(sens);
     end
-
+    
     if ~isempty(distance)
       % update the units of distance, this also updates the tra matrix
       sens = ft_convert_units(sens, distance);
@@ -218,7 +233,7 @@ switch version
       % determine the default, this may be needed to set the scaling
       distance = sens.unit;
     end
-
+    
     if ~isempty(amplitude) && isfield(sens, 'tra')
       % update the tra matrix for the units of amplitude, this ensures that
       % the leadfield values remain consistent with the units
@@ -254,14 +269,14 @@ switch version
         amplitude = 'unknown';
       end
     end
-
+    
     % perform some sanity checks
     if ismeg
       sel_m  = ~cellfun(@isempty, regexp(sens.chanunit, '/m$'));
       sel_dm = ~cellfun(@isempty, regexp(sens.chanunit, '/dm$'));
       sel_cm = ~cellfun(@isempty, regexp(sens.chanunit, '/cm$'));
       sel_mm = ~cellfun(@isempty, regexp(sens.chanunit, '/mm$'));
-
+      
       if     strcmp(sens.unit, 'm') && (any(sel_dm) || any(sel_cm) || any(sel_mm))
         ft_error('inconsistent units in input gradiometer');
       elseif strcmp(sens.unit, 'dm') && (any(sel_m) || any(sel_cm) || any(sel_mm))
@@ -271,9 +286,9 @@ switch version
       elseif strcmp(sens.unit, 'mm') && (any(sel_m) || any(sel_dm) || any(sel_cm))
         ft_error('inconsistent units in input gradiometer');
       end
-
+      
       if ~strcmp(amplitude, 'unknown') && ~strcmp(distance, 'unknown')
-
+        
         % the default should be "amplitude/distance" for neuromag and "amplitude" for all others
         if isempty(scaling)
           if ft_senstype(sens, 'neuromag') && ~any(contains(sens.chanunit, '/'))
@@ -284,7 +299,7 @@ switch version
             scaling = 'amplitude';
           end
         end
-
+        
         % update the gradiometer scaling
         if strcmp(scaling, 'amplitude') && isfield(sens, 'tra')
           for i=1:nchan
@@ -308,7 +323,7 @@ switch version
               ft_warning('unexpected channel unit "%s" in channel %d', sens.chanunit{i}, i);
             end % if
           end % for nchan
-
+          
         elseif strcmp(scaling, 'amplitude/distance') && isfield(sens, 'tra')
           for i=1:nchan
             if strcmp(sens.chanunit{i}, amplitude)
@@ -330,10 +345,10 @@ switch version
               ft_warning('unexpected channel unit "%s" in channel %d', sens.chanunit{i}, i);
             end % if
           end % for nchan
-
+          
         end % if strcmp scaling
       end % if amplitude and scaling are not unknown
-
+      
     else
       sel_m  = ~cellfun(@isempty, regexp(sens.chanunit, '/m$'));
       sel_dm = ~cellfun(@isempty, regexp(sens.chanunit, '/dm$'));
@@ -342,26 +357,26 @@ switch version
       if any(sel_m | sel_dm | sel_cm | sel_mm)
         ft_error('scaling of amplitude/distance has not been considered yet for EEG');
       end
-
+      
     end % if iseeg or ismeg
-
+    
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   case '2011v2'
-
+    
     % rename from old to org (reverse = true)
     sens = fixoldorg(sens, true);
-
+    
     if ~isempty(amplitude) || ~isempty(distance) || ~isempty(scaling)
       ft_warning('amplitude, distance and scaling are not supported for version "%s"', version);
     end
-
+    
     % This speeds up subsequent calls to ft_senstype and channelposition.
     % However, if it is not more precise than MEG or EEG, don't keep it in
     % the output (see further down).
     if ~isfield(sens, 'type')
       sens.type = ft_senstype(sens);
     end
-
+    
     if isfield(sens, 'pnt')
       if ismeg
         % sensor description is a MEG sensor-array, containing oriented coils
@@ -372,7 +387,7 @@ switch version
         sens.elecpos = sens.pnt; sens = rmfield(sens, 'pnt');
       end
     end
-
+    
     if ~isfield(sens, 'chanpos')
       if ismeg
         % sensor description is a MEG sensor-array, containing oriented coils
@@ -401,7 +416,7 @@ switch version
         end
       end
     end
-
+    
     if ~isfield(sens, 'chantype') || all(strcmp(sens.chantype, 'unknown'))
       if ismeg
         sens.chantype = ft_chantype(sens);
@@ -409,12 +424,12 @@ switch version
         % for EEG it is not required
       end
     end
-
+    
     if ~isfield(sens, 'unit')
       % this should be done prior to calling ft_chanunit, since ft_chanunit uses this for planar neuromag channels
       sens = ft_determine_units(sens);
     end
-
+    
     if ~isfield(sens, 'chanunit') || all(strcmp(sens.chanunit, 'unknown'))
       if ismeg
         sens.chanunit = ft_chanunit(sens);
@@ -422,13 +437,13 @@ switch version
         % for EEG it is not required
       end
     end
-
+    
     if any(strcmp(sens.type, {'meg', 'eeg', 'magnetometer', 'electrode', 'unknown'}))
       % this is not sufficiently informative, so better remove it
       % see also http://bugzilla.fieldtriptoolbox.org/show_bug.cgi?id=1806
       sens = rmfield(sens, 'type');
     end
-
+    
     if size(sens.chanpos,1)~=length(sens.label) || ...
         isfield(sens, 'tra') && size(sens.tra,1)~=length(sens.label) || ...
         isfield(sens, 'tra') && isfield(sens, 'elecpos') && size(sens.tra,2)~=size(sens.elecpos,1) || ...
@@ -438,13 +453,13 @@ switch version
         isfield(sens, 'chanori') && size(sens.chanori,1)~=length(sens.label)
       ft_error('inconsistent number of channels in sensor description');
     end
-
+    
     if ismeg
       % ensure that the magnetometer/gradiometer balancing is specified
       if ~isfield(sens, 'balance') || ~isfield(sens.balance, 'current')
         sens.balance.current = 'none';
       end
-
+      
       % try to add the chantype and chanunit to the CTF G1BR montage
       if isfield(sens, 'balance') && isfield(sens.balance, 'G1BR') && ~isfield(sens.balance.G1BR, 'chantype')
         sens.balance.G1BR.chantypeorg = repmat({'unknown'}, size(sens.balance.G1BR.labelorg));
@@ -459,7 +474,7 @@ switch version
         sens.balance.G1BR.chantypenew(sel1) = sens.chantype(sel2);
         sens.balance.G1BR.chanunitnew(sel1) = sens.chanunit(sel2);
       end
-
+      
       % idem for G2BR
       if isfield(sens, 'balance') && isfield(sens.balance, 'G2BR') && ~isfield(sens.balance.G2BR, 'chantype')
         sens.balance.G2BR.chantypeorg = repmat({'unknown'}, size(sens.balance.G2BR.labelorg));
@@ -474,7 +489,7 @@ switch version
         sens.balance.G2BR.chantypenew(sel1) = sens.chantype(sel2);
         sens.balance.G2BR.chanunitnew(sel1) = sens.chanunit(sel2);
       end
-
+      
       % idem for G3BR
       if isfield(sens, 'balance') && isfield(sens.balance, 'G3BR') && ~isfield(sens.balance.G3BR, 'chantype')
         sens.balance.G3BR.chantypeorg = repmat({'unknown'}, size(sens.balance.G3BR.labelorg));
@@ -490,11 +505,11 @@ switch version
         sens.balance.G3BR.chanunitnew(sel1) = sens.chanunit(sel2);
       end
     end
-
+    
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   otherwise
     ft_error('converting to version %s is not supported', version);
-
+    
 end % switch
 
 % this makes the display with the "disp" command look better

--- a/plotting/private/ft_datatype_sens.m
+++ b/plotting/private/ft_datatype_sens.m
@@ -38,10 +38,9 @@ function [sens] = ft_datatype_sens(sens, varargin)
 %    sens.optopos       = Nx3 matrix with the position of individual optodes
 %    sens.optotype      = Nx1 cell-array with information about the type of optode (receiver or transmitter)
 %    sens.optolabel     = Nx1 cell-array with optode labels
-%    sens.transmits     = NxK matrix, boolean, where N is the number of optodes and K the number of wavelengths. Specifies what optode is transmitting at what wavelength (or nothing at all, which indicates that it is a receiver).
 %    sens.wavelength    = 1xK vector of all wavelengths that were used
 %    sens.laserstrength = 1xK vector of the strength of the emitted light of the lasers
-%    sens.tra           = MxN matrix, boolean, contains information about how receiver and transmitter are combined to form channels
+%    sens.transmits     = MxN matrix, specifies for each of the M channels at which wavelength each of the N optodes transmits (positive integer from 1 to K), or receives (negative ingeger from 1 to K), or does not contribute at all (zeros)
 %
 % The following fields apply to MEG, EEG, sEEG and ECoG
 %    sens.chantype = Mx1 cell-array with the type of the channel, see FT_CHANTYPE
@@ -369,7 +368,7 @@ switch version
         sens.coilpos = sens.pnt; sens = rmfield(sens, 'pnt');
         sens.coilori = sens.ori; sens = rmfield(sens, 'ori');
       else
-        % sensor description is something else, EEG/ECoG etc
+        % sensor description is something else, EEG/ECoG/sEEG, etc
         sens.elecpos = sens.pnt; sens = rmfield(sens, 'pnt');
       end
     end

--- a/plotting/private/ft_senstype.m
+++ b/plotting/private/ft_senstype.m
@@ -152,11 +152,12 @@ isdata   = isa(input, 'struct')  && (isfield(input, 'hdr') || isfield(input, 'ti
 isheader = isa(input, 'struct')  && isfield(input, 'label') && isfield(input, 'Fs');
 isgrad   = isa(input, 'struct')  && isfield(input, 'label') && isfield(input, 'pnt')  &&  isfield(input, 'ori'); % old style
 iselec   = isa(input, 'struct')  && isfield(input, 'label') && isfield(input, 'pnt')  && ~isfield(input, 'ori'); % old style
-isgrad   = (isa(input, 'struct') && isfield(input, 'label') && isfield(input, 'coilpos')) || isgrad;             % new style
-iselec   = (isa(input, 'struct') && isfield(input, 'label') && isfield(input, 'elecpos')) || iselec;             % new style
-isnirs   = isa(input, 'struct')  && isfield(input, 'label') && isfield(input, 'optopos');
+isnirs   = isa(input, 'struct')  && isfield(input, 'label') && isfield(input, 'fiberpos');                       % old style
+isgrad   = (isa(input, 'struct') && isfield(input, 'label') && isfield(input, 'coilpos'))  || isgrad;            % new style
+iselec   = (isa(input, 'struct') && isfield(input, 'label') && isfield(input, 'elecpos'))  || iselec;            % new style
+isnirs   = (isa(input, 'struct')  && isfield(input, 'label') && isfield(input, 'optopos')) || isnirs;            % new style
 islabel  = isa(input, 'cell')    && ~isempty(input) && isa(input{1}, 'char');
-haslabel    = isa(input, 'struct')  && isfield(input, 'label');
+haslabel = isa(input, 'struct')  && isfield(input, 'label');
 
 if ~(isdata || isheader || isgrad || iselec || isnirs || islabel || haslabel) && isfield(input, 'hdr')
   input    = input.hdr;

--- a/private/channelposition.m
+++ b/private/channelposition.m
@@ -1,11 +1,11 @@
 function [pnt, ori, lab] = channelposition(sens)
 
 % CHANNELPOSITION computes the channel positions and orientations from the
-% coils or electrodes
+% MEG coils, EEG electrodes or NIRS optodes
 %
 % Use as
 %   [pos, ori, lab] = channelposition(sens)
-% where sens is an electrode,  gradiometer or optode array.
+% where sens is an gradiometer, electrode, or optode array.
 %
 % See also FT_DATATYPE_SENS
 
@@ -42,6 +42,12 @@ end
 if isfield(sens, 'pnt')
   sens.coilpos = sens.pnt;
   sens = rmfield(sens, 'pnt');
+end
+
+if isfield(sens, 'transmits') && ~isfield(sens, 'tra')
+  % this applies to optode definitions, the transmits matrix also codes for the wavelengths
+  % make a tra matrix where each optode weights in with the same amount
+  sens.tra = (sens.transmits~=0);
 end
 
 % treat all sensor arrays similar, i.e. as gradiometer systems

--- a/private/channelposition.m
+++ b/private/channelposition.m
@@ -44,12 +44,6 @@ if isfield(sens, 'pnt')
   sens = rmfield(sens, 'pnt');
 end
 
-if isfield(sens, 'transmits') && ~isfield(sens, 'tra')
-  % this applies to optode definitions, the transmits matrix also codes for the wavelengths
-  % make a tra matrix where each optode weights in with the same amount
-  sens.tra = (sens.transmits~=0);
-end
-
 % treat all sensor arrays similar, i.e. as gradiometer systems
 if     ~isfield(sens, 'coilori') && isfield(sens, 'coilpos')
   sens.coilori = nan(size(sens.coilpos));

--- a/private/ft_fetch_sens.m
+++ b/private/ft_fetch_sens.m
@@ -164,17 +164,17 @@ elseif hasoptofile
   display('reading optodes from file ''%s''\n', cfg.opto);
   sens = ft_read_sens(cfg.opto, 'senstype', 'nirs');
   % only keep known fields in case of NIRS optodes
-  sens = keepfields(sens, {'optopos', 'optotype', 'chanpos', 'unit', 'coordsys', 'label', 'transceiver', 'wavelength', 'transmits', 'laserstrength'});
+  sens = keepfields(sens, {'chanpos', 'label', 'optopos', 'optotype', 'optolabel', 'wavelength', 'tra', 'unit', 'coordsys'});
 elseif hascfgopto
   display('using optodes specified in the configuration\n');
   sens = cfg.opto;
   % only keep known fields in case of NIRS optodes
-  sens = keepfields(sens, {'optopos', 'optotype', 'chanpos', 'unit', 'coordsys', 'label', 'transceiver', 'wavelength', 'transmits', 'laserstrength'});
+  sens = keepfields(sens, {'chanpos', 'label', 'optopos', 'optotype', 'optolabel', 'wavelength', 'tra', 'unit', 'coordsys'});
 elseif hasdataopto
   display('using optodes specified in the data\n');
   sens = data.opto;
   % only keep known fields in case of NIRS optodes
-  sens = keepfields(sens, {'optopos', 'optotype', 'chanpos', 'unit', 'coordsys', 'label', 'transceiver', 'wavelength', 'transmits', 'laserstrength'});
+  sens = keepfields(sens, {'chanpos', 'label', 'optopos', 'optotype', 'optolabel', 'wavelength', 'tra', 'unit', 'coordsys'});
 
 elseif haslayout
   display('Using the 2-D layout to determine the sensor position\n');

--- a/test/private/ft_fetch_sens.m
+++ b/test/private/ft_fetch_sens.m
@@ -164,17 +164,17 @@ elseif hasoptofile
   display('reading optodes from file ''%s''\n', cfg.opto);
   sens = ft_read_sens(cfg.opto, 'senstype', 'nirs');
   % only keep known fields in case of NIRS optodes
-  sens = keepfields(sens, {'optopos', 'optotype', 'chanpos', 'unit', 'coordsys', 'label', 'transceiver', 'wavelength', 'transmits', 'laserstrength'});
+  sens = keepfields(sens, {'chanpos', 'label', 'optopos', 'optotype', 'optolabel', 'wavelength', 'tra', 'unit', 'coordsys'});
 elseif hascfgopto
   display('using optodes specified in the configuration\n');
   sens = cfg.opto;
   % only keep known fields in case of NIRS optodes
-  sens = keepfields(sens, {'optopos', 'optotype', 'chanpos', 'unit', 'coordsys', 'label', 'transceiver', 'wavelength', 'transmits', 'laserstrength'});
+  sens = keepfields(sens, {'chanpos', 'label', 'optopos', 'optotype', 'optolabel', 'wavelength', 'tra', 'unit', 'coordsys'});
 elseif hasdataopto
   display('using optodes specified in the data\n');
   sens = data.opto;
   % only keep known fields in case of NIRS optodes
-  sens = keepfields(sens, {'optopos', 'optotype', 'chanpos', 'unit', 'coordsys', 'label', 'transceiver', 'wavelength', 'transmits', 'laserstrength'});
+  sens = keepfields(sens, {'chanpos', 'label', 'optopos', 'optotype', 'optolabel', 'wavelength', 'tra', 'unit', 'coordsys'});
 
 elseif haslayout
   display('Using the 2-D layout to determine the sensor position\n');

--- a/test/private/ft_fetch_sens.m
+++ b/test/private/ft_fetch_sens.m
@@ -1,6 +1,6 @@
 function [sens] = ft_fetch_sens(cfg, data)
 
-% FT_FETCH_SENS mimics the behaviour of FT_READ_SENS, but for a FieldTrip
+% FT_FETCH_SENS mimics the behavior of FT_READ_SENS, but for a FieldTrip
 % data structure or a FieldTrip configuration instead of a file on disk.
 %
 % Use as

--- a/utilities/ft_datatype_sens.m
+++ b/utilities/ft_datatype_sens.m
@@ -1,13 +1,15 @@
 function [sens] = ft_datatype_sens(sens, varargin)
 
-% FT_DATATYPE_SENS describes the FieldTrip structure that represents an EEG, ECoG, or
-% MEG sensor array. This structure is commonly called "elec" for EEG, "grad" for MEG,
-% "opto" for NIRS, or general "sens" for either one.
+% FT_DATATYPE_SENS describes the FieldTrip structure that represents an MEG, EEG,
+% sEEG, ECoG, or NIRS sensor array. This structure is commonly called "grad" for MEG,
+% "elec" for EEG and intranial EEG, "opto" for NIRS, or in general "sens" if it could
+% be any one.
 %
 % For all sensor types a distinction should be made between the channel (i.e. the
 % output of the transducer that is A/D converted) and the sensor, which may have some
-% spatial extent. E.g. with EEG you can have a bipolar channel, where the position of
-% the channel can be represented as in between the position of the two electrodes.
+% spatial extent. For example in MEG gradiometers are comprised of multiple coils and
+% with EEG you can have a bipolar channel, where the position of the channel can be
+% represented as in between the position of the two electrodes.
 %
 % The structure for MEG gradiometers and/or magnetometers contains
 %    sens.label      = Mx1 cell-array with channel labels
@@ -18,9 +20,7 @@ function [sens] = ft_datatype_sens(sens, varargin)
 %    sens.tra        = MxN matrix to combine coils into channels
 %    sens.balance    = structure containing info about the balancing, See FT_APPLY_MONTAGE
 % and optionally
-%    sens.chanposold = Mx3 matrix with original channel positions (in case
-%                      sens.chanpos has been updated to contain NaNs, e.g.
-%                      after ft_componentanalysis)
+%    sens.chanposold = Mx3 matrix with original channel positions (in case sens.chanpos has been updated to contain NaNs, e.g. after FT_COMPONENTANALYSIS)
 %    sens.chanoriold = Mx3 matrix with original channel orientations
 %    sens.labelold   = Mx1 cell-array with original channel labels
 %
@@ -39,8 +39,7 @@ function [sens] = ft_datatype_sens(sens, varargin)
 %    sens.optotype      = Nx1 cell-array with information about the type of optode (receiver or transmitter)
 %    sens.optolabel     = Nx1 cell-array with optode labels
 %    sens.wavelength    = 1xK vector of all wavelengths that were used
-%    sens.laserstrength = 1xK vector of the strength of the emitted light of the lasers
-%    sens.transmits     = MxN matrix, specifies for each of the M channels at which wavelength each of the N optodes transmits (positive integer from 1 to K), or receives (negative ingeger from 1 to K), or does not contribute at all (zeros)
+%    sens.tra           = MxN matrix that specifies for each of the M channels which of the N optodes transmits at which wavelength (positive integer from 1 to K), or receives (negative ingeger from 1 to K)
 %
 % The following fields apply to MEG, EEG, sEEG and ECoG
 %    sens.chantype = Mx1 cell-array with the type of the channel, see FT_CHANTYPE
@@ -51,9 +50,12 @@ function [sens] = ft_datatype_sens(sens, varargin)
 %    sens.fid  = structure with fiducial information
 %
 % Historical fields:
-%    pnt, pos, ori, pnt1, pnt2, fiberpos, fibertype, fiberlabel, transceiver
+%    pnt, pos, ori, pnt1, pnt2, fiberpos, fibertype, fiberlabel, transceiver, transmits, laserstrength
 %
 % Revision history:
+% (2020/latest) Updated the specification of the NIRS sensor definition.
+%   Dropped the laserstrength and renamed transmits into tra for consistency.
+%
 % (2019/latest) Updated the specification of the NIRS sensor definition.
 %   Use "opto" instead of "fibers", see http://bit.ly/33WaqWU for details.
 %
@@ -141,7 +143,7 @@ if ~isempty(distance) && ~any(strcmp(distance, {'m' 'dm' 'cm' 'mm'}))
 end
 
 if strcmp(version, 'latest')
-  version = '2019';
+  version = '2020';
 end
 
 if isempty(sens)
@@ -151,17 +153,30 @@ end
 % this is needed further down
 nchan = length(sens.label);
 
-% there are many cases which deal with either eeg or meg
-ismeg = ft_senstype(sens, 'meg');
+% there are many cases which are MEG, EEG or NIRS specific
+ismeg  = ft_senstype(sens, 'meg');
+iseeg  = ft_senstype(sens, 'eeg');
+isnirs = ft_senstype(sens, 'nirs');
 
 switch version
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  case '2020'
+    % update it to the previous standard version
+    new_argin = ft_setopt(varargin, 'version', '2019');
+    sens      = ft_datatype_sens(sens, new_argin{:});
+    
+    if isnirs
+      sens = renamefields(sens, 'transmits', 'tra'); % this makes it more consistent with EEG and MEG
+      sens = removefields(sens, {'laserstrength'});
+    end
+    
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   case '2019'
     % update it to the previous standard version
     new_argin = ft_setopt(varargin, 'version', '2016');
     sens      = ft_datatype_sens(sens, new_argin{:});
     
-    if isfield(sens, 'fiberpos') || isfield(sens, 'optopos')
+    if isnirs
       % rename some NIRS field names
       sens = renamefields(sens, 'fiberpos', 'optopos');
       sens = renamefields(sens, 'fibertype', 'optotype');
@@ -172,7 +187,7 @@ switch version
       % especially the chanunit field needs some careful thought when converting between optical densities and chromophore concentrations.
       sens = removefields(sens, {'chantype', 'chanunit'});
     end
-
+    
     % ensure all positions are represented as 3D, not 2D
     fn = {'chanpos', 'optopos', 'elecpos', 'coilpos'};
     for i=1:numel(fn)
@@ -190,27 +205,27 @@ switch version
     
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   case '2016'
-
     % update it to the previous standard version
-    sens = ft_datatype_sens(sens, 'version', '2011v2');
-
+    new_argin = ft_setopt(varargin, 'version', '2011v2');
+    sens      = ft_datatype_sens(sens, new_argin{:});
+    
     % rename from org to old (reverse = false)
     sens = fixoldorg(sens, false);
-
+    
     % ensure that all numbers are represented in double precision
     % this only affects the top-level fields and does not recurse
     sens = ft_struct2double(sens, 1);
-
+    
     % in version 2011v2 this was optional, now it is required
     if ~isfield(sens, 'chantype') || all(strcmp(sens.chantype, 'unknown'))
       sens.chantype = ft_chantype(sens);
     end
-
+    
     % in version 2011v2 this was optional, now it is required
     if ~isfield(sens, 'chanunit') || all(strcmp(sens.chanunit, 'unknown'))
       sens.chanunit = ft_chanunit(sens);
     end
-
+    
     if ~isempty(distance)
       % update the units of distance, this also updates the tra matrix
       sens = ft_convert_units(sens, distance);
@@ -218,7 +233,7 @@ switch version
       % determine the default, this may be needed to set the scaling
       distance = sens.unit;
     end
-
+    
     if ~isempty(amplitude) && isfield(sens, 'tra')
       % update the tra matrix for the units of amplitude, this ensures that
       % the leadfield values remain consistent with the units
@@ -254,14 +269,14 @@ switch version
         amplitude = 'unknown';
       end
     end
-
+    
     % perform some sanity checks
     if ismeg
       sel_m  = ~cellfun(@isempty, regexp(sens.chanunit, '/m$'));
       sel_dm = ~cellfun(@isempty, regexp(sens.chanunit, '/dm$'));
       sel_cm = ~cellfun(@isempty, regexp(sens.chanunit, '/cm$'));
       sel_mm = ~cellfun(@isempty, regexp(sens.chanunit, '/mm$'));
-
+      
       if     strcmp(sens.unit, 'm') && (any(sel_dm) || any(sel_cm) || any(sel_mm))
         ft_error('inconsistent units in input gradiometer');
       elseif strcmp(sens.unit, 'dm') && (any(sel_m) || any(sel_cm) || any(sel_mm))
@@ -271,9 +286,9 @@ switch version
       elseif strcmp(sens.unit, 'mm') && (any(sel_m) || any(sel_dm) || any(sel_cm))
         ft_error('inconsistent units in input gradiometer');
       end
-
+      
       if ~strcmp(amplitude, 'unknown') && ~strcmp(distance, 'unknown')
-
+        
         % the default should be "amplitude/distance" for neuromag and "amplitude" for all others
         if isempty(scaling)
           if ft_senstype(sens, 'neuromag') && ~any(contains(sens.chanunit, '/'))
@@ -284,7 +299,7 @@ switch version
             scaling = 'amplitude';
           end
         end
-
+        
         % update the gradiometer scaling
         if strcmp(scaling, 'amplitude') && isfield(sens, 'tra')
           for i=1:nchan
@@ -308,7 +323,7 @@ switch version
               ft_warning('unexpected channel unit "%s" in channel %d', sens.chanunit{i}, i);
             end % if
           end % for nchan
-
+          
         elseif strcmp(scaling, 'amplitude/distance') && isfield(sens, 'tra')
           for i=1:nchan
             if strcmp(sens.chanunit{i}, amplitude)
@@ -330,10 +345,10 @@ switch version
               ft_warning('unexpected channel unit "%s" in channel %d', sens.chanunit{i}, i);
             end % if
           end % for nchan
-
+          
         end % if strcmp scaling
       end % if amplitude and scaling are not unknown
-
+      
     else
       sel_m  = ~cellfun(@isempty, regexp(sens.chanunit, '/m$'));
       sel_dm = ~cellfun(@isempty, regexp(sens.chanunit, '/dm$'));
@@ -342,26 +357,26 @@ switch version
       if any(sel_m | sel_dm | sel_cm | sel_mm)
         ft_error('scaling of amplitude/distance has not been considered yet for EEG');
       end
-
+      
     end % if iseeg or ismeg
-
+    
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   case '2011v2'
-
+    
     % rename from old to org (reverse = true)
     sens = fixoldorg(sens, true);
-
+    
     if ~isempty(amplitude) || ~isempty(distance) || ~isempty(scaling)
       ft_warning('amplitude, distance and scaling are not supported for version "%s"', version);
     end
-
+    
     % This speeds up subsequent calls to ft_senstype and channelposition.
     % However, if it is not more precise than MEG or EEG, don't keep it in
     % the output (see further down).
     if ~isfield(sens, 'type')
       sens.type = ft_senstype(sens);
     end
-
+    
     if isfield(sens, 'pnt')
       if ismeg
         % sensor description is a MEG sensor-array, containing oriented coils
@@ -372,7 +387,7 @@ switch version
         sens.elecpos = sens.pnt; sens = rmfield(sens, 'pnt');
       end
     end
-
+    
     if ~isfield(sens, 'chanpos')
       if ismeg
         % sensor description is a MEG sensor-array, containing oriented coils
@@ -401,7 +416,7 @@ switch version
         end
       end
     end
-
+    
     if ~isfield(sens, 'chantype') || all(strcmp(sens.chantype, 'unknown'))
       if ismeg
         sens.chantype = ft_chantype(sens);
@@ -409,12 +424,12 @@ switch version
         % for EEG it is not required
       end
     end
-
+    
     if ~isfield(sens, 'unit')
       % this should be done prior to calling ft_chanunit, since ft_chanunit uses this for planar neuromag channels
       sens = ft_determine_units(sens);
     end
-
+    
     if ~isfield(sens, 'chanunit') || all(strcmp(sens.chanunit, 'unknown'))
       if ismeg
         sens.chanunit = ft_chanunit(sens);
@@ -422,13 +437,13 @@ switch version
         % for EEG it is not required
       end
     end
-
+    
     if any(strcmp(sens.type, {'meg', 'eeg', 'magnetometer', 'electrode', 'unknown'}))
       % this is not sufficiently informative, so better remove it
       % see also http://bugzilla.fieldtriptoolbox.org/show_bug.cgi?id=1806
       sens = rmfield(sens, 'type');
     end
-
+    
     if size(sens.chanpos,1)~=length(sens.label) || ...
         isfield(sens, 'tra') && size(sens.tra,1)~=length(sens.label) || ...
         isfield(sens, 'tra') && isfield(sens, 'elecpos') && size(sens.tra,2)~=size(sens.elecpos,1) || ...
@@ -438,13 +453,13 @@ switch version
         isfield(sens, 'chanori') && size(sens.chanori,1)~=length(sens.label)
       ft_error('inconsistent number of channels in sensor description');
     end
-
+    
     if ismeg
       % ensure that the magnetometer/gradiometer balancing is specified
       if ~isfield(sens, 'balance') || ~isfield(sens.balance, 'current')
         sens.balance.current = 'none';
       end
-
+      
       % try to add the chantype and chanunit to the CTF G1BR montage
       if isfield(sens, 'balance') && isfield(sens.balance, 'G1BR') && ~isfield(sens.balance.G1BR, 'chantype')
         sens.balance.G1BR.chantypeorg = repmat({'unknown'}, size(sens.balance.G1BR.labelorg));
@@ -459,7 +474,7 @@ switch version
         sens.balance.G1BR.chantypenew(sel1) = sens.chantype(sel2);
         sens.balance.G1BR.chanunitnew(sel1) = sens.chanunit(sel2);
       end
-
+      
       % idem for G2BR
       if isfield(sens, 'balance') && isfield(sens.balance, 'G2BR') && ~isfield(sens.balance.G2BR, 'chantype')
         sens.balance.G2BR.chantypeorg = repmat({'unknown'}, size(sens.balance.G2BR.labelorg));
@@ -474,7 +489,7 @@ switch version
         sens.balance.G2BR.chantypenew(sel1) = sens.chantype(sel2);
         sens.balance.G2BR.chanunitnew(sel1) = sens.chanunit(sel2);
       end
-
+      
       % idem for G3BR
       if isfield(sens, 'balance') && isfield(sens.balance, 'G3BR') && ~isfield(sens.balance.G3BR, 'chantype')
         sens.balance.G3BR.chantypeorg = repmat({'unknown'}, size(sens.balance.G3BR.labelorg));
@@ -490,11 +505,11 @@ switch version
         sens.balance.G3BR.chanunitnew(sel1) = sens.chanunit(sel2);
       end
     end
-
+    
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   otherwise
     ft_error('converting to version %s is not supported', version);
-
+    
 end % switch
 
 % this makes the display with the "disp" command look better

--- a/utilities/ft_datatype_sens.m
+++ b/utilities/ft_datatype_sens.m
@@ -38,10 +38,9 @@ function [sens] = ft_datatype_sens(sens, varargin)
 %    sens.optopos       = Nx3 matrix with the position of individual optodes
 %    sens.optotype      = Nx1 cell-array with information about the type of optode (receiver or transmitter)
 %    sens.optolabel     = Nx1 cell-array with optode labels
-%    sens.transmits     = NxK matrix, boolean, where N is the number of optodes and K the number of wavelengths. Specifies what optode is transmitting at what wavelength (or nothing at all, which indicates that it is a receiver).
 %    sens.wavelength    = 1xK vector of all wavelengths that were used
 %    sens.laserstrength = 1xK vector of the strength of the emitted light of the lasers
-%    sens.tra           = MxN matrix, boolean, contains information about how receiver and transmitter are combined to form channels
+%    sens.transmits     = MxN matrix, specifies for each of the M channels at which wavelength each of the N optodes transmits (positive integer from 1 to K), or receives (negative ingeger from 1 to K), or does not contribute at all (zeros)
 %
 % The following fields apply to MEG, EEG, sEEG and ECoG
 %    sens.chantype = Mx1 cell-array with the type of the channel, see FT_CHANTYPE
@@ -369,7 +368,7 @@ switch version
         sens.coilpos = sens.pnt; sens = rmfield(sens, 'pnt');
         sens.coilori = sens.ori; sens = rmfield(sens, 'ori');
       else
-        % sensor description is something else, EEG/ECoG etc
+        % sensor description is something else, EEG/ECoG/sEEG, etc
         sens.elecpos = sens.pnt; sens = rmfield(sens, 'pnt');
       end
     end

--- a/utilities/private/channelposition.m
+++ b/utilities/private/channelposition.m
@@ -1,11 +1,11 @@
 function [pnt, ori, lab] = channelposition(sens)
 
 % CHANNELPOSITION computes the channel positions and orientations from the
-% coils or electrodes
+% MEG coils, EEG electrodes or NIRS optodes
 %
 % Use as
 %   [pos, ori, lab] = channelposition(sens)
-% where sens is an electrode,  gradiometer or optode array.
+% where sens is an gradiometer, electrode, or optode array.
 %
 % See also FT_DATATYPE_SENS
 
@@ -42,6 +42,12 @@ end
 if isfield(sens, 'pnt')
   sens.coilpos = sens.pnt;
   sens = rmfield(sens, 'pnt');
+end
+
+if isfield(sens, 'transmits') && ~isfield(sens, 'tra')
+  % this applies to optode definitions, the transmits matrix also codes for the wavelengths
+  % make a tra matrix where each optode weights in with the same amount
+  sens.tra = (sens.transmits~=0);
 end
 
 % treat all sensor arrays similar, i.e. as gradiometer systems

--- a/utilities/private/channelposition.m
+++ b/utilities/private/channelposition.m
@@ -44,12 +44,6 @@ if isfield(sens, 'pnt')
   sens = rmfield(sens, 'pnt');
 end
 
-if isfield(sens, 'transmits') && ~isfield(sens, 'tra')
-  % this applies to optode definitions, the transmits matrix also codes for the wavelengths
-  % make a tra matrix where each optode weights in with the same amount
-  sens.tra = (sens.transmits~=0);
-end
-
 % treat all sensor arrays similar, i.e. as gradiometer systems
 if     ~isfield(sens, 'coilori') && isfield(sens, 'coilpos')
   sens.coilori = nan(size(sens.coilpos));


### PR DESCRIPTION
- this follows up on #1245 and renames `opto.transmits` into `opto.tra` for consistency with elec annd grad
- this removes opto.laserstrength, which was never used
- this concatenates the d, s and aux for Homer nirs files and makes the trigger detection more consistent
- this improves the denoising of analog TTL channels

 