### PR TITLE
fix - correcting distance calculation of Rx-Tx combinations

### DIFF
--- a/external/artinis/ft_nirs_prepare_ODtransformation.m
+++ b/external/artinis/ft_nirs_prepare_ODtransformation.m
@@ -197,19 +197,15 @@ wlidx = bsxfun(@minus, coefs(:, 1), wavelengths);
 % find the relevant channel combinations
 chancmb = logical([]); % we need to loop here to get size of chancmb
 chanUsed = zeros(numel(chanidx), 1);
-chanCmbMapping = zeros(0, 1); % to map the "sens" indices to "chancmb" indices
-chanCmbMappingCounter = 1; % counts how many wavelengths are used per 
 for c=1:numel(chanidx)
   % skip channel if it already was in another channel combination
   if chanUsed(c)
-    chanCmbMapping(size(chancmb, 2), 1) = 5;
     continue;
   end
   % compute the channel combinations
   tupletidx = sum(bsxfun(@minus, optodeidx, optodeidx(c, :))~=0, 2)==0;
   chanUsed = chanUsed|tupletidx;
   chancmb(:, end+1) = tupletidx;  
-  chanCmbMapping(c, 1) = size(chancmb, 2);
 end
 
 % do the transformation


### PR DESCRIPTION
Computation of optode distances could have been wrong in some cases. The error was that indexing of optode positions was based on optode index in a local array instead of global optode number.