### PR TITLE
Fix data formatting in ft_connectivityanalysis.m for 'powcorr_orth' method

### DIFF
--- a/ft_connectivityanalysis.m
+++ b/ft_connectivityanalysis.m
@@ -895,7 +895,7 @@ switch cfg.method
       [nrpttap, nchan, nfreq] = size(data.fourierspctrm);
       datout = cell(1, nfreq);
       for i=1:length(data.freq)
-        dat       = reshape(data.fourierspctrm(:,:,i), nrpttap, nchan).';
+        dat       = data.fourierspctrm(:,:,i).';
         datout{i} = ft_connectivity_powcorr_ortho(dat, optarg{:});
       end
       datout = cat(3, datout{:});


### PR DESCRIPTION
When using the powcorr_orth method in ft_connectivityanalysis, I found that all of my results looked like random noise. After contacting a former coleague, Sean Tanabe, who had used this method, I found that he had previously discussed a fix for this code with Jan-Mathis, who requested that the code be changed and a pull request made. Reference to correspondance: https://mailman.science.ru.nl/pipermail/fieldtrip/2018-November/038411.html

This evidently never occurred, so I am making the pull request now.