### PR TITLE
append_common should append chans in data with dimord chan_freq_time

### DIFF
--- a/private/append_common.m
+++ b/private/append_common.m
@@ -131,19 +131,12 @@ switch cfg.appenddim
             chansel = match_str(varargin{j}.label, oldlabel{j});
             data.(cfg.parameter{i})(:,chansel,chansel) = varargin{j}.(cfg.parameter{i})(:,chansel,chansel);
           end
-         
-        case {'chan_freq_time'}
+           
+        case {'chan' 'chan_time' 'chan_freq' 'chan_freq_time'}
           data.(cfg.parameter{i}) = nan(dimsiz);
           for j=1:numel(varargin)
             chansel = match_str(varargin{j}.label, oldlabel{j});
             data.(cfg.parameter{i})(chansel,:,:) = varargin{j}.(cfg.parameter{i})(chansel,:,:);
-          end
-          
-        case {'chan' 'chan_time' 'chan_freq'}
-          data.(cfg.parameter{i}) = nan(dimsiz);
-          for j=1:numel(varargin)
-            chansel = match_str(varargin{j}.label, oldlabel{j});
-            data.(cfg.parameter{i})(chansel,:) = varargin{j}.(cfg.parameter{i})(chansel,:);
           end
           
         case {'rpt_chan_time' 'subj_chan_time' 'rpt_chan_freq' 'rpttap_chan_freq' 'subj_chan_freq'}

--- a/test/test_pull1566.m
+++ b/test/test_pull1566.m
@@ -22,7 +22,12 @@ freq2_s = ft_selectdata(cfg,freq2);
 cfg=[];
 cfg.appenddim = 'chan';
 cfg.parameter = 'powspctrm';
-freqA = ft_appendfreq(cfg,freq1_s,freq2_s)
+freqA = ft_appendfreq(cfg,freq1_s,freq2_s);
+
+% The below assertions are 'incorrect', i.e. they should be throwing an
+% error if this issue is solved
+assert(isequal(freqA.freq, [0;0]));
+assert(~isfield(freqA, 'powspctrm'));
 
 % another situation
 freq1=[];
@@ -45,12 +50,16 @@ cfg.appenddim = 'chan';
 cfg.parameter = 'powspctrm';
 freqB = ft_appendfreq(cfg,freq1_s,freq2_s);
 
+% This scenario yields an OK structure
+assert(isfield(freqB, 'powspctrm'));
+assert(isequal(freqB.freq, 0));
+
 % another situation
 freq1=[];
 freq1.label={'chan1'};
 freq1.dimord='chan_freq';
 freq1.freq=[1:2];
-freq1.powspctrm = rand(2,size(freq1.freq,2));
+freq1.powspctrm = rand(1,size(freq1.freq,2));
 
 freq2=freq1;
 freq2.label={'chan2'};
@@ -58,4 +67,10 @@ freq2.label={'chan2'};
 cfg=[];
 cfg.appenddim = 'chan';
 cfg.parameter = 'powspctrm';
-freqC = ft_appendfreq(cfg,freq1,freq2)
+freqC = ft_appendfreq(cfg,freq1,freq2);
+
+% This scenario seems to correctly append the powerspectra, but the
+% freq-field is incorrect, the second assertion should throw an error once
+% this has been solved.
+assert(isequal(freqC.powspctrm, [freq1.powspctrm;freq2.powspctrm]));
+assert(isequal(freqC.freq, [1 2;1 2]));

--- a/test/test_pull1566.m
+++ b/test/test_pull1566.m
@@ -74,3 +74,11 @@ freqC = ft_appendfreq(cfg,freq1,freq2);
 % this has been solved.
 assert(isequal(freqC.powspctrm, [freq1.powspctrm;freq2.powspctrm]));
 assert(isequal(freqC.freq, [1 2;1 2]));
+
+% the thing that seems to go wrong is the following:
+% line 94 in append_common calls ft_selectdata with multiple inputs (and
+% outputs). Once there is just a single channel in the input data, it seems
+% that the numeric field freq (and possibly also time, as of yet untested)
+% is treated as a 'data field', and appended in the 'unionized' output.
+
+

--- a/test/test_pull1566.m
+++ b/test/test_pull1566.m
@@ -26,8 +26,8 @@ freqA = ft_appendfreq(cfg,freq1_s,freq2_s);
 
 % The below assertions are 'incorrect', i.e. they should be throwing an
 % error if this issue is solved
-assert(isequal(freqA.freq, [0;0]));
-assert(~isfield(freqA, 'powspctrm'));
+%assert(isequal(freqA.freq, [0;0]));
+%assert(~isfield(freqA, 'powspctrm'));
 
 % another situation
 freq1=[];
@@ -73,7 +73,7 @@ freqC = ft_appendfreq(cfg,freq1,freq2);
 % freq-field is incorrect, the second assertion should throw an error once
 % this has been solved.
 assert(isequal(freqC.powspctrm, [freq1.powspctrm;freq2.powspctrm]));
-assert(isequal(freqC.freq, [1 2;1 2]));
+%assert(isequal(freqC.freq, [1 2;1 2]));
 
 % the thing that seems to go wrong is the following:
 % line 94 in append_common calls ft_selectdata with multiple inputs (and
@@ -97,4 +97,12 @@ cfg.parameter = 'trial';
 tlckA = ft_appendtimelock(cfg, tlck1, tlck2);
 
 % this is incorrect, too:
-assert(isequal(tlckA.time, [1 2;1 2]));
+%assert(isequal(tlckA.time, [1 2;1 2]));
+
+% snippet of code that directly goes into the function in which it goes
+% wrong
+cfg = [];
+cfg.select = 'union';
+dataout = cell(1,2);
+[dataout{:}] = ft_selectdata(cfg, tlck1, tlck2);
+assert(isequal(size(dataout{1}.time), [1 2]));

--- a/test/test_pull1566.m
+++ b/test/test_pull1566.m
@@ -1,0 +1,61 @@
+function test_pull1566
+
+% MEM 8gb
+% WALLTIME 00:20:00
+% DEPENDENCY ft_appendfreq append_common ft_selectdata
+
+freq1=[];
+freq1.label={'chan1'};
+freq1.dimord='chan_freq';
+freq1.freq=[1:20];
+freq1.powspctrm = rand(1,size(freq1.freq,2));
+
+freq2=freq1;
+freq2.label={'chan2'};
+
+cfg=[];
+cfg.avgoverfreq='yes';
+cfg.keepfreqdim='no';
+freq1_s = ft_selectdata(cfg,freq1);
+freq2_s = ft_selectdata(cfg,freq2);
+
+cfg=[];
+cfg.appenddim = 'chan';
+cfg.parameter = 'powspctrm';
+freqA = ft_appendfreq(cfg,freq1_s,freq2_s)
+
+% another situation
+freq1=[];
+freq1.label={'chan1';'chan2'};
+freq1.dimord='chan_freq';
+freq1.freq=[1:20];
+freq1.powspctrm = rand(2,size(freq1.freq,2));
+
+freq2=freq1;
+freq2.label={'chan3';'chan4'};
+
+cfg=[];
+cfg.avgoverfreq='yes';
+cfg.keepfreqdim='no';
+freq1_s = ft_selectdata(cfg,freq1);
+freq2_s = ft_selectdata(cfg,freq2);
+
+cfg=[];
+cfg.appenddim = 'chan';
+cfg.parameter = 'powspctrm';
+freqB = ft_appendfreq(cfg,freq1_s,freq2_s);
+
+% another situation
+freq1=[];
+freq1.label={'chan1'};
+freq1.dimord='chan_freq';
+freq1.freq=[1:2];
+freq1.powspctrm = rand(2,size(freq1.freq,2));
+
+freq2=freq1;
+freq2.label={'chan2'};
+
+cfg=[];
+cfg.appenddim = 'chan';
+cfg.parameter = 'powspctrm';
+freqC = ft_appendfreq(cfg,freq1,freq2)

--- a/test/test_pull1566.m
+++ b/test/test_pull1566.m
@@ -2,7 +2,7 @@ function test_pull1566
 
 % MEM 8gb
 % WALLTIME 00:20:00
-% DEPENDENCY ft_appendfreq append_common ft_selectdata
+% DEPENDENCY ft_appendfreq append_common ft_selectdata ft_appendtimelock
 
 freq1=[];
 freq1.label={'chan1'};
@@ -81,4 +81,20 @@ assert(isequal(freqC.freq, [1 2;1 2]));
 % that the numeric field freq (and possibly also time, as of yet untested)
 % is treated as a 'data field', and appended in the 'unionized' output.
 
+tlck1 = [];
+tlck1.label = {'chan1'};
+tlck1.time  = [1 2];
+tlck1.trial = [0 0];
+tlck1.dimord = 'chan_time';
 
+tlck2 = tlck1;
+tlck2.label = {'chan2'};
+tlck2.trial = [1 1];
+
+cfg = [];
+cfg.appenddim = 'chan';
+cfg.parameter = 'trial';
+tlckA = ft_appendtimelock(cfg, tlck1, tlck2);
+
+% this is incorrect, too:
+assert(isequal(tlckA.time, [1 2;1 2]));

--- a/utilities/ft_selectdata.m
+++ b/utilities/ft_selectdata.m
@@ -526,6 +526,10 @@ switch selmode
   case 'union'
     if ~isempty(selindx) && all(isnan(selindx))
       % no selection needs to be made
+    elseif isequal(seldim,1) && any(strcmp({'time' 'freq'}, datfield))
+      % treat this as an exception, because these fields should only be
+      % unionized along the second dimension, so here also no selection
+      % needs to be made
     else
       tmp = data.(datfield);
       siz = size(tmp);


### PR DESCRIPTION
This pull request fixes append_common to append channels in freq data with dimord 'chan_freq_time'. Run this to check that powspctrm is not in the output while freq.label is correct:

freq1=[];
freq1.label={'chan1'};
freq1.dimord='chan_freq_time';
freq1.freq=[1:20];
freq1.time=[0:0.05:0.5];
freq1.powspctrm = rand(1,size(freq1.freq,2),size(freq1.time,2));

freq2=freq1;
freq2.label={'chan2'};

cfg=[];
cfg.appenddim = 'chan';
cfg.parameter = 'powspctrm';
freq = ft_appendfreq(cfg,freq1,freq2)

freq = 

  struct with fields:

     label: {2×1 cell}
      freq: [1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20]
      time: [0 0.0500 0.1000 0.1500 0.2000 0.2500 0.3000 0.3500 0.4000 0.4500 0.5000]
    dimord: 'chan_freq_time'
       cfg: [1×1 struct]




