### PR TITLE
BUG: empty array of artifacts

### DIFF
--- a/ft_rejectartifact.m
+++ b/ft_rejectartifact.m
@@ -306,8 +306,13 @@ for i=1:length(cfg.artfctdef.type)
       endsample = [];
     end
   else
-    begsample = artifact{i}(:,1);
-    endsample = artifact{i}(:,2);
+    if ~isempty(artifact{i})
+      begsample = artifact{i}(:,1);
+      endsample = artifact{i}(:,2);
+    else
+      begsample = [];
+      endsample = [];
+    end
   end
   for j=1:length(begsample)
     rejectall(begsample(j):endsample(j)) = i;  % the artifact type is coded here

--- a/ft_rejectartifact.m
+++ b/ft_rejectartifact.m
@@ -296,23 +296,14 @@ trialall = trl2boolvec(trl);
 % combine all artifacts into a single vector
 rejectall = zeros(1, max(trl(:,2)));
 for i=1:length(cfg.artfctdef.type)
-  if istable(artifact{i})
-    if ~isempty(artifact{i})
-      begsample = artifact{i}.begsample;
-      endsample = artifact{i}.endsample;
-    else
-      % an empty table does not contain any columns
-      begsample = [];
-      endsample = [];
-    end
-  else
-    if ~isempty(artifact{i})
-      begsample = artifact{i}(:,1);
-      endsample = artifact{i}(:,2);
-    else
-      begsample = [];
-      endsample = [];
-    end
+  begsample = [];
+  endsample = [];
+  if istable(artifact{i}) && ~isempty(artifact{i})
+    begsample = artifact{i}.begsample;
+    endsample = artifact{i}.endsample;
+  elseif ~istable(artifact{i}) && ~isempty(artifact{i})
+    begsample = artifact{i}(:,1);
+    endsample = artifact{i}(:,2);
   end
   for j=1:length(begsample)
     rejectall(begsample(j):endsample(j)) = i;  % the artifact type is coded here


### PR DESCRIPTION
The latest version returned error when the artifacts array was empty. The error report is appended below.

Index in position 2 exceeds array bounds.

Error in ft_rejectartifact (line 309)
    begsample = artifact{i}(:,1);