### PR TITLE
added try-catch if the mex file is invalid with instructions

### DIFF
--- a/forward/ft_headmodel_duneuro.m
+++ b/forward/ft_headmodel_duneuro.m
@@ -221,7 +221,12 @@ else
   end
 end
 
-headmodel.driver = duneuro_meeg(cfg);
+try
+    headmodel.driver = duneuro_meeg(cfg);
+catch
+    warning('To generate a valid Mex File, please compile duneuro-matlab on your machine following the instructions on the <a href = "https://gitlab.dune-project.org/duneuro/duneuro/-/wikis/Installation-instructions">DUNEuro Wiki page</a>.');
+    return
+end
 
 headmodel.type              = 'duneuro';
 headmodel.forward           = forward;


### PR DESCRIPTION
hi all, hi @s-schrader,
I added a try-catch if the duneuro_matlab.mex64 file is invalid. 
a warning points to the instructions on how to generate a valid mex file (DUNEuro Wiki page).
what do you think?
best,
MC