### PR TITLE
pass through non-MEG channels in ft_megplanar

### DIFF
--- a/ft_megplanar.m
+++ b/ft_megplanar.m
@@ -116,7 +116,7 @@ cfg = ft_checkconfig(cfg, 'renamed', {'grid',    'sourcemodel'});
 cfg = ft_checkconfig(cfg, 'renamed', {'pruneratio', 'tolerance'});
 
 % set the default configuration
-cfg.channel      = ft_getopt(cfg, 'channel',      'MEG');
+cfg.channel      = ft_getopt(cfg, 'channel',      'all');
 cfg.tolerance    = ft_getopt(cfg, 'tolerance',    1e-3);
 cfg.trials       = ft_getopt(cfg, 'trials',       'all', 1);
 cfg.planarmethod = ft_getopt(cfg, 'planarmethod', 'sincos');

--- a/ft_megplanar.m
+++ b/ft_megplanar.m
@@ -12,7 +12,7 @@ function [data] = ft_megplanar(cfg, data)
 %
 % The configuration should contain
 %   cfg.planarmethod   = string, can be 'sincos', 'orig', 'fitplane', 'sourceproject' (default = 'sincos')
-%   cfg.channel        =  Nx1 cell-array with selection of channels (default = 'MEG'), see FT_CHANNELSELECTION for details
+%   cfg.channel        =  Nx1 cell-array with selection of channels (default = 'all'), see FT_CHANNELSELECTION for details
 %   cfg.trials         = 'all' or a selection given as a 1xN vector (default = 'all')
 %
 % The methods orig, sincos and fitplane are all based on a neighbourhood interpolation.

--- a/test/test_issue1671.m
+++ b/test/test_issue1671.m
@@ -1,0 +1,22 @@
+function test_issue1671
+
+% MEM 2gb
+% WALLTIME 00:10:00
+% DEPENDENCY ft_megplanar ft_apply_montage
+
+load(dccnpath('/home/common/matlab/fieldtrip/data/ftp/tutorial/connectivity/data.mat'));
+
+cfg = [];
+cfg.method = 'template';
+cfg.template = 'ctf151_neighb.mat';
+neighb = ft_prepare_neighbours(cfg);
+
+cfg = [];
+cfg.method = 'sincos';
+cfg.neighbours = neighb;
+datplan = ft_megplanar(cfg, data);
+
+assert(any(strcmp(data.label, 'EMGlft')));
+assert(any(strcmp(datplan.label, 'EMGlft')));
+
+end


### PR DESCRIPTION
This fixes #1671 by simply changing the default `cfg.channel` to `'all'`. (The issue was not in `ft_apply_montage` but in `ft_megplanar` itself.)

As requested by @robertoostenveld, I also had a look at `ft_megrealign`. While I didn't run any explicit tests for `ft_megrealign`, the code handles channel selection differently, explicitly taking care of non-MEG channels:
https://github.com/fieldtrip/fieldtrip/blob/d8e913aa20a7478946d90af66e41a5a8d8afb76d/ft_megrealign.m#L163-L168

so I don't expect that the same issue affects the code there.