### PR TITLE
this reimplements Tibor's PR #1695

### DIFF
--- a/test/test_issue1695.m
+++ b/test/test_issue1695.m
@@ -18,44 +18,15 @@ cfg     = [];
 cfg.dim = mri.dim;
 mri     = ft_volumereslice(cfg,mri);
 
+% this seemed to initially crash
 cfg = [];
 cfg.spmversion = 'spm12';
 cfg.spmmethod = 'new';
 cfg.nonlinear = 'no';
 normalise = ft_volumenormalise(cfg, mri);
+pos       = ft_warp_apply(normalise.params, sourcemodel.pos, 'sn2individual');
 
-% this will likely crash
-pos = ft_warp_apply(normalise.params, sourcemodel.pos, 'sn2individual');
-
-%% Normalise #2 - SPM
-% Full version of SPM12 is required
-
-tmpfile = spm_file(tempname,'ext','nii');
-copyfile(fullfile(ftpath, 'template/anatomy/single_subj_T1.nii'),tmpfile);
-job.channel.vols = {tmpfile};
-job.channel.biasreg = 1e-3;
-job.channel.biasfwhm = 60;
-job.channel.write = [0 0];
-job.channel.tpm = fullfile(spm('Dir'),'tpm/TPM.nii');
-job.channel.ngaus = [2 2 2 3 4 2];
-job.channel.native = [0 0];
-job.channel.warped = [0 0];
-for t = 1:6
-  job.tissue(t).tpm = spm_file(job.channel.tpm,'number',t);
-  job.tissue(t).ngaus = job.channel.ngaus(t);
-  job.tissue(t).native = [0 0];
-  job.tissue(t).warped = [0 0];
-end
-job.warp.affreg = 'mni';
-job.warp.reg = [0 1.0000e-03 0.5000 0.0500 0.2000];
-job.warp.samp = 1;
-job.warp.write = [0 0];
-job.warp.bb = NaN(2,3);
-job.warp.vox = 1.5;
-job.warp.mrf = 1;
-job.warp.cleanup = 0;
-spm_preproc_run(job);
-seg = load(spm_file(tmpfile,'suffix','_seg8','ext','mat'));
-
-pos = ft_warp_apply(seg, sourcemodel.pos, 'sn2individual');
-end
+% this worked before
+cfg.nonlinear = 'yes';
+normalise2 = ft_volumenormalise(cfg, mri);
+pos2       = ft_warp_apply(normalise2.params, sourcemodel.pos, 'sn2individual');

--- a/utilities/private/sn2individual.m
+++ b/utilities/private/sn2individual.m
@@ -8,7 +8,7 @@ function [warped]= sn2individual(P, input)
 % modified from code originally written by John Ashburner:
 % http://www.sph.umich.edu/~nichols/JG2/get_orig_coord2.m
 
-% Copyright (C) 2013-2017, Jan-Mathijs Schoffelen
+% Copyright (C) 2013-2021, Jan-Mathijs Schoffelen
 %
 % This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
 % for the documentation and details.
@@ -80,14 +80,16 @@ else
   
   fname  = [tempname,'.nii'];
   V      = nifti;
-  V.dat  = file_array(fname, P.image(1).dim(1:3), [spm_type('float32') spm_platform('bigend')], 0, 1, 0);
-  V.mat  = P.image(1).mat;
-  V.mat0 = P.image(1).mat;
-  V.descrip = 'dummy volume';
+  V.dat  = file_array(fname, P.image.dim(1:3), [spm_type('float32') spm_platform('bigend')], 0, 1, 0);
+  V.mat  = P.image.mat;
+  if isfield(P.image, 'mat0') 
+    V.mat0 = P.image.mat0;
+  end
+  V.descrip = 'deformation field';
   create(V);
-  V.dat(:) = 0;
-  P.image(1) = spm_vol(fname);
+  V.dat(:) = 0; % this is necessary, otherwise SPM fails: image too small
   
+  P.image  = spm_vol(fname);
   spm_preproc_write8(P, zeros(6,4), [0 0], [0 1], 1, 1, nan(2,3), nan);
   
   [pth,nam,ext] = fileparts(fname);


### PR DESCRIPTION
The error Tibor got was a low-level file's too small error thrown by SPM(12) when trying to create a deformation volume on-the-fly, based on the spatial normalisation parameters. test_ft_volumenormalise (which also calls ft_warp_apply with sn2indivdual as a method) has not complained before, and Tibor's use case differed with respect to the ones in the existing test function in that cfg.nonlinear was 'no' in his call to ft_volumennormalise (in the other use case it was set to 'yes').

I couldn't find why this caused the error, but I checked that with the new version of the code both warps work, i.e. with parameters obtained from ft_volumenormalise (spm12) with nonlinear = 'yes' , and 'no'