### PR TITLE
Allow for missing *.eeg file in neuroscope data

### DIFF
--- a/fileio/ft_read_header.m
+++ b/fileio/ft_read_header.m
@@ -2210,6 +2210,8 @@ switch headerformat
       % FIXME this assumes only 1 such file, or at least it only takes the
       % first one.
       lfpfile = filenames{lfpfile_idx(1)};
+    else
+      lfpfile = {};
     end
     if ~isempty(rawfile_idx)
       rawfile = filenames{rawfile_idx(1)};


### PR DESCRIPTION
ft_read_header would handle missing *.eeg files in neuroscope data, by checking whether the variable lfpfile is empty. However, ft_read_header currently throws an error at this point, because the lfpfile variable would not be generated, if there is no *.eeg file. This commit fixes the problem by generating an empty lfpfile array in case there is no *.eeg file.