### PR TITLE
Fix for issue #1632 by adding lf=sens.tra*lf for case 'openmeeg'

### DIFF
--- a/forward/ft_compute_leadfield.m
+++ b/forward/ft_compute_leadfield.m
@@ -278,6 +278,11 @@ elseif ismeg
         dsm            = ft_sysmat_openmeeg(dippos, headmodel, sens, nonadaptive);
       end
       lf               = ds2sens + h2sens*headmodel.mat*dsm;
+      
+      if isfield(sens, 'tra')
+        % compute the leadfield for each gradiometer (linear combination of coils)
+        lf = sens.tra * lf;
+      end
 
     case {'infinite_magneticdipole', 'infinite'}
       %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/test/test_issue1632.m
+++ b/test/test_issue1632.m
@@ -1,0 +1,33 @@
+function test_issue1632
+
+% MEM 4gb
+% WALLTIME 00:10:00
+% DEPENDENCY ft_compute_leadfield
+
+% https://github.com/fieldtrip/fieldtrip/issues/1632
+% This script will demonstrate that with ft_prepare leadfields, the
+% leadfields are calculated for every coil and not every sensor.
+% Subsequently, it will show that ft_sourceanalysis lines 437-443 truncate
+% the leadfield matrix, removing all lines beyond the number of sensors.
+
+% The mat-file includes: 
+% data (emptied except for grad and label) from ftp://ftp.fieldtriptoolbox.org/pub/fieldtrip/tutorial/beamformer_lcmv/
+% headmodel created with ft_prepare_mesh and ft_prepare_headmodel with
+% method 'openmeeg', based on segmentedmri.mat from ftp://ftp.fieldtriptoolbox.org/pub/fieldtrip/tutorial/beamformer_lcmv/
+% Author: B Knipscheer 13-01-2021
+
+load(dccnpath('/home/common/matlab/fieldtrip/data/test/test_issue1632.mat'));
+
+cfg                  = [];
+cfg.grad             = data.grad;
+cfg.headmodel        = headmodel;
+cfg.sourcemodel.pos  = [0 0 0.07];
+cfg.channel          = 'MEG';
+cfg.normalize        = 'column';
+sourcemodel          = ft_prepare_leadfield(cfg);
+
+fprintf('Number of good MEG sensors = %d\n', size(data.label,1));  % There are 274 MEG sensors
+fprintf('Number of coils matching the MEG sensors = %d\n', size(data.grad.tra,2)); % There are 548 MEG coils for the 274 MEG sensors.
+fprintf('Number of leadfield rows for point 1 before ft_sourceanalysis = %d\n', size(sourcemodel.leadfield{1},1));
+
+assert(isequal(size(sourcemodel.leadfield{1},1), numel(data.label)));


### PR DESCRIPTION
Fix for issue #1632 Omission in ft_compute_leadfield for MEG and OpenMEEG headmodel.
The following lines have been added in ft_compute_leadfield (lines 281-285):
_if isfield(sens, 'tra')
% compute the leadfield for each gradiometer (linear combination of coils)
lf = sens.tra * lf;
end_