### PR TITLE
FIX - new attempt for speed up, before there was an infinite recursio…

### DIFF
--- a/utilities/private/defaultId.m
+++ b/utilities/private/defaultId.m
@@ -39,8 +39,8 @@ else
   
   % remove the non-FieldTrip functions and scripts, these should not be part of the message identifier
   [v, p] = ft_version;
-  keep = ~startsWith({stack.file}, p);
-  stack = stack(keep);
+  keep   = startsWith({stack.file}, p);
+  stack  = stack(keep);
 end
 
 switch numel(stack)

--- a/utilities/private/defaultId.m
+++ b/utilities/private/defaultId.m
@@ -54,7 +54,7 @@ switch numel(stack)
   otherwise
     % it is called from within a function
     name = sprintf('%s:', stack(end:-1:1).name); % this creates something like fun1:fun2:fun3:
-    id   = sprintf('FieldTrip:%sline%d', name, stack(1).line);
+    id   = sprintf('FieldTrip:%s:line%d', name, stack(1).line);
 end
 
 % slashes occur when using nested functions, but are not allowed in the identifier

--- a/utilities/private/defaultId.m
+++ b/utilities/private/defaultId.m
@@ -54,7 +54,7 @@ switch numel(stack)
   otherwise
     % it is called from within a function
     name = sprintf('%s:', stack(end:-1:1).name); % this creates something like fun1:fun2:fun3:
-    id   = sprintf('FieldTrip:%s:line%d', name, stack(1).line);
+    id   = sprintf('FieldTrip:%sline%d', name, stack(1).line);
 end
 
 % slashes occur when using nested functions, but are not allowed in the identifier

--- a/utilities/private/ft_notification.m
+++ b/utilities/private/ft_notification.m
@@ -424,9 +424,9 @@ end
 function r = getreturnstate(s, msgId, ident)
 if nargin<2
   r = s;
+  ident = {r.identifier};
   % don't return these
-  r(strcmp('timeout',   ident)) = [];
-  r(strcmp('last',      ident)) = [];
+  r(strcmp(ident, 'timeout')|strcmp(ident, 'last')) = [];
   % don't return the timestamps
   r = rmfield(r, 'timestamp');
 else

--- a/utilities/private/ft_notification.m
+++ b/utilities/private/ft_notification.m
@@ -92,7 +92,7 @@ end
 ident = {s.identifier};
 
 % set the default notification state
-if ~any(strcmp({s.identifier}, 'all'))
+if ~any(strcmp(ident, 'all'))
   [s, ident] = setstate(s, 'all', 'on', ident);
 end
 
@@ -172,7 +172,7 @@ switch varargin{1}
       % return the message state of this specific one
       varargout{1} = getreturnstate(s, msgId);
       % switch this specific item on
-      s = setstate(s, msgId, 'on');
+      s = setstate(s, msgId, 'on', ident);
       if strcmp(msgId, 'backtrace')
         defaultbacktrace = false;
       end
@@ -183,7 +183,7 @@ switch varargin{1}
       % return the message state of all
       varargout{1} = getreturnstate(s);
       % switch all on
-      s = setstate(s, 'all', 'on');
+      s = setstate(s, 'all', 'on', ident);
     end
     
   case 'off'
@@ -245,7 +245,7 @@ switch varargin{1}
       end
       msgState = getstate(s, msgId, ident);
       if nargout
-        varargout{1} = getreturnstate(s, msgId, ident);
+        varargout{1} = getreturnstate(s, msgId);
       elseif strcmp(msgId, 'verbose')
         if istrue(msgState)
           fprintf('%s output is verbose.\n', level);
@@ -263,7 +263,7 @@ switch varargin{1}
       end
     else
       % return all items
-      r = getreturnstate(s, [], ident);
+      r = getreturnstate(s);
       
       if nargout
         % return the state of all items
@@ -289,7 +289,7 @@ switch varargin{1}
   otherwise
     
     if nargout
-      varargout{1} = getreturnstate(s, [], ident);
+      varargout{1} = getreturnstate(s);
     end
     
     % first input might be msgId
@@ -421,7 +421,7 @@ end
 % SUBFUNCTIONS
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-function r = getreturnstate(s, msgId, ident)
+function r = getreturnstate(s, msgId)
 if nargin<2
   r = s;
   ident = {r.identifier};

--- a/utilities/private/ft_notification.m
+++ b/utilities/private/ft_notification.m
@@ -430,7 +430,7 @@ if nargin<2
   % don't return the timestamps
   r = rmfield(r, 'timestamp');
 else
-  msgState = getstate(s, msgId, ident);
+  msgState = getstate(s, msgId, {s.identifier});
   r = struct('identifier', msgId, 'state', msgState);
 end
 

--- a/utilities/private/ft_notification.m
+++ b/utilities/private/ft_notification.m
@@ -67,15 +67,13 @@ switch stack(2).name
 end
 
 % remove this function itself and the ft_xxx calling function
-stack = stack(3:end);
+%stack = stack(3:end);
+%stack(1:2) = [];
 
 % remove the non-FieldTrip functions from the path, these should not be part of the default message identifier
-keep = true(size(stack));
 [v, p] = ft_version;
-for i=1:numel(stack)
-  keep(i) = strncmp(p, stack(i).file, length(p));
-end
-stack = stack(keep);
+keep   = ~startsWith({stack.file}, p);
+stack  = stack(keep);
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% handle the defaults
@@ -91,51 +89,52 @@ end
 if isempty(s)
   s = struct('identifier', {}, 'state', {}, 'timestamp', {});
 end
+ident = {s.identifier};
 
 % set the default notification state
-if ~ismember('all', {s.identifier})
-  s = setstate(s, 'all', 'on');
+if ~any(strcmp({s.identifier}, 'all'))
+  [s, ident] = setstate(s, 'all', 'on', ident);
 end
 
 % set the default backtrace state
 defaultbacktrace = false;
-if ~ismember('backtrace', {s.identifier})
+if ~any(strcmp(ident, 'backtrace'))
   switch level
     case {'debug' 'info' 'notice'}
-      s = setstate(s, 'backtrace', 'off');
+      [s, ident] = setstate(s, 'backtrace', 'off', ident);
     case 'warning'
       defaultbacktrace = true;
       t = warning('query', 'backtrace'); % get the default state
-      s = setstate(s, 'backtrace', t.state);
+      [s, ident] = setstate(s, 'backtrace', t.state, ident);
     case 'error'
-      s = setstate(s, 'backtrace', 'on');
+      [s, ident] = setstate(s, 'backtrace', 'on', ident);
   end % switch
 end
 
 % set the default verbose state
 defaultverbose = false;
-if ~ismember('verbose', {s.identifier})
+if ~any(strcmp(ident, 'verbose'))
   switch level
     case 'warning'
       defaultverbose = true;
       t = warning('query', 'verbose'); % get the default state
-      s = setstate(s, 'verbose', t.state);
+      [s, ident] = setstate(s, 'verbose', t.state, ident);
     otherwise
-      s = setstate(s, 'verbose', 'off');
+      [s, ident] = setstate(s, 'verbose', 'off', ident);
   end
 end
 
 % set the default timeout
-if ~ismember('timeout', {s.identifier})
-  s = setstate(s, 'timeout', 60);
+if ~any(strcmp(ident, 'timeout'))
+  [s, ident] = setstate(s, 'timeout', 60, ident);
 end
 
 % set the last notification to empty
-if ~ismember('last', {s.identifier})
+if ~any(strcmp(ident, 'last'))
   state.message    = '';
   state.identifier = '';
   state.stack      = struct('file', {}, 'name', {}, 'line', {});
-  s = setstate(s, 'last', state);
+  [s, ident] = setstate(s, 'last', state, ident);
 end
 
 if strcmp(level, 'warning')
@@ -153,7 +152,7 @@ end
 
 if numel(varargin)==1 && (isstruct(varargin{1}) || isempty(varargin{1}))
   for i=1:numel(varargin{1})
-    s = setstate(s, varargin{1}(i).identifier, varargin{1}(i).state);
+    [s, ident] = setstate(s, varargin{1}(i).identifier, varargin{1}(i).state, ident);
   end
   ft_default.notification.(level) = s;
   return
@@ -193,7 +192,7 @@ switch varargin{1}
       % return the message state of this specific one
       varargout{1} = getreturnstate(s, msgId);
       % switch this specific item on
-      s = setstate(s, msgId, 'off');
+      s = setstate(s, msgId, 'off', ident);
       if strcmp(msgId, 'backtrace')
         defaultbacktrace = false;
       end
@@ -204,7 +203,7 @@ switch varargin{1}
       % return the message state of all
       varargout{1} = getreturnstate(s);
       % switch all off
-      s = setstate(s, 'all', 'off');
+      s = setstate(s, 'all', 'off', ident);
     end
     
   case 'once'
@@ -213,25 +212,25 @@ switch varargin{1}
       % return the specific message state
       varargout{1} = getreturnstate(s, msgId);
       % switch a specific item to once
-      s = setstate(s, msgId, 'once');
+      s = setstate(s, msgId, 'once', ident);
     else
       % return the message state of all
       varargout{1} = getreturnstate(s);
       % switch all to once
-      s = setstate(s, 'all', 'once');
+      s = setstate(s, 'all', 'once', ident);
     end
     
   case 'timeout'
     % set the timeout, this is used for 'once'
     if ischar(varargin{2})
-      s = setstate(s, 'timeout', str2double(varargin{2}));
+      s = setstate(s, 'timeout', str2double(varargin{2}), ident);
     else
-      s = setstate(s, 'timeout', varargin{2});
+      s = setstate(s, 'timeout', varargin{2}, ident);
     end
     
   case {'last' '-last'}
     % return the last notification
-    varargout{1} = getstate(s, 'last');
+    varargout{1} = getstate(s, 'last', ident);
     
   case {'clear' '-clear'}
     % reset the notification system
@@ -241,12 +240,12 @@ switch varargin{1}
     if numel(varargin)>1
       % select a specific item
       msgId = varargin{2};
-      if ~ismember(msgId, {s.identifier})
+      if ~any(strcmp(ident, msgId))
         error('Unknown setting or incorrect message identifier ''%s''.', msgId);
       end
-      msgState = getstate(s, msgId);
+      msgState = getstate(s, msgId, ident);
       if nargout
-        varargout{1} = getreturnstate(s, msgId);
+        varargout{1} = getreturnstate(s, msgId, ident);
       elseif strcmp(msgId, 'verbose')
         if istrue(msgState)
           fprintf('%s output is verbose.\n', level);
@@ -264,14 +263,14 @@ switch varargin{1}
       end
     else
       % return all items
-      r = getreturnstate(s);
+      r = getreturnstate(s, [], ident);
       
       if nargout
         % return the state of all items
         varargout{1} = r;
       else
         % show the state of all items that are different from the default
-        default = getstate(s, 'all');
+        default = getstate(s, 'all', ident);
         fprintf('The default %s state is ''%s''.', level, default);
         r = r(~strcmp({r.state}, default));
         % don't show these
@@ -290,7 +289,7 @@ switch varargin{1}
   otherwise
     
     if nargout
-      varargout{1} = getreturnstate(s);
+      varargout{1} = getreturnstate(s, [], ident);
     end
     
     % first input might be msgId
@@ -299,11 +298,11 @@ switch varargin{1}
       varargin = varargin(2:end); % shift them all by one
     else
       % use an automatically generated default identifier
-      msgId = defaultId;
+      msgId = defaultId(stack);
     end
     
     % get the state for this notification, it will default to the 'all' state
-    msgState = getstate(s, msgId);
+    msgState = getstate(s, msgId, ident);
     
     % errors are always to be printed
     if strcmp(level, 'error')
@@ -311,7 +310,7 @@ switch varargin{1}
     end
     
     if strcmp(msgState, 'once')
-      timeout = getstate(s, 'timeout');
+      timeout = getstate(s, 'timeout', ident);
       since   = elapsed(gettimestamp(s, msgId));
       if (since>timeout)
         % the timeout has passed, update the timestamp and print the message
@@ -333,7 +332,7 @@ switch varargin{1}
     state.identifier = msgId;
     if ~isempty(stack)
       state.stack      = stack;
-      s = setstate(s, 'last', state);
+      s = setstate(s, 'last', state, ident);
     end
     
     if strcmp(msgState, 'on')
@@ -365,7 +364,7 @@ switch varargin{1}
       end % if level=error, warning or otherwise
       
       % decide whether the stack trace should be shown
-      if istrue(getstate(s, 'backtrace'))
+      if istrue(getstate(s, 'backtrace', ident))
         for i=1:numel(stack)
           % show the deepest and lowest-level function first
           [p, f, x] = fileparts(stack(i).file);
@@ -389,7 +388,7 @@ switch varargin{1}
       end
       
       % decide whether a verbose message should be shown
-      if istrue(getstate(s, 'verbose'))
+      if istrue(getstate(s, 'verbose', ident))
         if ~isempty(msgId)
           fprintf('Type "ft_%s off %s" to suppress this message.\n', level, msgId)
         else
@@ -422,28 +421,28 @@ end
 % SUBFUNCTIONS
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-function r = getreturnstate(s, msgId)
+function r = getreturnstate(s, msgId, ident)
 if nargin<2
   r = s;
   % don't return these
-  r(strcmp('timeout',   {r.identifier})) = [];
-  r(strcmp('last',      {r.identifier})) = [];
+  r(strcmp('timeout',   ident)) = [];
+  r(strcmp('last',      ident)) = [];
   % don't return the timestamps
   r = rmfield(r, 'timestamp');
 else
-  msgState = getstate(s, msgId);
+  msgState = getstate(s, msgId, ident);
   r = struct('identifier', msgId, 'state', msgState);
 end
 
-function state = getstate(s, msgId)
-sel = find(strcmp({s.identifier}, msgId));
+function state = getstate(s, msgId, ident)
+sel = find(strcmp(ident, msgId));
 if numel(sel)==1
   state = s(sel).state;
   if isempty(state)
-    state = getstate(s, 'all');
+    state = getstate(s, 'all', ident);
   end
 else
-  state = getstate(s, 'all');
+  state = getstate(s, 'all', ident);
 end
 
 function timestamp = gettimestamp(s, msgId)
@@ -454,15 +453,19 @@ else
   timestamp = nan;
 end
 
-function s = setstate(s, msgId, state)
+function [s, ident] = setstate(s, msgId, state, ident)
 if isempty(msgId), return; end % this happens from the command line
-sel = find(strcmp({s.identifier}, msgId));
+if nargin<4, ident = {s.identifier}; end
+sel = find(strcmp(ident, msgId));
 if numel(sel)==1
   s(sel).state = state;
 else
   s(end+1).identifier = msgId;
   s(end  ).state      = state;
   s(end  ).timestamp  = nan;
+  if nargout>1
+    ident{end+1} = msgId;
+  end
 end
 
 function s = settimestamp(s, msgId, timestamp)

--- a/utilities/private/ft_notification.m
+++ b/utilities/private/ft_notification.m
@@ -68,11 +68,11 @@ end
 
 % remove this function itself and the ft_xxx calling function
 %stack = stack(3:end);
-%stack(1:2) = [];
+stack(1:2) = [];
 
 % remove the non-FieldTrip functions from the path, these should not be part of the default message identifier
 [v, p] = ft_version;
-keep   = ~startsWith({stack.file}, p);
+keep   = startsWith({stack.file}, p);
 stack  = stack(keep);
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
…n, causing all test functions to fail

The cause of this was the fact that I failed to realize that the 'ident' variable (that was computed from the {s.identifier} at the top of the function, should be updated in some cases of the setstate subfunction call (since this could lead to an expansion of the s struct array, which required the ident to be expanded in parallel). This caused an infinite recursion in getstate (calling itself) in case the s struct array input was inconsistent with its corresponding ident variable.

This error was undetected by my clunky test script, because it called ft_notification directly rather than from underlying fieldtrip-code. Hence, setstate was not called and tested appropriately. 

Anyhow, given the time spent on this already, and the still non negligible speed up of the code, we should consider merging this new PR again, but I will first run some more tests... (note that I made the fix on my Mac, and want to run the tests on the cluster)