### PR TITLE
Improve path handling in reproducescript

### DIFF
--- a/utilities/printstruct.m
+++ b/utilities/printstruct.m
@@ -107,7 +107,7 @@ elseif isstruct(val)
         case 'struct'
           line = [printstruct([name '.' fn{i}], fv, varargin{:}) 10];
         case 'function_handle'
-          line = printstr([name '.' fn{i}], func2str(fv));
+          line = printstr([name '.' fn{i}], func2str(fv), linebreaks, transposed);
         otherwise
           ft_error('unsupported');
       end

--- a/utilities/private/reproducescript.m
+++ b/utilities/private/reproducescript.m
@@ -53,7 +53,14 @@ tmpcfg = printstruct('cfg', tmpcfg);
 % pipeline is identical to an output variable at an earlier step, the
 % output variable will automatically be used thanks to the hashing
 % mechanism (see make_or_fetch_inputfile).
-re = ['(?<=' regexptranslate('escape', reproducescript_dir) '[/\\]{1})(\w+_input_\w+(\.mat){1})'];
+% handle path separators in reproducescript_dir: either / or \ should match
+thedir = regexprep(reproducescript_dir, '[/\\]', '[/\\\\]');
+% make sure thedir does not end with a path separator (we will explicitly
+% add it later)
+if strcmp(thedir(end-4:end), '[/\\]')
+  thedir = thedir(1:end-5);
+end
+re = ['(?<=' thedir '[/\\])(\w+_input_\w+(\.mat))'];
 if exist(filename, 'file')
   script = fileread(filename);
   existing_infiles = regexp(script, re, 'match');


### PR DESCRIPTION
This fixes #1617. I tracked this down to the reproduce folder being specified with a trailing path separator (i.e. `cfg.reproducescript = 'reproduce/';` rather than `cfg.reproducescript = 'reproduce';`). This PR improves robustness to all path separators, including trailing ones, and should handle both `/` and `\`.

There is also a commit to handle a slight change I encountered in the API of `utilities/printstruct>printstr`.

@robertoostenveld @matsvanes 