### PR TITLE
ENH - implemented reading header and data from matlab file

### DIFF
--- a/external/artinis/ft_nirs_prepare_ODtransformation.m
+++ b/external/artinis/ft_nirs_prepare_ODtransformation.m
@@ -122,15 +122,15 @@ cfg.age     = ft_getopt(cfg, 'age', []);
 cfg.dpf     = ft_getopt(cfg, 'dpf', []);
 
 % get the optode definition
-sens = [];
+% FIXME this should use FT_FETCH_SENS
 if ~isfield(data, 'opto')
   if ~isfield(data, 'hdr') && ~isfield(data.hdr, 'opto')
     error('no optode structure found in the data');
   else
-    sens = data.hdr.opto;
+    opto = data.hdr.opto;
   end
 else
-  sens = data.opto;
+  opto = data.opto;
 end
 
 % select the appropriate channels
@@ -145,7 +145,7 @@ elseif isfield(data, 'label')
   cfg.channel = ft_channelselection(cfg.channel, data.label);
 else
   % update the selected channels based on the optode definition
-  cfg.channel = ft_channelselection(cfg.channel, sens.label);
+  cfg.channel = ft_channelselection(cfg.channel, opto.label);
 end
 cfg.channel = ft_channelselection('nirs', cfg.channel); % only NIRS valid
 
@@ -161,7 +161,7 @@ if isempty(cfg.channel)
 end
 
 % channel indices wrt optode structure
-chanidx     = match_str(sens.label, cfg.channel);
+chanidx     = match_str(opto.label, cfg.channel);
 
 % check on DPF values
 if ~isempty(cfg.age) && ~isempty(cfg.dpf)
@@ -171,7 +171,7 @@ elseif ~isempty(cfg.age)
 elseif ~isempty(cfg.dpf)
   dpfs = repmat(cfg.dpf, size(cfg.channel));
 else
-  dpfs = sens.DPF(chanidx);
+  dpfs = opto.DPF(chanidx);
 end
 
 % which chromophores are desired
@@ -180,18 +180,18 @@ chromophoreName = {'O2Hb' 'HHb'};
 
 %% transform to concentrations or to OD
 % read in the coefficient table
-% TODO FIXME put this into an own function to read this out
+% FIXME put this into an own function to read this out
 fid = fopen(fullfile(fileparts(mfilename('fullpath')), 'private', 'Cope_ext_coeff_table.txt'));
 coefs = cell2mat(textscan(fid, '%f %f %f %f %f'));
 
 % extract all optode combinations that are relevant here
-tratra         = sens.tra(chanidx, :)';
+tratra         = opto.tra(chanidx, :)';
 transmitteridx = tratra>0;
 receiveridx    = tratra<0;
 optodeidx      = (transmitteridx | receiveridx)'; % transpose to get back to tra order
 
 % extract the wavelengths
-wavelengths  = sens.wavelength(tratra(transmitteridx));
+wavelengths  = opto.wavelength(tratra(transmitteridx));
 wlidx = bsxfun(@minus, coefs(:, 1), wavelengths);
 
 % find the relevant channel combinations
@@ -225,7 +225,7 @@ for c=1:size(chancmb, 2)
 
   % compute the transmitter/receiver distance in cm
   optoidx = find(chanidx, 1, 'first'); % we can take 'first' because the transmitter-optodes have to be physically in the exact same spot to form "one" channel
-  dist = sqrt(sum(diff(sens.optopos(optodeidx(optoidx, :), :)).^2));
+  dist = sqrt(sum(diff(opto.optopos(optodeidx(optoidx, :), :)).^2));
     
   % select dpf
   dpf = mean(dpfs(chanidx));

--- a/fileio/ft_chantype.m
+++ b/fileio/ft_chantype.m
@@ -734,7 +734,11 @@ if nargin>1
   if isequal(desired, 'meg') || isequal(desired, 'ref')
     % only compare the first three characters, i.e. meggrad or megmag should match
     chantype = strncmp(desired, chantype, 3);
+  elseif isequal(desired, 'trigger')
+    % search for the different types of trigger channels
+    chantype = contains(chantype, desired);
   else
+    % search for an exact match
     chantype = strcmp(desired, chantype);
   end
 end

--- a/fileio/ft_read_data.m
+++ b/fileio/ft_read_data.m
@@ -1009,7 +1009,7 @@ switch dataformat
     dat = dat(chanindx, :);
     
   case 'matlab'
-    % read the header structure from a MATLAB file
+    % read the data structure from a MATLAB file
     % it should either contain a numerical "dat" array, or a FieldTrip data structure according to FT_DATATYPE_RAW
     w = whos(matfile(filename));
     if any(strcmp({w.name}, 'dat'))

--- a/fileio/ft_read_data.m
+++ b/fileio/ft_read_data.m
@@ -1008,6 +1008,18 @@ switch dataformat
     end
     dat = dat(chanindx, :);
     
+  case 'matlab'
+    % read the header structure from a MATLAB file
+    % it should either contain a numerical "dat" array, or a FieldTrip data structure according to FT_DATATYPE_RAW
+    w = whos(matfile(filename));
+    if any(strcmp({w.name}, 'dat'))
+      dat = loadvar(filename, 'dat');
+      dat = dat(chanindx, begsample:endsample);
+    elseif any(strcmp({w.name}, 'data')) || length(w)==1
+      data = loadvar(filename, 'data');
+      dat = ft_fetch_data(data, 'begsample', begsample, 'endsample', endsample, 'chanindx', chanindx);
+    end
+    
   case 'mayo_mef30'
     hdr.sampleunit = 'index';
     dat = read_mayo_mef30(filename, password, sortchannel, hdr, begsample, endsample, chanindx);

--- a/fileio/ft_read_event.m
+++ b/fileio/ft_read_event.m
@@ -1362,9 +1362,15 @@ switch eventformat
     end
     
   case 'matlab'
-    % read the events from a normal MATLAB file
-    tmp   = load(filename, 'event');
-    event = tmp.event;
+    % read the event structure from a MATLAB file
+    % it should either contain an "event" structure, or a FieldTrip data structure according to FT_DATATYPE_RAW
+    w = whos(matfile(filename));
+    if any(strcmp({w.name}, 'event'))
+      event = loadvar(filename, 'event');
+    elseif any(strcmp({w.name}, 'data')) || length(w)==1
+      data = loadvar(filename, 'data');
+      event = ft_fetch_event(data);
+    end
     
   case {'manscan_mbi', 'manscan_mb2'}
     if isempty(hdr)

--- a/fileio/ft_read_header.m
+++ b/fileio/ft_read_header.m
@@ -1665,6 +1665,17 @@ switch headerformat
     end
     hdr.orig = orig;
     
+  case 'matlab'
+    % read the header structure from a MATLAB file
+    % it should either contain a "hdr" structure, or a FieldTrip data structure according to FT_DATATYPE_RAW
+    w = whos(matfile(filename));
+    if any(strcmp({w.name}, 'hdr'))
+      hdr = loadvar(filename, 'hdr');
+    elseif any(strcmp({w.name}, 'data')) || length(w)==1
+      data = loadvar(filename, 'data');
+      hdr = ft_fetch_header(data);
+    end
+
   case 'mayo_mef30'
     ft_hastoolbox('mayo_mef', 1); % make sure mayo_mef exists
     hdr = read_mayo_mef30(filename, password, sortchannel);
@@ -2409,6 +2420,7 @@ switch headerformat
         hdr.orig.(fn{iFn}) = tmp.(fn{iFn});
       end
     end
+    
   case 'artinis_oxy3'
     ft_hastoolbox('artinis', 1);
     hdr = read_artinis_oxy3(filename);

--- a/fileio/private/read_trigger.m
+++ b/fileio/private/read_trigger.m
@@ -294,6 +294,13 @@ for i=1:length(chanindx)
           event(end  ).value  = trig(j-1-trigshift);    % assign the trigger value just _before_ going down
         end
       end
+    case 'any'
+      % convert the trigger into an event with a value at a specific sample
+      for j=find(diff([begpad trig endpad])~=0)
+        event(end+1).type   = channel;
+        event(end  ).sample = j + begsample - 1;            % assign the sample at which the trigger has gone up or down
+        event(end  ).value  = trig(j+trigshift);            % assign the trigger value just _after_ going up
+      end
     case {'bit', 'biton'}
       trig = uint32([begpad trig]);
       for k=1:32


### PR DESCRIPTION
I noticed that it was already supported to read **events** from a mat file, but not the **data** or **header**. That meant that `ft_definetrial` still would not work. I now made all three ft_read_xxx functions consistent. The mat file should either contain hdr, dat, event, or it should contain a FT raw data structure.