### PR TITLE
plot events as boxes in ft_databrowser when duration is > 0

### DIFF
--- a/ft_databrowser.m
+++ b/ft_databrowser.m
@@ -1806,8 +1806,12 @@ if strcmp(cfg.plotevents, 'yes')
       
       % compute the time of the event
       eventtim(ievent) = (event(ievent).sample-begsample)/opt.fsample + opt.hlim(1);
-      
-      lh = ft_plot_line([eventtim(ievent) eventtim(ievent)], [-1 1], 'tag', 'event', 'color', eventcol{ievent}, 'hpos', opt.hpos, 'vpos', opt.vpos, 'width', opt.width, 'height', opt.height, 'hlim', opt.hlim, 'vlim', [-1 1]);
+      % if line event --> plot line, else plot event duration as a box 
+      if isempty(event(ievent).duration) || event(ievent).duration==0
+        lh = ft_plot_line([eventtim(ievent) eventtim(ievent)], [-1 1], 'tag', 'event', 'color', eventcol{ievent}, 'hpos', opt.hpos, 'vpos', opt.vpos, 'width', opt.width, 'height', opt.height, 'hlim', opt.hlim, 'vlim', [-1 1]);
+      else
+        lh = ft_plot_box([eventtim(ievent) eventtim(ievent)+event(ievent).duration/opt.fsample -1 1], 'tag', 'event', 'edgecolor', eventcol{ievent}, 'facealpha', 0.1, 'facecolor', eventcol{ievent},  'hpos', opt.hpos,  'vpos', opt.vpos, 'width', opt.width, 'height', opt.height, 'hlim', opt.hlim, 'vlim', [-1 1]);
+      end
       
       % store this data in the line object so that it can be displayed in the
       % data cursor (see subfunction cb_datacursortext below)


### PR DESCRIPTION
Events were previously plotted as lines, regardless of their duration. With the proposed adaptation, when an event has a duration >0, event durations will be plotted as a box. When duration of the event =0, the event will still be plotted as a line.