### PR TITLE
data2bids onset duration added to events.tsv

### DIFF
--- a/data2bids.m
+++ b/data2bids.m
@@ -1541,7 +1541,7 @@ if need_events_tsv
     events_tsv = cfg.events;
     begsample                   = table2array(events_tsv(:,{'begsample'}));
     endsample                   = table2array(events_tsv(:,{'endsample'}));
-    onset                       = begsample./hdr.Fs;
+    onset                       = (begsample-1)./hdr.Fs;
     duration                    = (endsample-begsample+1)./hdr.Fs; 
     table_onset_duration        = table(onset, duration);
     events_tsv                  = [table_onset_duration events_tsv];


### PR DESCRIPTION
Some forms of cfg.events input are of form "onset" "duration" whereas others are of form "begsample", "endsample", "offset". In the later case, an error was given when the table gets sorted so that onset and duration are the first columns of the table (old lines 1590 to 1603). It should now be solved by the addition of columns "onset" and ""duration" to tables of the latter form.