### PR TITLE
Add BrainVision timestamps for markers

### DIFF
--- a/fileio/ft_read_event.m
+++ b/fileio/ft_read_event.m
@@ -514,9 +514,8 @@ switch eventformat
               event(end  ).value    = tok{2};
               event(end  ).sample   = str2num(tok{3});
               event(end  ).duration = str2num(tok{4});
-              if size(tok, 2) >= 6
-                event(end).timestamp = datetime(tok{6}, 'InputFormat', ...
-                'yyyyMMddHHmmssSSSSSS');
+              if size(tok, 2) >= 6 && ft_platform_supports('datetime')
+                event(end).timestamp = datetime(tok{6}, 'InputFormat', 'yyyyMMddHHmmssSSSSSS');
               end
             end
           end

--- a/fileio/ft_read_event.m
+++ b/fileio/ft_read_event.m
@@ -514,6 +514,10 @@ switch eventformat
               event(end  ).value    = tok{2};
               event(end  ).sample   = str2num(tok{3});
               event(end  ).duration = str2num(tok{4});
+              if size(tok, 2) >= 6
+                event(end).timestamp = datetime(tok{6}, 'InputFormat', ...
+                'yyyyMMddHHmmssSSSSSS');
+              end
             end
           end
         end

--- a/utilities/ft_platform_supports.m
+++ b/utilities/ft_platform_supports.m
@@ -37,6 +37,7 @@ function tf = ft_platform_supports(what,varargin)
 %   'uimenu'                        uimenu(...)
 %   'weboptions'                    weboptions(...)
 %   'parula'                        parula(...)
+%   'datetime'                      datetime structure
 %   'html'                          html rendering in desktop
 %
 % See also FT_VERSION, VERSION, VER, VERLESSTHAN
@@ -179,6 +180,9 @@ switch what
     tf = is_matlab() && matlabversion('2014b', Inf);
     
   case 'parula'
+    tf = is_matlab() && matlabversion('2014b', Inf);
+    
+  case 'datetime'
     tf = is_matlab() && matlabversion('2014b', Inf);
 
   case 'html'


### PR DESCRIPTION
A small modification of `ft_read_event.m` that copy the BrainVision timestamps (if present) into `events.timestamp`. 
Timestamps are converted into `datetime` structure.

In BrainVision format, the acquisition time can be only derived from markers timestamps, but they are ignored during conversion.
This pull corrects that by copying BV timestamp (stored as last field in marker file) into events array.

The changing is not invasive and affects only BrainVision files, the timestamp column, for my knowledge,  is not standardised in fieldtrip.