### PR TITLE
ENH - improved handling of probabilistic fsl derived atlases

### DIFF
--- a/fileio/ft_read_atlas.m
+++ b/fileio/ft_read_atlas.m
@@ -1993,6 +1993,15 @@ switch fileformat
           fn = strrep(fn, ')', '');
           
           atlas.(fn) = tmp.anatomy(:,:,:,m);
+          if ~isa(atlas.(fn), 'double') && ~isa(atlas.(fn), 'single')
+            % ensure that the probabilistic values are either double or
+            % single precision, do single precision to save memory
+            atlas.(fn) = single(atlas.(fn));
+          end
+          if any(atlas.(fn)(:)>1)
+            % convert to probability values, assuming 100 to be max
+            atlas.(fn) = atlas.(fn)./100;
+          end
         end
         atlas.coordsys = 'mni';
     end


### PR DESCRIPTION
The probabilistic atlases in fsl are in int8, and expressed in percent values (it seems that is: 100 = max). This is not recognized by FT as a probabilistic representation.