### PR TITLE
don't open new figures in bivariate_common

### DIFF
--- a/private/bivariate_common.m
+++ b/private/bivariate_common.m
@@ -139,9 +139,6 @@ for i=1:numel(varargin)
   end % if sparse or full
 end % for varargin
 
-% Ensure that the new figure appears at the same position
-figure('Position', get(gcf, 'Position'));
-
 % Remove these fields from the configuration
 fn = {'originalfunction', 'inputfile', 'refchannel'};
 


### PR DESCRIPTION
The opening of new figure windows has been unified in private function [`open_figure`](https://github.com/fieldtrip/fieldtrip/blob/master/private/open_figure.m) since July 2020. Within `bivariate_common`, there was still a call to `figure` to open a new window, leading to multiple (left empty) figure windows being opened when bivariate data is passed to e.g. `ft_multiplotER`. Simply removing this line fixes this issue.

**Note**: I don't know/haven't tested how this affects the handling of interactive GUI-based selection of reference channels. This functionality appears a bit shaky in general (e.g. it will show a pick-refchannel-gui even if there is only one possible non-MEG refchannel in the data), so I *think* this PR should not break anything over and above that (though I'm not sure).