### PR TITLE
improve support for processing of fMRI time series data 

### DIFF
--- a/contrib/nutmegtrip/private/getdimord.m
+++ b/contrib/nutmegtrip/private/getdimord.m
@@ -610,6 +610,7 @@ if exist('dimord', 'var') && iscell(data.(field))
   end
 end
 
+
 if ~exist('dimord', 'var')
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   % ATTEMPT 4: there is only one way that the dimensions can be interpreted
@@ -641,6 +642,7 @@ if ~exist('dimord', 'var')
     return
   end
 end % if dimord does not exist
+
 
 if ~exist('dimord', 'var')
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -684,6 +686,7 @@ if ~exist('dimord', 'var')
   end
 end % if dimord does not exist
 
+
 if ~exist('dimord', 'var')
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   % ATTEMPT 6: check whether it is a 3-D volume
@@ -691,12 +694,20 @@ if ~exist('dimord', 'var')
   if isequal(datsiz, [ndim1 ndim2 ndim3])
     dimord = 'dim1_dim2_dim3';
     return
+  elseif isequal(datsiz, [ndim1 ndim2 ndim3 ntime])
+    dimord = 'dim1_dim2_dim3_time';
+    return
+  elseif isequal(datsiz, [ndim1 ndim2 ndim3 nfreq])
+    dimord = 'dim1_dim2_dim3_freq';
+    return
+  elseif isequal(datsiz, [ndim1 ndim2 ndim3 nfreq ntime])
+    dimord = 'dim1_dim2_dim3_freq_time';
+    return
   elseif isfield(data, 'pos') && prod(datsiz)==size(data.pos, 1)
     dimord = 'dim1_dim2_dim3';
     return
   end
 end % if dimord does not exist
-
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/contrib/nutmegtrip/private/parameterselection.m
+++ b/contrib/nutmegtrip/private/parameterselection.m
@@ -90,7 +90,7 @@ for i=1:length(param)
       select{end+1} = param{i};
     elseif isfield(data, 'pos') && (prod(dim)==size(data.pos, 1) || dim(1)==size(data.pos,1))
       select{end+1} = param{i};
-    elseif isfield(data, 'dimord') && (isfield(data, 'pos') || isfield(data, 'transform')),
+    elseif isfield(data, 'dimord') && (isfield(data, 'pos') || isfield(data, 'transform'))
       dimtok = tokenize(data.dimord, '_');
       nels   = 1;
       for k=1:numel(dimtok)

--- a/contrib/spike/private/getdimord.m
+++ b/contrib/spike/private/getdimord.m
@@ -610,6 +610,7 @@ if exist('dimord', 'var') && iscell(data.(field))
   end
 end
 
+
 if ~exist('dimord', 'var')
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   % ATTEMPT 4: there is only one way that the dimensions can be interpreted
@@ -641,6 +642,7 @@ if ~exist('dimord', 'var')
     return
   end
 end % if dimord does not exist
+
 
 if ~exist('dimord', 'var')
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -684,6 +686,7 @@ if ~exist('dimord', 'var')
   end
 end % if dimord does not exist
 
+
 if ~exist('dimord', 'var')
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   % ATTEMPT 6: check whether it is a 3-D volume
@@ -691,12 +694,20 @@ if ~exist('dimord', 'var')
   if isequal(datsiz, [ndim1 ndim2 ndim3])
     dimord = 'dim1_dim2_dim3';
     return
+  elseif isequal(datsiz, [ndim1 ndim2 ndim3 ntime])
+    dimord = 'dim1_dim2_dim3_time';
+    return
+  elseif isequal(datsiz, [ndim1 ndim2 ndim3 nfreq])
+    dimord = 'dim1_dim2_dim3_freq';
+    return
+  elseif isequal(datsiz, [ndim1 ndim2 ndim3 nfreq ntime])
+    dimord = 'dim1_dim2_dim3_freq_time';
+    return
   elseif isfield(data, 'pos') && prod(datsiz)==size(data.pos, 1)
     dimord = 'dim1_dim2_dim3';
     return
   end
 end % if dimord does not exist
-
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/fileio/private/fixinside.m
+++ b/fileio/private/fixinside.m
@@ -1,4 +1,4 @@
-function [source] = fixinside(source, opt)
+function [source] = fixinside(source, target)
 
 % FIXINSIDE ensures that the region of interest (which is indicated by the
 % field "inside") is consistently defined for source structures and volume
@@ -29,9 +29,8 @@ function [source] = fixinside(source, opt)
 %
 % $Id$
 
-
 if nargin<2
-  opt = 'logical';
+  target = 'logical';
 end
 
 if ~isfield(source, 'inside')
@@ -45,9 +44,9 @@ if ~isfield(source, 'inside')
     % assume that all positions are inside the region of interest
     source.inside  = [1:size(source.pos,1)]';
     source.outside = [];
-  elseif isfield(source, 'dim')
+  elseif isfield(source, 'dim') && isfield(source, 'transform')
     % assume that all positions are inside the region of interest
-    source.inside  = [1:prod(source.dim)]';
+    source.inside  = [1:prod(source.dim(1:3))]';
     source.outside = [];
   end
 end
@@ -59,35 +58,41 @@ end
 
 % determine the format
 if isa(source.inside, 'logical')
-  logicalfmt = 1;
+  current = 'logical';
 elseif all(source.inside(:)==0 | source.inside(:)==1)
   source.inside = logical(source.inside);
-  logicalfmt = 1;
+  current = 'logical';
 else
-  logicalfmt = 0;
+  current = 'indexed';
 end
 
-if ~logicalfmt && strcmp(opt, 'logical')
-  % convert to a logical array
-  if ~isfield(source, 'outside')
-    source.outside = [];
-  end
-  if isfield(source, 'pos')
-    tmp  = false(size(source.pos,1),1);
-  elseif isfield(source, 'dim')
-    tmp  = false(prod(source.dim),1);
-  end
-  tmp(source.inside) = true;
+if strcmp(current, 'indexed') && strcmp(target, 'logical')
+  % remove outside
   if isfield(source, 'outside')
-    tmp(source.outside) = false;
     source = rmfield(source, 'outside');
   end
-  source.inside = tmp(:);
-elseif logicalfmt && strcmp(opt, 'index')
+  % convert inside to a logical array
+  if isfield(source, 'pos')
+    tmp = false(size(source.pos,1), 1);
+  elseif isfield(source, 'dim') && isfield(source, 'transform')
+    tmp = false(source.dim(1:3));
+  end
+  tmp(source.inside) = true;
+  source.inside = tmp;
+  
+elseif strcmp(current, 'logical') && strcmp(target, 'index')
   % convert to a vectors with indices
   tmp = source.inside;
   source.inside  = find( tmp(:));
   source.outside = find(~tmp(:));
-else
-  % nothing to do
+end
+
+if strcmp(target, 'logical')
+  if isfield(source, 'pos')
+    % reshape it so that it matches the positions
+    source.inside = reshape(source.inside, size(source.pos,1), 1);
+  elseif isfield(source, 'dim') && isfield(source, 'transform')
+    % reshape it so that it matches the volume dimensions
+    source.inside = reshape(source.inside, source.dim(1:3));
+  end
 end

--- a/fileio/private/ft_apply_montage.m
+++ b/fileio/private/ft_apply_montage.m
@@ -368,7 +368,7 @@ elseif ft_datatype(input, 'freq') && isfield(input, 'crsspctrm')
   inputtype = 'freq_crsspctrm';
   
   % attempt to convert to a chan-chan representation
-  input     = ft_checkdata(input, 'cmbrepresentation', 'full');
+  input     = ft_checkdata(input, 'cmbstyle', 'full');
 else
   inputtype = 'unknown';
 end

--- a/fileio/private/ft_checkdata.m
+++ b/fileio/private/ft_checkdata.m
@@ -771,13 +771,13 @@ if isequal(current, desired)
   % nothing to do
   
 elseif strcmp(current, 'fourier') && strcmp(desired, 'sparsewithpow')
-  if startsWith(dimord, 'rpttap')
+  if startsWith(data.dimord, 'rpttap')
     nrpt = size(data.cumtapcnt,1);
   else
     nrpt = 1;
   end
-  if contains(dimord, 'freq'), nfrq = length(data.freq); else nfrq = 1; end
-  if contains(dimord, 'time'), ntim = length(data.time); else ntim = 1; end
+  if contains(data.dimord, 'freq'), nfrq = length(data.freq); else nfrq = 1; end
+  if contains(data.dimord, 'time'), ntim = length(data.time); else ntim = 1; end
   
   fastflag = all(data.cumtapcnt(:)==data.cumtapcnt(1));
   flag     = nrpt==1; % needed to truncate the singleton dimension upfront
@@ -859,13 +859,13 @@ elseif strcmp(current, 'fourier') && strcmp(desired, 'sparsewithpow')
   
 elseif strcmp(current, 'fourier') && strcmp(desired, 'sparse')
   if isempty(channelcmb), ft_error('no channel combinations are specified'); end
-  if startsWith(dimord, 'rpttap')
+  if startsWith(data.dimord, 'rpttap')
     nrpt = size(data.cumtapcnt,1);
   else
     nrpt = 1;
   end
-  if contains(dimord, 'freq'), nfrq = length(data.freq); else nfrq = 1; end
-  if contains(dimord, 'time'), ntim = length(data.time); else ntim = 1; end
+  if contains(data.dimord, 'freq'), nfrq = length(data.freq); else nfrq = 1; end
+  if contains(data.dimord, 'time'), ntim = length(data.time); else ntim = 1; end
   
   flag      = nrpt==1; % flag needed to squeeze first dimension if singleton
   ncmb      = size(channelcmb,1);
@@ -947,15 +947,15 @@ elseif strcmp(current, 'fourier') && strcmp(desired, 'sparse')
   
 elseif strcmp(current, 'fourier') && strcmp(desired, 'full')
   % this is how it is currently and the desired functionality of prepare_freq_matrices
-  if startsWith(dimord, 'rpttap')
+  if startsWith(data.dimord, 'rpttap')
     nrpt = size(data.cumtapcnt, 1);
     flag = 0;
   else
     nrpt = 1;
     flag = 1;
   end
-  if contains(dimord, 'freq'), nfrq = length(data.freq); else nfrq = 1; end
-  if contains(dimord, 'time'), ntim = length(data.time); else ntim = 1; end
+  if contains(data.dimord, 'freq'), nfrq = length(data.freq); else nfrq = 1; end
+  if contains(data.dimord, 'time'), ntim = length(data.time); else ntim = 1; end
   if any(data.cumtapcnt(1,:) ~= data.cumtapcnt(1,1)), ft_error('this only works when all frequencies have the same number of tapers'); end
   nchan     = length(data.label);
   crsspctrm = zeros(nrpt,nchan,nchan,nfrq,ntim);
@@ -991,7 +991,7 @@ elseif strcmp(current, 'fourier') && strcmp(desired, 'fullfast')
   nrpt = size(data.fourierspctrm, 1);
   nchn = numel(data.label);
   nfrq = length(data.freq);
-  if contains(dimord, 'time'), ntim = length(data.time); else ntim = 1; end
+  if contains(data.dimord, 'time'), ntim = length(data.time); else ntim = 1; end
   
   data.fourierspctrm = reshape(data.fourierspctrm, [nrpt nchn nfrq*ntim]);
   data.fourierspctrm(~isfinite(data.fourierspctrm)) = 0;
@@ -1051,9 +1051,9 @@ elseif strcmp(current, 'sparse') && strcmp(desired, 'sparsewithpow')
   end
   
 elseif strcmp(current, 'full') && strcmp(desired, 'sparse')
-  if contains(dimord, 'rpt'),  nrpt = size(data.cumtapcnt,1); else nrpt = 1; end
-  if contains(dimord, 'freq'), nfrq = length(data.freq); else nfrq = 1; end
-  if contains(dimord, 'time'), ntim = length(data.time); else ntim = 1; end
+  if contains(data.dimord, 'rpt'),  nrpt = size(data.cumtapcnt,1); else nrpt = 1; end
+  if contains(data.dimord, 'freq'), nfrq = length(data.freq); else nfrq = 1; end
+  if contains(data.dimord, 'time'), ntim = length(data.time); else ntim = 1; end
   nchan    = length(data.label);
   ncmb     = nchan*nchan;
   labelcmb = cell(ncmb, 2);
@@ -1112,9 +1112,9 @@ elseif strcmp(current, 'sparsewithpow') && strcmp(desired, 'sparse')
   data = rmfield(data, 'label');
   
 elseif strcmp(current, 'sparse') && strcmp(desired, 'full')
-  if contains(dimord, 'rpt'),  nrpt = size(data.cumtapcnt,1); else nrpt = 1; end
-  if contains(dimord, 'freq'), nfrq = length(data.freq); else nfrq = 1; end
-  if contains(dimord, 'time'), ntim = length(data.time); else ntim = 1; end
+  if contains(data.dimord, 'rpt'),  nrpt = size(data.cumtapcnt,1); else nrpt = 1; end
+  if contains(data.dimord, 'freq'), nfrq = length(data.freq); else nfrq = 1; end
+  if contains(data.dimord, 'time'), ntim = length(data.time); else ntim = 1; end
   
   if ~isfield(data, 'label')
     % ensure that the bivariate spectral factorization results can be
@@ -1190,9 +1190,9 @@ elseif strcmp(current, 'sparse') && strcmp(desired, 'full')
   end
   
 elseif strcmp(current, 'sparse') && strcmp(desired, 'fullfast')
-  if contains(dimord, 'rpt'),  nrpt = size(data.cumtapcnt,1); else nrpt = 1; end
-  if contains(dimord, 'freq'), nfrq = length(data.freq); else nfrq = 1; end
-  if contains(dimord, 'time'), ntim = length(data.time); else ntim = 1; end
+  if contains(data.dimord, 'rpt'),  nrpt = size(data.cumtapcnt,1); else nrpt = 1; end
+  if contains(data.dimord, 'freq'), nfrq = length(data.freq); else nfrq = 1; end
+  if contains(data.dimord, 'time'), ntim = length(data.time); else ntim = 1; end
   
   if ~isfield(data, 'label')
     data.label = unique(data.labelcmb(:));

--- a/fileio/private/ft_convert_units.m
+++ b/fileio/private/ft_convert_units.m
@@ -19,7 +19,7 @@ function [object] = ft_convert_units(object, target, varargin)
 % specified, this function will only determine the geometrical units of the input
 % object.
 %
-% See also FT_DETERMINE_UNITS, FT_DETERMINE_COODSYS, FT_CONVERT_COORDSYS, FT_PLOT_AXES, FT_PLOT_XXX
+% See also FT_DETERMINE_UNITS, FT_DETERMINE_COORDSYS, FT_CONVERT_COORDSYS, FT_PLOT_AXES, FT_PLOT_XXX
 
 % Copyright (C) 2005-2020, Robert Oostenveld
 %

--- a/fileio/private/getdimord.m
+++ b/fileio/private/getdimord.m
@@ -610,6 +610,7 @@ if exist('dimord', 'var') && iscell(data.(field))
   end
 end
 
+
 if ~exist('dimord', 'var')
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   % ATTEMPT 4: there is only one way that the dimensions can be interpreted
@@ -641,6 +642,7 @@ if ~exist('dimord', 'var')
     return
   end
 end % if dimord does not exist
+
 
 if ~exist('dimord', 'var')
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -684,6 +686,7 @@ if ~exist('dimord', 'var')
   end
 end % if dimord does not exist
 
+
 if ~exist('dimord', 'var')
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   % ATTEMPT 6: check whether it is a 3-D volume
@@ -691,12 +694,20 @@ if ~exist('dimord', 'var')
   if isequal(datsiz, [ndim1 ndim2 ndim3])
     dimord = 'dim1_dim2_dim3';
     return
+  elseif isequal(datsiz, [ndim1 ndim2 ndim3 ntime])
+    dimord = 'dim1_dim2_dim3_time';
+    return
+  elseif isequal(datsiz, [ndim1 ndim2 ndim3 nfreq])
+    dimord = 'dim1_dim2_dim3_freq';
+    return
+  elseif isequal(datsiz, [ndim1 ndim2 ndim3 nfreq ntime])
+    dimord = 'dim1_dim2_dim3_freq_time';
+    return
   elseif isfield(data, 'pos') && prod(datsiz)==size(data.pos, 1)
     dimord = 'dim1_dim2_dim3';
     return
   end
 end % if dimord does not exist
-
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/fileio/private/parameterselection.m
+++ b/fileio/private/parameterselection.m
@@ -90,7 +90,7 @@ for i=1:length(param)
       select{end+1} = param{i};
     elseif isfield(data, 'pos') && (prod(dim)==size(data.pos, 1) || dim(1)==size(data.pos,1))
       select{end+1} = param{i};
-    elseif isfield(data, 'dimord') && (isfield(data, 'pos') || isfield(data, 'transform')),
+    elseif isfield(data, 'dimord') && (isfield(data, 'pos') || isfield(data, 'transform'))
       dimtok = tokenize(data.dimord, '_');
       nels   = 1;
       for k=1:numel(dimtok)

--- a/forward/ft_apply_montage.m
+++ b/forward/ft_apply_montage.m
@@ -368,7 +368,7 @@ elseif ft_datatype(input, 'freq') && isfield(input, 'crsspctrm')
   inputtype = 'freq_crsspctrm';
   
   % attempt to convert to a chan-chan representation
-  input     = ft_checkdata(input, 'cmbrepresentation', 'full');
+  input     = ft_checkdata(input, 'cmbstyle', 'full');
 else
   inputtype = 'unknown';
 end

--- a/forward/ft_convert_units.m
+++ b/forward/ft_convert_units.m
@@ -19,7 +19,7 @@ function [object] = ft_convert_units(object, target, varargin)
 % specified, this function will only determine the geometrical units of the input
 % object.
 %
-% See also FT_DETERMINE_UNITS, FT_DETERMINE_COODSYS, FT_CONVERT_COORDSYS, FT_PLOT_AXES, FT_PLOT_XXX
+% See also FT_DETERMINE_UNITS, FT_DETERMINE_COORDSYS, FT_CONVERT_COORDSYS, FT_PLOT_AXES, FT_PLOT_XXX
 
 % Copyright (C) 2005-2020, Robert Oostenveld
 %

--- a/forward/private/getdimord.m
+++ b/forward/private/getdimord.m
@@ -610,6 +610,7 @@ if exist('dimord', 'var') && iscell(data.(field))
   end
 end
 
+
 if ~exist('dimord', 'var')
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   % ATTEMPT 4: there is only one way that the dimensions can be interpreted
@@ -641,6 +642,7 @@ if ~exist('dimord', 'var')
     return
   end
 end % if dimord does not exist
+
 
 if ~exist('dimord', 'var')
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -684,6 +686,7 @@ if ~exist('dimord', 'var')
   end
 end % if dimord does not exist
 
+
 if ~exist('dimord', 'var')
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   % ATTEMPT 6: check whether it is a 3-D volume
@@ -691,12 +694,20 @@ if ~exist('dimord', 'var')
   if isequal(datsiz, [ndim1 ndim2 ndim3])
     dimord = 'dim1_dim2_dim3';
     return
+  elseif isequal(datsiz, [ndim1 ndim2 ndim3 ntime])
+    dimord = 'dim1_dim2_dim3_time';
+    return
+  elseif isequal(datsiz, [ndim1 ndim2 ndim3 nfreq])
+    dimord = 'dim1_dim2_dim3_freq';
+    return
+  elseif isequal(datsiz, [ndim1 ndim2 ndim3 nfreq ntime])
+    dimord = 'dim1_dim2_dim3_freq_time';
+    return
   elseif isfield(data, 'pos') && prod(datsiz)==size(data.pos, 1)
     dimord = 'dim1_dim2_dim3';
     return
   end
 end % if dimord does not exist
-
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/ft_connectivityanalysis.m
+++ b/ft_connectivityanalysis.m
@@ -215,7 +215,7 @@ switch cfg.method
       if hasrpt && ~hasjack
         ft_warning('partialisation on single trial observations is not supported, removing trial dimension');
         try
-          data = ft_checkdata(data, 'datatype', {'freqmvar' 'freq'}, 'cmbrepresentation', 'fullfast');
+          data = ft_checkdata(data, 'datatype', {'freqmvar' 'freq'}, 'cmbstyle', 'fullfast');
           inparam = 'crsspctrm';
           hasrpt = 0;
         catch
@@ -223,7 +223,7 @@ switch cfg.method
         end
       else
         %         try
-        %           data = ft_checkdata(data, 'datatype', {'freqmvar' 'freq'}, 'cmbrepresentation', 'full');
+        %           data = ft_checkdata(data, 'datatype', {'freqmvar' 'freq'}, 'cmbstyle', 'full');
         %           inparam = 'crsspctrm';
         %         catch
         %           ft_error('partial coherence/csd is only supported for input allowing for a all-to-all csd representation');
@@ -457,10 +457,10 @@ if any(~isfield(data, inparam)) || (isfield(data, 'crsspctrm') && (ischar(inpara
           % FIXME this is fast but throws away the trial dimension, consider
           % a way to keep trial information if needed, but use the fast way
           % if possible
-          data = ft_checkdata(data, 'cmbrepresentation', 'fullfast');
+          data = ft_checkdata(data, 'cmbstyle', 'fullfast');
           hasrpt = 0;
         elseif isfield(data, 'powspctrm')
-          data = ft_checkdata(data, 'cmbrepresentation', 'full');
+          data = ft_checkdata(data, 'cmbstyle', 'full');
         end
         
         % convert the inparam back to cell-array in the case of granger
@@ -970,7 +970,7 @@ switch cfg.method
           cfg.refindx = match_str(newlabel, cfg.refchannel);
           
           dat       = dat([i1; i3], :);
-          refindx   = cfg.refindx; 
+          refindx   = cfg.refindx;
         else
           tra      = [];
           newlabel = [];
@@ -1034,7 +1034,7 @@ switch cfg.method
     if strcmp(cfg.method, 'dfi'), optarg = cat(2, optarg, {'combinelags', cfg.(cfg.method).combinelags}); end
     [datout] = ft_connectivity_mutualinformation(dat, optarg{:});
     varout   = [];
-    nrpt     = [];    
+    nrpt     = [];
   case 'corr'
     % pearson's correlation coefficient
     optarg = {'dimord', getdimord(data, inparam), 'feedback', cfg.feedback, 'hasjack', hasjack, 'pownorm', true, 'complex', 'complex'};

--- a/ft_connectivityplot.m
+++ b/ft_connectivityplot.m
@@ -114,7 +114,7 @@ for k = 1:Ndata
       % that's ok
     case {'chancmb_freq' 'chancmb_freq_time'}
       % convert into 'chan_chan_freq'
-      varargin{k} = ft_checkdata(varargin{k}, 'cmbrepresentation', 'full');
+      varargin{k} = ft_checkdata(varargin{k}, 'cmbstyle', 'full');
     otherwise
       ft_error('the data should have a dimord of %s or %s', 'chan_chan_freq', 'chancmb_freq');
   end

--- a/ft_freqdescriptives.m
+++ b/ft_freqdescriptives.m
@@ -85,7 +85,7 @@ end
 % check if the input data is valid for this function
 freq = ft_checkdata(freq, 'datatype', {'freq', 'freqmvar'}, 'feedback', 'yes');
 % get data in the correct representation, it should only have power
-freq = ft_checkdata(freq, 'cmbrepresentation', 'sparsewithpow', 'channelcmb', {});
+freq = ft_checkdata(freq, 'cmbstyle', 'sparsewithpow', 'channelcmb', {});
 
 % check if the input cfg is valid for this function
 cfg = ft_checkconfig(cfg, 'forbidden',  {'channels', 'trial'}); % prevent accidental typos, see issue 1729

--- a/ft_prepare_sourcemodel.m
+++ b/ft_prepare_sourcemodel.m
@@ -764,7 +764,7 @@ end
 
 if strcmp(cfg.tight, 'yes')
   if ~isfield(sourcemodel, 'dim')
-    ft_error('tightgrid only works for positions on a regular 3D grid');
+    ft_error('cfg.tight only works for positions on a regular 3D grid');
   end
   fprintf('%d dipoles inside, %d dipoles outside brain\n', sum(sourcemodel.inside), sum(~sourcemodel.inside));
   fprintf('making tight grid\n');

--- a/ft_sourceanalysis.m
+++ b/ft_sourceanalysis.m
@@ -350,7 +350,7 @@ if isfreq && isfield(data, 'labelcmb')
   % this point, this step may take some time, if multiple trials are
   % present in the data
   fprintf('converting the linearly indexed channelcombinations into a square CSD-matrix\n');
-  data = ft_checkdata(data, 'cmbrepresentation', 'full');
+  data = ft_checkdata(data, 'cmbstyle', 'full');
 end
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/ft_sourcegrandaverage.m
+++ b/ft_sourcegrandaverage.m
@@ -86,7 +86,7 @@ end
 
 % check if the input data is valid for this function
 for i=1:length(varargin)
-  varargin{i} = ft_checkdata(varargin{i}, 'datatype', {'source'}, 'feedback', 'no', 'inside', 'logical');
+  varargin{i} = ft_checkdata(varargin{i}, 'datatype', {'source'}, 'feedback', 'no', 'insidestyle', 'logical');
   varargin{i} = ft_datatype_source(varargin{i}, 'version', 'upcoming');
 end
 

--- a/ft_sourceinterpolate.m
+++ b/ft_sourceinterpolate.m
@@ -17,7 +17,7 @@ function [interp] = ft_sourceinterpolate(cfg, functional, anatomical)
 %   example with a low-res grid for the functional data and a high-res grid for the
 %   anatomy.
 %
-% - The functional data is defined on a 3D regular grid and the anatomical data is 
+% - The functional data is defined on a 3D regular grid and the anatomical data is
 %   defined on an irregular point cloud, which can be a 2D triangulated surface mesh.
 %
 % - The functional data is defined on an irregular point cloud, which can be a 2D
@@ -27,7 +27,7 @@ function [interp] = ft_sourceinterpolate(cfg, functional, anatomical)
 %   cloud, which can be a 2D triangulated mesh.
 %
 % - The functional data is defined on a low-resolution 2D triangulated surface mesh and the
-%   anatomical data is defined on a high-resolution 2D triangulated surface mesh, where the 
+%   anatomical data is defined on a high-resolution 2D triangulated surface mesh, where the
 %   low-res vertices form a subset of the high-res vertices. This allows for mesh-based
 %   interpolation. The algorithm currently implemented is so-called 'smudging' as it is
 %   also applied by the MNE-suite software.
@@ -160,15 +160,15 @@ else
 end
 
 if isUnstructuredAna
-  anatomical = ft_checkdata(anatomical, 'datatype', {'source', 'source+label', 'mesh'}, 'inside', 'logical', 'feedback', 'yes', 'hasunit', 'yes');
+  anatomical = ft_checkdata(anatomical, 'datatype', {'source', 'source+label', 'mesh'}, 'insidestyle', 'logical', 'feedback', 'yes', 'hasunit', 'yes');
 else
-  anatomical = ft_checkdata(anatomical, 'datatype', {'volume', 'volume+label'}, 'inside', 'logical', 'feedback', 'yes', 'hasunit', 'yes');
+  anatomical = ft_checkdata(anatomical, 'datatype', {'volume', 'volume+label'}, 'insidestyle', 'logical', 'feedback', 'yes', 'hasunit', 'yes');
 end
 
 if isUnstructuredFun
-  functional = ft_checkdata(functional, 'datatype', 'source', 'inside', 'logical', 'feedback', 'yes', 'hasunit', 'yes');
+  functional = ft_checkdata(functional, 'datatype', 'source', 'insidestyle', 'logical', 'feedback', 'yes', 'hasunit', 'yes');
 else
-  functional = ft_checkdata(functional, 'datatype', 'volume', 'inside', 'logical', 'feedback', 'yes', 'hasunit', 'yes');
+  functional = ft_checkdata(functional, 'datatype', 'volume', 'insidestyle', 'logical', 'feedback', 'yes', 'hasunit', 'yes');
 end
 
 if ~isa(cfg.parameter, 'cell')
@@ -476,7 +476,7 @@ elseif ~isUnstructuredFun && isUnstructuredAna
         for m=1:dimf(5)
           fv    = double_ifnot(dat_array{i}(:,:,:,k,m)); % ensure double precision to allow sparse multiplication
           fv    = fv(functional.inside(:));
-          av    = interpmat*fv; 
+          av    = interpmat*fv;
           allav(:,k,m) = av;
         end
       end
@@ -539,6 +539,7 @@ elseif ~isUnstructuredFun && ~isUnstructuredAna
     
   elseif isequal(cfg.interpmethod, 'mode') && ~isAtlasFun
     ft_error('the interpolation method ''mode'' is only supported for parcellations');
+
   else
     % start with an empty structure, keep some fields
     interp = keepfields(functional, {'time', 'freq'});
@@ -641,6 +642,10 @@ elseif ~isUnstructuredFun && ~isUnstructuredAna
         allav = reshape(allav, prod(anatomical.dim), dimf(4), dimf(5));
       end
       interp = setsubfield(interp, dat_name{i}, allav);
+      % keep the description of the labels in the segmentation/parcellation
+      if strcmp(cfg.interpmethod, 'nearest') && isfield(functional, [dat_name{i} 'label'])
+        interp.([dat_name{i} 'label']) = functional.([dat_name{i} 'label']);
+      end
     end
     
   end

--- a/ft_topoplotCC.m
+++ b/ft_topoplotCC.m
@@ -77,7 +77,7 @@ if ft_abort
 end
 
 % check if the input data is valid for this function
-freq = ft_checkdata(freq, 'cmbrepresentation', 'sparse');
+freq = ft_checkdata(freq, 'cmbstyle', 'sparse');
 
 % check if the input cfg is valid for this function
 cfg = ft_checkconfig(cfg, 'required', {'foi', 'layout'});

--- a/ft_virtualchannel.m
+++ b/ft_virtualchannel.m
@@ -203,7 +203,8 @@ elseif useparcellation
   end
   
   % ensure that the source and the parcellation are anatomically consistent
-  if ~isalmostequal(source.pos, parcellation.pos, 'abstol', 1000000*eps)
+  tolerance = 0.1 * ft_scalingfactor('mm', source.unit);
+  if ~isalmostequal(source.pos, parcellation.pos, 'abstol', tolerance)
     ft_error('the source positions are not consistent with the parcellation, please use FT_SOURCEINTERPOLATE');
   end
   

--- a/ft_virtualchannel.m
+++ b/ft_virtualchannel.m
@@ -276,7 +276,7 @@ for i = 1:nvc
         % create a covariance, or csd matrix that is to be used for the
         % svd. this needs to be computed only once.
         if isfreq
-          tmp = ft_checkdata(data, 'cmbrepresentation', 'fullfast');
+          tmp = ft_checkdata(data, 'cmbstyle', 'fullfast');
           C   = tmp.crsspctrm;
         else
           tmpcfg = [];

--- a/ft_virtualchannel.m
+++ b/ft_virtualchannel.m
@@ -94,7 +94,7 @@ data   = ft_checkdata(data, 'datatype', {'raw', 'raw+comp', 'mvar' 'freq'}, 'fee
 
 % ensure that the source input is a source structure , not a volume structure
 % this will also return source.filter, rather than source.avg.filter
-source = ft_checkdata(source, 'datatype', 'source', 'inside', 'logical', 'hasunit', 'yes');
+source = ft_checkdata(source, 'datatype', 'source', 'insidestyle', 'logical', 'hasunit', 'yes');
 
 % get the defaults
 cfg.pos          = ft_getopt(cfg, 'pos');

--- a/ft_volumereslice.m
+++ b/ft_volumereslice.m
@@ -79,7 +79,7 @@ end
 
 % check if the input data is valid for this function and ensure that the structures correctly describes a volume
 if isfield(mri, 'inside')
-  mri = ft_checkdata(mri, 'datatype', 'volume', 'feedback', 'yes', 'hasunit', 'yes', 'inside', 'logical');
+  mri = ft_checkdata(mri, 'datatype', 'volume', 'feedback', 'yes', 'hasunit', 'yes', 'insidestyle', 'logical');
 else
   mri = ft_checkdata(mri, 'datatype', 'volume', 'feedback', 'yes', 'hasunit', 'yes');
 end

--- a/plotting/private/ft_apply_montage.m
+++ b/plotting/private/ft_apply_montage.m
@@ -368,7 +368,7 @@ elseif ft_datatype(input, 'freq') && isfield(input, 'crsspctrm')
   inputtype = 'freq_crsspctrm';
   
   % attempt to convert to a chan-chan representation
-  input     = ft_checkdata(input, 'cmbrepresentation', 'full');
+  input     = ft_checkdata(input, 'cmbstyle', 'full');
 else
   inputtype = 'unknown';
 end

--- a/plotting/private/ft_convert_units.m
+++ b/plotting/private/ft_convert_units.m
@@ -19,7 +19,7 @@ function [object] = ft_convert_units(object, target, varargin)
 % specified, this function will only determine the geometrical units of the input
 % object.
 %
-% See also FT_DETERMINE_UNITS, FT_DETERMINE_COODSYS, FT_CONVERT_COORDSYS, FT_PLOT_AXES, FT_PLOT_XXX
+% See also FT_DETERMINE_UNITS, FT_DETERMINE_COORDSYS, FT_CONVERT_COORDSYS, FT_PLOT_AXES, FT_PLOT_XXX
 
 % Copyright (C) 2005-2020, Robert Oostenveld
 %

--- a/preproc/private/nearest.m
+++ b/preproc/private/nearest.m
@@ -1,0 +1,185 @@
+function [indx] = nearest(array, val, insideflag, toleranceflag)
+
+% NEAREST return the index of an array nearest to a scalar
+%
+% Use as
+%   [indx] = nearest(array, val, insideflag, toleranceflag)
+%
+% The second input val can be a scalar, or a [minval maxval] vector for
+% limits selection.
+%
+% If not specified or if left empty, the insideflag and the toleranceflag
+% will default to false.
+%
+% The boolean insideflag can be used to specify whether the value should be
+% within the array or not. For example nearest(1:10, -inf) will return 1,
+% but nearest(1:10, -inf, true) will return an error because -inf is not
+% within the array.
+%
+% The boolean toleranceflag is used when insideflag is true. It can be used
+% to specify whether some tolerance should be allowed for values that are
+% just outside the array. For example nearest(1:10, 0.99, true, false) will
+% return an error, but nearest(1:10, 0.99, true, true) will return 1. The
+% tolerance that is allowed is half the distance between the subsequent
+% values in the array.
+%
+% See also FIND
+
+% Copyright (C) 2002-2012, Robert Oostenveld
+%
+% This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
+% for the documentation and details.
+%
+%    FieldTrip is free software: you can redistribute it and/or modify
+%    it under the terms of the GNU General Public License as published by
+%    the Free Software Foundation, either version 3 of the License, or
+%    (at your option) any later version.
+%
+%    FieldTrip is distributed in the hope that it will be useful,
+%    but WITHOUT ANY WARRANTY; without even the implied warranty of
+%    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%    GNU General Public License for more details.
+%
+%    You should have received a copy of the GNU General Public License
+%    along with FieldTrip. If not, see <http://www.gnu.org/licenses/>.
+%
+% $Id$
+
+mbreal(array);
+mbreal(val);
+
+mbvector(array);
+assert(all(~isnan(val)), 'incorrect value (NaN)');
+
+if numel(val)==2
+  % interpret this as a range specification like [minval maxval]
+  % see also http://bugzilla.fieldtriptoolbox.org/show_bug.cgi?id=1431
+  intervaltol = eps;
+  sel = find(array>=val(1) & array<=val(2));
+  if isempty(sel)
+    ft_error('The limits you selected are outside the range available in the data');
+  end
+  indx = sel([1 end]);
+  if indx(1)>1 && abs(array(indx(1)-1)-val(1))<=intervaltol
+    indx(1) = indx(1)-1;
+  end
+  if indx(2)<length(array) && abs(array(indx(2)+1)-val(2))<=intervaltol
+    indx(2) = indx(2)+1;
+  end
+  return
+end
+
+mbscalar(val);
+
+if nargin<3 || isempty(insideflag)
+  insideflag = false;
+end
+
+if nargin<4 || isempty(toleranceflag)
+  toleranceflag = false;
+end
+
+% ensure that it is a column vector
+array = array(:);
+
+% determine the most extreme values in the array
+minarray = min(array);
+maxarray = max(array);
+
+% do some strict checks whether the value lies within the min-max range
+if insideflag
+  if ~toleranceflag
+    if val<minarray || val>maxarray
+      if numel(array)==1
+        ft_warning('the selected value %g should be within the range of the array from %g to %g', val, minarray, maxarray);
+      else
+        ft_error('the selected value %g should be within the range of the array from %g to %g', val, minarray, maxarray);
+      end
+    end
+  else
+    if ~isequal(array, sort(array))
+      ft_error('the input array should be sorted from small to large');
+    end
+    if numel(array)<2
+      ft_error('the input array must have multiple elements to compute the tolerance');
+    end
+    mintolerance = (array(2)-array(1))/2;
+    maxtolerance = (array(end)-array(end-1))/2;
+    if val<(minarray-mintolerance) || val>(maxarray+maxtolerance)
+      ft_error('the value %g should be within the range of the array from %g to %g with a tolerance of %g and %g on both sides', val, minarray, maxarray, mintolerance, maxtolerance);
+    end
+  end % toleragceflag
+end % insideflag
+
+% FIXME it would be possible to do some soft checks and potentially give a
+% warning in case the user did not explicitly specify the inside and
+% tolerance flags
+
+% note that [dum, indx] = min([1 1 2]) will return indx=1
+% and that  [dum, indx] = max([1 2 2]) will return indx=2
+% whereas it is desired to have consistently the match that is most towards the side of the array
+
+if val>maxarray
+  % return the last occurence of the largest number
+  [dum, indx] = max(flipud(array));
+  indx = numel(array) + 1 - indx;
+
+elseif val<minarray
+  % return the first occurence of the smallest number
+  [dum, indx] = min(array);
+
+else
+  % implements a threshold to correct for errors due to numerical precision
+  % see http://bugzilla.fieldtriptoolbox.org/show_bug.cgi?id=498 and http://bugzilla.fieldtriptoolbox.org/show_bug.cgi?id=1943
+  %   if maxarray==minarray
+  %     precision = 1;
+  %   else
+  %     precision = (maxarray-minarray) / 10^6;
+  %   end
+  %
+  %   % return the first occurence of the nearest number
+  %   [dum, indx] = min(round((abs(array(:) - val)./precision)).*precision);
+
+  % use find instead, see http://bugzilla.fieldtriptoolbox.org/show_bug.cgi?id=1943
+  wassorted = true;
+  if ~issorted(array)
+    wassorted = false;
+    [array, xidx] = sort(array);
+  end
+
+  indx2 = find(array<=val, 1, 'last');
+  indx3 = find(array>=val, 1, 'first');
+  if abs(array(indx2)-val) <= abs(array(indx3)-val)
+    indx = indx2;
+  else
+    indx = indx3;
+  end
+  if ~wassorted
+    indx = xidx(indx);
+  end
+
+end
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% SUBFUNCTION
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+function mbreal(a)
+if ~isreal(a)
+  ft_error('Argument to mbreal must be real');
+end
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% SUBFUNCTION
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+function mbscalar(a)
+if ~all(size(a)==1)
+  ft_error('Argument to mbscalar must be scalar');
+end
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% SUBFUNCTION
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+function mbvector(a)
+if ndims(a) > 2 || (size(a, 1) > 1 && size(a, 2) > 1)
+  ft_error('Argument to mbvector must be a vector');
+end

--- a/private/determine_segmentationstyle.m
+++ b/private/determine_segmentationstyle.m
@@ -1,8 +1,8 @@
 function [indexed, probabilistic] = determine_segmentationstyle(segmentation, fn, dim)
 
 % DETERMINE_SEGMENTATIONSTYLE is a helper function that determines the type of segmentation
-% contained in each of the fields. It is used by ft_datatype_segmentation and
-% ft_datatype_parcellation.
+% contained in each of the fields. It is used by FT_DATATYPE_SEGMENTATION and
+% FT_DATATYPE_PARCELLATION.
 %
 % See also FIXSEGMENTATION, CONVERT_SEGMENTATIONSTYLE
 

--- a/private/fixinside.m
+++ b/private/fixinside.m
@@ -1,4 +1,4 @@
-function [source] = fixinside(source, opt)
+function [source] = fixinside(source, target)
 
 % FIXINSIDE ensures that the region of interest (which is indicated by the
 % field "inside") is consistently defined for source structures and volume
@@ -29,9 +29,8 @@ function [source] = fixinside(source, opt)
 %
 % $Id$
 
-
 if nargin<2
-  opt = 'logical';
+  target = 'logical';
 end
 
 if ~isfield(source, 'inside')
@@ -45,9 +44,9 @@ if ~isfield(source, 'inside')
     % assume that all positions are inside the region of interest
     source.inside  = [1:size(source.pos,1)]';
     source.outside = [];
-  elseif isfield(source, 'dim')
+  elseif isfield(source, 'dim') && isfield(source, 'transform')
     % assume that all positions are inside the region of interest
-    source.inside  = [1:prod(source.dim)]';
+    source.inside  = [1:prod(source.dim(1:3))]';
     source.outside = [];
   end
 end
@@ -59,35 +58,41 @@ end
 
 % determine the format
 if isa(source.inside, 'logical')
-  logicalfmt = 1;
+  current = 'logical';
 elseif all(source.inside(:)==0 | source.inside(:)==1)
   source.inside = logical(source.inside);
-  logicalfmt = 1;
+  current = 'logical';
 else
-  logicalfmt = 0;
+  current = 'indexed';
 end
 
-if ~logicalfmt && strcmp(opt, 'logical')
-  % convert to a logical array
-  if ~isfield(source, 'outside')
-    source.outside = [];
-  end
-  if isfield(source, 'pos')
-    tmp  = false(size(source.pos,1),1);
-  elseif isfield(source, 'dim')
-    tmp  = false(prod(source.dim),1);
-  end
-  tmp(source.inside) = true;
+if strcmp(current, 'indexed') && strcmp(target, 'logical')
+  % remove outside
   if isfield(source, 'outside')
-    tmp(source.outside) = false;
     source = rmfield(source, 'outside');
   end
-  source.inside = tmp(:);
-elseif logicalfmt && strcmp(opt, 'index')
+  % convert inside to a logical array
+  if isfield(source, 'pos')
+    tmp = false(size(source.pos,1), 1);
+  elseif isfield(source, 'dim') && isfield(source, 'transform')
+    tmp = false(source.dim(1:3));
+  end
+  tmp(source.inside) = true;
+  source.inside = tmp;
+  
+elseif strcmp(current, 'logical') && strcmp(target, 'index')
   % convert to a vectors with indices
   tmp = source.inside;
   source.inside  = find( tmp(:));
   source.outside = find(~tmp(:));
-else
-  % nothing to do
+end
+
+if strcmp(target, 'logical')
+  if isfield(source, 'pos')
+    % reshape it so that it matches the positions
+    source.inside = reshape(source.inside, size(source.pos,1), 1);
+  elseif isfield(source, 'dim') && isfield(source, 'transform')
+    % reshape it so that it matches the volume dimensions
+    source.inside = reshape(source.inside, source.dim(1:3));
+  end
 end

--- a/private/fourierspctrm2lcrsspctrm.m
+++ b/private/fourierspctrm2lcrsspctrm.m
@@ -97,7 +97,7 @@ for k = 1:numel(lags_indx)
                                  tmpfreq.fourierspctrm(:,:,:,indx2));
   tmpfreq.time  = freq.time(indx1);
   tmpfreq.label = cat(1, label, label_lagged);
-  tmpfreq       = ft_checkdata(tmpfreq, 'cmbrepresentation', 'sparse', 'channelcmb', tmpchannelcmb);
+  tmpfreq       = ft_checkdata(tmpfreq, 'cmbstyle', 'sparse', 'channelcmb', tmpchannelcmb);
 
   if timeresolved
     error('to do');

--- a/private/getdimord.m
+++ b/private/getdimord.m
@@ -610,6 +610,7 @@ if exist('dimord', 'var') && iscell(data.(field))
   end
 end
 
+
 if ~exist('dimord', 'var')
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   % ATTEMPT 4: there is only one way that the dimensions can be interpreted
@@ -641,6 +642,7 @@ if ~exist('dimord', 'var')
     return
   end
 end % if dimord does not exist
+
 
 if ~exist('dimord', 'var')
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -684,6 +686,7 @@ if ~exist('dimord', 'var')
   end
 end % if dimord does not exist
 
+
 if ~exist('dimord', 'var')
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   % ATTEMPT 6: check whether it is a 3-D volume
@@ -691,12 +694,20 @@ if ~exist('dimord', 'var')
   if isequal(datsiz, [ndim1 ndim2 ndim3])
     dimord = 'dim1_dim2_dim3';
     return
+  elseif isequal(datsiz, [ndim1 ndim2 ndim3 ntime])
+    dimord = 'dim1_dim2_dim3_time';
+    return
+  elseif isequal(datsiz, [ndim1 ndim2 ndim3 nfreq])
+    dimord = 'dim1_dim2_dim3_freq';
+    return
+  elseif isequal(datsiz, [ndim1 ndim2 ndim3 nfreq ntime])
+    dimord = 'dim1_dim2_dim3_freq_time';
+    return
   elseif isfield(data, 'pos') && prod(datsiz)==size(data.pos, 1)
     dimord = 'dim1_dim2_dim3';
     return
   end
 end % if dimord does not exist
-
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/private/parameterselection.m
+++ b/private/parameterselection.m
@@ -90,7 +90,7 @@ for i=1:length(param)
       select{end+1} = param{i};
     elseif isfield(data, 'pos') && (prod(dim)==size(data.pos, 1) || dim(1)==size(data.pos,1))
       select{end+1} = param{i};
-    elseif isfield(data, 'dimord') && (isfield(data, 'pos') || isfield(data, 'transform')),
+    elseif isfield(data, 'dimord') && (isfield(data, 'pos') || isfield(data, 'transform'))
       dimtok = tokenize(data.dimord, '_');
       nels   = 1;
       for k=1:numel(dimtok)

--- a/private/prepare_freq_matrices.m
+++ b/private/prepare_freq_matrices.m
@@ -62,9 +62,9 @@ if isfield(freq, 'crsspctrm')
 end
 if ~hasfull
   if keeptrials
-    freq = ft_checkdata(freq, 'cmbrepresentation', 'full');
+    freq = ft_checkdata(freq, 'cmbstyle', 'full');
   else
-    freq = ft_checkdata(freq, 'cmbrepresentation', 'fullfast');
+    freq = ft_checkdata(freq, 'cmbstyle', 'fullfast');
     Ntrials = 1;
   end
 end

--- a/private/prepare_mesh_segmentation.m
+++ b/private/prepare_mesh_segmentation.m
@@ -8,8 +8,8 @@ function mesh = prepare_mesh_segmentation(cfg, mri)
 %   cfg.radbound    = a scalar indicating the radius of the target surface
 %                     mesh element bounding sphere
 %
-% See also PREPARE_MESH_MANUAL, PREPARE_MESH_HEADSHAPE,
-% PREPARE_MESH_HEXAHEDRAL, PREPARE_MESH_TETRAHEDRAL
+% See also PREPARE_MESH_MANUAL, PREPARE_MESH_HEADSHAPE, PREPARE_MESH_HEXAHEDRAL,
+% PREPARE_MESH_TETRAHEDRAL
 
 % Copyrights (C) 2009-2021, Robert Oostenveld
 %
@@ -40,8 +40,7 @@ cfg.method        = ft_getopt(cfg, 'method', 'projectmesh');
 cfg.maxsurf       = ft_getopt(cfg, 'maxsurf', 1);
 cfg.radbound      = ft_getopt(cfg, 'radbound', 3);
 if all(isfield(mri, {'gray', 'white', 'csf'}))
-  % the default in this case is to combine gray, white and csf into brain
-  % and segment that with 3000 vertices
+  % the default in this case is to combine gray, white and csf into brain, and segment that with 3000 vertices
   cfg.tissue      = ft_getopt(cfg, 'tissue', 'brain');    % set the default
   cfg.numvertices = ft_getopt(cfg, 'numvertices', 3000);  % set the default
 else
@@ -57,7 +56,8 @@ ft_hastoolbox(cfg.spmversion, 1);
 % try to determine the tissue (if not specified)
 
 % special exceptional case first
-if isempty(cfg.tissue) && numel(cfg.numvertices)==1 && isfield(mri,'white') && isfield(mri,'gray') && isfield(mri,'csf')
+if isempty(cfg.tissue) && numel(cfg.numvertices)==1 && isfield(mri, 'gray') && isfield(mri, 'white') && isfield(mri, 'csf')
+  % combine the gray, white and csf into a single brain segmentation
   mri = ft_datatype_segmentation(mri, 'segmentationstyle', 'probabilistic', 'hasbrain', 'yes');
   cfg.tissue = 'brain';
 end
@@ -105,35 +105,48 @@ end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % do the mesh extraction
 
-for i =1:numel(cfg.tissue)
+for i=1:numel(cfg.tissue)
+  
   if iscell(cfg.tissue)
-    % the code below assumes that it is a probabilistic representation
-    % for example {'brain', 'skull', scalp'}
+    % the code below assumes that it is a probabilistic representation, for example {'brain', 'skull', scalp'}
     try
       seg = mri.(fixname(cfg.tissue{i}));
     catch
       ft_error('Please specify cfg.tissue to correspond to tissue types in the segmented MRI')
     end
-    tissue = cfg.tissue{i};
-  else
-    % this assumes that it is an indexed representation
-    % for example [3 2 1]
+    seglabel = cfg.tissue{i};
+  elseif isnumeric(cfg.tissue) && isfield(mri, 'seg')
+    % for backward compatibility with hard-coded seg field
+    % this assumes that it is an indexed representation, for example [3 2 1]
     seg = (mri.seg==cfg.tissue(i));
     if isfield(mri, 'seglabel')
       try
-        tissue = mri.seglabel{cfg.tissue(i)};
+        seglabel = mri.seglabel{cfg.tissue(i)};
       catch
-        ft_error('Please specify cfg.tissue to correspond to (the name or number of) tissue types in the segmented MRI')
+        ft_error('specify cfg.tissue as the tissue name or tissue number')
       end
     else
-      tissue = sprintf('tissue %d', i);
+      seglabel = sprintf('tissue %d', i);
+    end
+  elseif isnumeric(cfg.tissue) && isfield(mri, 'tissue')
+    % for backward compatibility with hard-coded tissue field
+    % this assumes that it is an indexed representation, for example [3 2 1]
+    seg = (mri.tissue==cfg.tissue(i));
+    if isfield(mri, 'tissuelabel')
+      try
+        seglabel = mri.tissuelabel{cfg.tissue(i)};
+      catch
+        ft_error('specify cfg.tissue as the tissue name or tissue number')
+      end
+    else
+      seglabel = sprintf('tissue %d', i);
     end
   end
   
   if strcmp(cfg.method, 'isosurface')
-    fprintf('triangulating the outer boundary of compartment %d (%s) with the isosurface method\n', i, tissue);
+    fprintf('triangulating the outer boundary of compartment %d (%s) with the isosurface method\n', i, seglabel);
   else
-    fprintf('triangulating the outer boundary of compartment %d (%s) with %d vertices\n', i, tissue, cfg.numvertices(i));
+    fprintf('triangulating the outer boundary of compartment %d (%s) with %d vertices\n', i, seglabel, cfg.numvertices(i));
   end
   
   % in principle it is possible to do volumesmooth and volumethreshold, but
@@ -141,7 +154,7 @@ for i =1:numel(cfg.tissue)
   % seg = volumesmooth(seg, nan, nan);
   
   % ensure that the segmentation is binary and that there is a single contiguous region
-  seg = volumethreshold(seg, 0.5, tissue);
+  seg = volumethreshold(seg, 0.5, seglabel);
   
   % add a layer on all sides to ensure that the tissue can be meshed all the way up to the edges
   % this also ensures that the mesh at the bottom of the neck will be closed
@@ -157,7 +170,7 @@ for i =1:numel(cfg.tissue)
   transform(2,4) = transform(2,4) - shift(2);
   transform(3,4) = transform(3,4) - shift(3);
   
-  % the function that generates the mesh will fail if there is a hole in the middle
+  % the mesh generation will fail if there is a hole in the middle
   seg = volumefillholes(seg);
   
   switch cfg.method
@@ -218,8 +231,6 @@ if strcmp(cfg.method, 'iso2surf')
   mesh = mesh(order);
 end
 
-end % function
-
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % SUBFUNCTION
@@ -227,8 +238,7 @@ end % function
 function mesh = decouplesurf(mesh)
 for ii = 1:length(mesh)-1
   % Despite what the instructions for surfboolean says, surfaces should be ordered from inside-out!!
-  [newnode, newelem] = surfboolean(mesh(ii+1).pos,mesh(ii+1).tri,'decouple',mesh(ii).pos,mesh(ii).tri);
+  [newnode, newelem] = surfboolean(mesh(ii+1).pos, mesh(ii+1).tri, 'decouple', mesh(ii).pos,mesh(ii).tri);
   mesh(ii+1).tri = newelem(newelem(:,4)==2,1:3) - size(mesh(ii+1).pos,1);
   mesh(ii+1).pos = newnode(newnode(:,4)==2,1:3);
 end % for
-end % function

--- a/private/prepare_mesh_tetrahedral.m
+++ b/private/prepare_mesh_tetrahedral.m
@@ -79,8 +79,8 @@ else
   % probably a remnant of old code.
   mri = ft_datatype_segmentation(mri, 'segmentationstyle', 'indexed');
   % keep the tissue types as they are
-  seg      = mri.seg;
-  seglabel = mri.seglabel;
+  seg      = mri.tissue;
+  seglabel = mri.tissuelabel;
 end
 
 % this requires the external iso2mesh toolbox

--- a/private/univariate2bivariate.m
+++ b/private/univariate2bivariate.m
@@ -60,9 +60,9 @@ switch dtype
     if strcmp(inparam, 'fourierspctrm') && strcmp(outparam, 'crsspctrm')
       % fourier coefficients -> cross-spectral density
       if dofull
-        data = ft_checkdata(data, 'cmbrepresentation', 'full');
+        data = ft_checkdata(data, 'cmbstyle', 'full');
       else
-        data = ft_checkdata(data, 'cmbrepresentation', 'sparse', 'channelcmb', cmb);
+        data = ft_checkdata(data, 'cmbstyle', 'sparse', 'channelcmb', cmb);
         getpowindx = 1;
       end
     elseif strcmp(inparam, 'fourierspctrm') && strcmp(outparam, 'lcrsspctrm')
@@ -70,18 +70,18 @@ switch dtype
       getpowindx = 1;
     elseif strcmp(inparam, 'powandcsd') && strcmp(outparam, 'crsspctrm')
       if ~isempty(cmb)
-        data = ft_checkdata(data, 'cmbrepresentation', 'sparse', 'channelcmb', cmb);
+        data = ft_checkdata(data, 'cmbstyle', 'sparse', 'channelcmb', cmb);
         % ensure getting powindx later on to prevent crash
         getpowindx = 1;
       else
-        % data = ft_checkdata(data, 'cmbrepresentation', 'full');
+        % data = ft_checkdata(data, 'cmbstyle', 'full');
         % this should not be possible
         ft_error('cannot convert to a full csd representation');
       end
       
     elseif strcmp(inparam, 'fourierspctrm') && strcmp(outparam, 'powcovspctrm')
       % fourier coefficients -> power covariance
-      data = ft_checkdata(data, 'cmbrepresentation', 'sparsewithpow', 'channelcmb', {});
+      data = ft_checkdata(data, 'cmbstyle', 'sparsewithpow', 'channelcmb', {});
       if sqrtflag, data.powspctrm = sqrt(data.powspctrm); end
       % get covariance by using ft_checkdata
       if demeanflag
@@ -95,9 +95,9 @@ switch dtype
       data.cumtapcnt(:) = 1;
       data.cumsumcnt(:) = 1;
       if ncmb < (nchan-1)*nchan*0.5
-        data = ft_checkdata(data, 'cmbrepresentation', 'sparse', 'channelcmb', cmb);
+        data = ft_checkdata(data, 'cmbstyle', 'sparse', 'channelcmb', cmb);
       else
-        data = ft_checkdata(data, 'cmbrepresentation', 'full');
+        data = ft_checkdata(data, 'cmbstyle', 'full');
       end
       data.powcovspctrm = data.crsspctrm;
       data = rmfield(data, 'crsspctrm');
@@ -117,9 +117,9 @@ switch dtype
       data.cumtapcnt(:) = 1;
       data.cumsumcnt(:) = 1;
       if ncmb < (nchan-1)*nchan*0.5
-        data = ft_checkdata(data, 'cmbrepresentation', 'sparse', 'channelcmb', cmb);
+        data = ft_checkdata(data, 'cmbstyle', 'sparse', 'channelcmb', cmb);
       else
-        data = ft_checkdata(data, 'cmbrepresentation', 'full');
+        data = ft_checkdata(data, 'cmbstyle', 'full');
       end
       data.powcovspctrm = data.crsspctrm;
       data = rmfield(data, 'crsspctrm');

--- a/private/volumefillholes.m
+++ b/private/volumefillholes.m
@@ -5,7 +5,7 @@ function [output] = volumefillholes(input, along)
 % See also VOLUMETHRESHOLD, VOLUMESMOOTH
 
 % ensure that SPM is available, needed for spm_bwlabel
-hasspm = ft_hastoolbox('spm8up', 3) || ft_hastoolbox('spm2', 1);
+ft_hastoolbox('spm8up', 3) || ft_hastoolbox('spm2', 1);
 
 if nargin<2
   inflate = false(size(input)+2);                   % grow the edges along each dimension

--- a/test/private/getdimord.m
+++ b/test/private/getdimord.m
@@ -610,6 +610,7 @@ if exist('dimord', 'var') && iscell(data.(field))
   end
 end
 
+
 if ~exist('dimord', 'var')
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   % ATTEMPT 4: there is only one way that the dimensions can be interpreted
@@ -641,6 +642,7 @@ if ~exist('dimord', 'var')
     return
   end
 end % if dimord does not exist
+
 
 if ~exist('dimord', 'var')
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -684,6 +686,7 @@ if ~exist('dimord', 'var')
   end
 end % if dimord does not exist
 
+
 if ~exist('dimord', 'var')
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   % ATTEMPT 6: check whether it is a 3-D volume
@@ -691,12 +694,20 @@ if ~exist('dimord', 'var')
   if isequal(datsiz, [ndim1 ndim2 ndim3])
     dimord = 'dim1_dim2_dim3';
     return
+  elseif isequal(datsiz, [ndim1 ndim2 ndim3 ntime])
+    dimord = 'dim1_dim2_dim3_time';
+    return
+  elseif isequal(datsiz, [ndim1 ndim2 ndim3 nfreq])
+    dimord = 'dim1_dim2_dim3_freq';
+    return
+  elseif isequal(datsiz, [ndim1 ndim2 ndim3 nfreq ntime])
+    dimord = 'dim1_dim2_dim3_freq_time';
+    return
   elseif isfield(data, 'pos') && prod(datsiz)==size(data.pos, 1)
     dimord = 'dim1_dim2_dim3';
     return
   end
 end % if dimord does not exist
-
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/test/test_bug1677.m
+++ b/test/test_bug1677.m
@@ -68,7 +68,7 @@ tmp = ft_freqdescriptives(tmpcfg,freq);
 %     data = fixcsd(data, cmbrepresentation, channelcmb);
 % 
 % Error in ft_freqdescriptives (line 131)
-% freq = ft_checkdata(freq, 'cmbrepresentation', 'sparsewithpow', 'channelcmb', {});
+% freq = ft_checkdata(freq, 'cmbstyle', 'sparsewithpow', 'channelcmb', {});
 %  
 % 740       powspctrm = powspctrm + abs(data.fourierspctrm(p:ntap:end,:,:,:,:)).^2
 

--- a/test/test_bug2005.m
+++ b/test/test_bug2005.m
@@ -25,9 +25,9 @@ f_data = ft_freqanalysis(cfg, data);
 
 % JM hack
 cf_data = f_data;
-cf_data = ft_checkdata(cf_data,'cmbrepresentation','fullfast'); % efficiently compute crsspctrm
-cf_data = ft_checkdata(cf_data,'cmbrepresentation','sparse'); % remove redundancy in channelcomb
-cf_data = ft_checkdata(cf_data,'cmbrepresentation','sparsewithpow'); % restore power data
+cf_data = ft_checkdata(cf_data, 'cmbstyle', 'fullfast'); % efficiently compute crsspctrm
+cf_data = ft_checkdata(cf_data, 'cmbstyle', 'sparse'); % remove redundancy in channelcomb
+cf_data = ft_checkdata(cf_data, 'cmbstyle', 'sparsewithpow'); % restore power data
 % data is now ready to be fed into sourceanalysis
 
 % Source analysis
@@ -51,8 +51,8 @@ sf_data                         = ft_sourceanalysis(cfg, cf_data);
 cfg                             = [];
 cfg.method                      = 'pcc';
 
-cfg.sourcemodel                        = sourceModelGrid;
-cfg.sourcemodel.filter                 = sf_data.avg.filter;
+cfg.sourcemodel                 = sourceModelGrid;
+cfg.sourcemodel.filter          = sf_data.avg.filter;
 cfg.headmodel                   = sourceModelVol;
 cfg.frequency                   = foi;
 

--- a/test/test_bug2148.m
+++ b/test/test_bug2148.m
@@ -7,7 +7,7 @@ function test_bug2148
 % ft_checkdata (ie fixdimord) always wants to reverts dimord to 'chan'
 % although 'labelcmb' is present. The only way to make e.g.
 % ft_connectivitplot work atm is to use:
-% ft_checkdata(data, 'cmbrepresentation', 'full');
+% ft_checkdata(data, 'cmbstyle', 'full');
 % This will make dimord chan_chan_freq and convert labelcmb to label.
 
 cfg             = [];
@@ -57,7 +57,7 @@ cfgp.refchannel = 'AFz';
 ft_topoplotTFR(cfgp, c1);
 
 % do JM's juicy transforms
-tmp = ft_checkdata(freq, 'cmbrepresentation', 'fullfast');
+tmp = ft_checkdata(freq, 'cmbstyle', 'fullfast');
 c1             = ft_connectivityanalysis(cfgc, freq);
 try
   ft_freqdescriptives([], tmp);
@@ -86,7 +86,7 @@ cfgs.frequency = 10;
 cfgs.elecfile = 'standard_1020.elc';
 ft_sourceanalysis(cfgs, tmp);
 
-tmp = ft_checkdata(tmp, 'cmbrepresentation', 'sparse');
+tmp = ft_checkdata(tmp, 'cmbstyle', 'sparse');
 c1             = ft_connectivityanalysis(cfgc, freq);
 try
   ft_freqdescriptives([], tmp);
@@ -113,7 +113,7 @@ cfgs.elecfile = 'standard_1020.elc';
 ft_sourceanalysis(cfgs, tmp);
 
 
-tmp = ft_checkdata(tmp, 'cmbrepresentation', 'sparsewithpow');
+tmp = ft_checkdata(tmp, 'cmbstyle', 'sparsewithpow');
 c1             = ft_connectivityanalysis(cfgc, freq);
 ft_freqdescriptives([], tmp);
 ft_topoplotTFR(cfgp, c1);

--- a/test/test_bug2639.m
+++ b/test/test_bug2639.m
@@ -47,39 +47,39 @@ assert(isequal(freq2o.fourierspctrm(:,selo,:), freq2r.fourierspctrm(:,selr,:)));
 
 %% full, sparse, fourier, sparsewithpow, fullfast
 
-freq2o = ft_checkdata(freq1o, 'cmbrepresentation', 'fourier');
-freq2r = ft_checkdata(freq1r, 'cmbrepresentation', 'fourier');
+freq2o = ft_checkdata(freq1o, 'cmbstyle', 'fourier');
+freq2r = ft_checkdata(freq1r, 'cmbstyle', 'fourier');
 [selo, selr] = match_str(freq2o.label, freq2r.label);
 assert(isequal(freq2o.fourierspctrm(:,selo,:), freq2r.fourierspctrm(:,selr,:)));
 
 assert( isequal(freq1r.label,freq2r.label));
 assert(~isequal(freq2o.label,freq2r.label));
 
-freq2o = ft_checkdata(freq1o, 'cmbrepresentation', 'full');
-freq2r = ft_checkdata(freq1r, 'cmbrepresentation', 'full');
+freq2o = ft_checkdata(freq1o, 'cmbstyle', 'full');
+freq2r = ft_checkdata(freq1r, 'cmbstyle', 'full');
 [selo, selr] = match_str(freq2o.label, freq2r.label);
 assert(isequal(freq2o.crsspctrm(selo,selo), freq2r.crsspctrm(selr,selr)));
 
 assert( isequal(freq1r.label,freq2r.label));
 assert(~isequal(freq2o.label,freq2r.label));
 
-freq2o = ft_checkdata(freq1o, 'cmbrepresentation', 'fullfast');
-freq2r = ft_checkdata(freq1r, 'cmbrepresentation', 'fullfast');
+freq2o = ft_checkdata(freq1o, 'cmbstyle', 'fullfast');
+freq2r = ft_checkdata(freq1r, 'cmbstyle', 'fullfast');
 [selo, selr] = match_str(freq2o.label, freq2r.label);
 assert(isequal(freq2o.crsspctrm(selo,selo), freq2r.crsspctrm(selr,selr)));
 
 assert( isequal(freq1r.label,freq2r.label));
 assert(~isequal(freq2o.label,freq2r.label));
 
-freq2o = ft_checkdata(freq1o, 'cmbrepresentation', 'sparse', 'channelcmb', channelcmb);
-freq2r = ft_checkdata(freq1r, 'cmbrepresentation', 'sparse', 'channelcmb', channelcmb);
+freq2o = ft_checkdata(freq1o, 'cmbstyle', 'sparse', 'channelcmb', channelcmb);
+freq2r = ft_checkdata(freq1r, 'cmbstyle', 'sparse', 'channelcmb', channelcmb);
 [selo, selr] = match_strcmb(freq2o.labelcmb, freq2r.labelcmb);
 assert(isequal(freq2o.crsspctrm(selo,:), freq2r.crsspctrm(selr,:)));
 
 assert( isequal(freq2o.labelcmb,freq2r.labelcmb));
 
-freq2o = ft_checkdata(freq1o, 'cmbrepresentation', 'sparsewithpow', 'channelcmb', channelcmb);
-freq2r = ft_checkdata(freq1r, 'cmbrepresentation', 'sparsewithpow', 'channelcmb', channelcmb);
+freq2o = ft_checkdata(freq1o, 'cmbstyle', 'sparsewithpow', 'channelcmb', channelcmb);
+freq2r = ft_checkdata(freq1r, 'cmbstyle', 'sparsewithpow', 'channelcmb', channelcmb);
 [selo, selr] = match_strcmb(freq2o.labelcmb, freq2r.labelcmb);
 assert(isequal(freq2o.crsspctrm(selo,:), freq2r.crsspctrm(selr,:)));
 [selo, selr] = match_str(freq2o.label, freq2r.label);
@@ -120,16 +120,16 @@ assert(isequal(freq2o.powspctrm(selo,:), freq2r.powspctrm(selr,:)));
 [selo, selr] = match_strcmb(freq2o.labelcmb, freq2r.labelcmb);
 assert(isequal(freq2o.crsspctrm(selo,:), freq2r.crsspctrm(selr,:)));
 
-freq2o = ft_checkdata(freq1o, 'cmbrepresentation', 'full');
-freq2r = ft_checkdata(freq1r, 'cmbrepresentation', 'full');
+freq2o = ft_checkdata(freq1o, 'cmbstyle', 'full');
+freq2r = ft_checkdata(freq1r, 'cmbstyle', 'full');
 [selo, selr] = match_str(freq2o.label, freq2r.label);
 assert(isequal(freq2o.crsspctrm(selo,selo), freq2r.crsspctrm(selr,selr)));
 
 % assert( isequal(freq1r.label,freq2r.label)); % this is where the channel reordering becomes clear
 % assert(~isequal(freq2o.label,freq2r.label)); % this is where the channel reordering becomes clear
 
-freq2o = ft_checkdata(freq1o, 'cmbrepresentation', 'fullfast');
-freq2r = ft_checkdata(freq1r, 'cmbrepresentation', 'fullfast');
+freq2o = ft_checkdata(freq1o, 'cmbstyle', 'fullfast');
+freq2r = ft_checkdata(freq1r, 'cmbstyle', 'fullfast');
 [selo, selr] = match_str(freq2o.label, freq2r.label);
 assert(isequal(freq2o.crsspctrm(selo,selo), freq2r.crsspctrm(selr,selr))); % this is where another problem appears
 
@@ -144,4 +144,3 @@ for i=1:size(chancmb2,1)
   chan2{i} = sprintf('%s_%s', chancmb2{i,:});
 end
 [sel1, sel2] = match_str(chan1, chan2);
-

--- a/test/test_bug3359.m
+++ b/test/test_bug3359.m
@@ -46,10 +46,10 @@ cfg.foilim = [0 80];
 cfg.taper  = 'hanning';
 cfg.pad    = 1;
 freq = ft_freqanalysis(cfg, data);
-freq = ft_checkdata(freq, 'cmbrepresentation', 'fullfast');
+freq = ft_checkdata(freq, 'cmbstyle', 'fullfast');
 
 freq_sim = ft_freqanalysis(cfg, data_sim);
-freq_sim = ft_checkdata(freq_sim, 'cmbrepresentation', 'fullfast');
+freq_sim = ft_checkdata(freq_sim, 'cmbstyle', 'fullfast');
 
 cfg = [];
 cfg.method = 'psi';

--- a/test/test_bug46.m
+++ b/test/test_bug46.m
@@ -35,7 +35,7 @@ coh        = ft_connectivityanalysis(cfg, freq);
 %    data = fixcsd(data, cmbrepresentation, channelcmb);
 %
 %Error in ==> ft_connectivityanalysis>univariate2bivariate at 992
-%      data    = checkdata(data, 'cmbrepresentation', 'sparse', 'channelcmb',
+%      data    = checkdata(data, 'cmbstyle', 'sparse', 'channelcmb',
 %      cmb);
 %
 %Error in ==> ft_connectivityanalysis at 138

--- a/test/test_bug896.m
+++ b/test/test_bug896.m
@@ -8,8 +8,8 @@ load(dccnpath('/home/common/matlab/fieldtrip/data/test/bug896.mat'));
 
 ft_checkdata(stat_coh, 'datatype', 'freq');
 ft_checkdata(stat_coh_full, 'datatype', 'freq');
-ft_checkdata(stat_coh, 'datatype', 'freq', 'cmbrepresentation', 'full');
-ft_checkdata(stat_coh_full, 'datatype', 'freq', 'cmbrepresentation', 'full');
+ft_checkdata(stat_coh, 'datatype', 'freq', 'cmbstyle', 'full');
+ft_checkdata(stat_coh_full, 'datatype', 'freq', 'cmbstyle', 'full');
 
 if ~ft_datatype(stat_coh, 'freq')
   error('ft_datatype failed on the "stat_coh" input data');

--- a/test/test_ft_topoplotER.m
+++ b/test/test_ft_topoplotER.m
@@ -96,10 +96,10 @@ cfg.parameter = 'cohspctrm';
 % cfg.refchannel = 'gui';
 cfg.refchannel = freq2.label{5};
 
-coh2 = ft_checkdata(coh2, 'cmbrepresentation', 'full');
+coh2 = ft_checkdata(coh2, 'cmbstyle', 'full');
 figure; ft_topoplotER(cfg, coh2);drawnow
 
-coh2 = ft_checkdata(coh2, 'cmbrepresentation', 'sparse');
+coh2 = ft_checkdata(coh2, 'cmbstyle', 'sparse');
 figure; ft_topoplotER(cfg, coh2);drawnow
 
 %create connectivity-data with very sparse linear indexing
@@ -116,11 +116,11 @@ coh4 = ft_connectivityanalysis(cfgc2, freq2);
 %plot
 cfg.refchannel = freq2.label{5};
 
-coh2 = ft_checkdata(coh2, 'cmbrepresentation', 'full');
+coh2 = ft_checkdata(coh2, 'cmbstyle', 'full');
 figure; ft_topoplotER(cfg, coh4);drawnow
 
 %plot: this works
-coh2 = ft_checkdata(coh2, 'cmbrepresentation', 'sparse');
+coh2 = ft_checkdata(coh2, 'cmbstyle', 'sparse');
 figure; ft_topoplotER(cfg, coh4);drawnow
 
 %create connectivity-data with asymmetry

--- a/test/test_old_fixcsd.m
+++ b/test/test_old_fixcsd.m
@@ -18,38 +18,38 @@ freq.cfg    = [];
 
 channelcmb = ft_channelcombination({'all' 'all'}, freq.label, 1);
 
-f1 = ft_checkdata(freq, 'cmbrepresentation', 'full');
-f2 = ft_checkdata(freq, 'cmbrepresentation', 'sparsewithpow', 'channelcmb', channelcmb(1,:));
-f3 = ft_checkdata(freq, 'cmbrepresentation', 'sparse', 'channelcmb', channelcmb);
+f1 = ft_checkdata(freq, 'cmbstyle', 'full');
+f2 = ft_checkdata(freq, 'cmbstyle', 'sparsewithpow', 'channelcmb', channelcmb(1,:));
+f3 = ft_checkdata(freq, 'cmbstyle', 'sparse', 'channelcmb', channelcmb);
 
 f1f = f1;
-f2f = ft_checkdata(f2, 'cmbrepresentation', 'full');
-f3f = ft_checkdata(f3, 'cmbrepresentation', 'full');
+f2f = ft_checkdata(f2, 'cmbstyle', 'full');
+f3f = ft_checkdata(f3, 'cmbstyle', 'full');
 
-f1f2  = ft_checkdata(f1f, 'cmbrepresentation', 'sparse');
-f1f2f = ft_checkdata(f1f2, 'cmbrepresentation', 'full');
+f1f2  = ft_checkdata(f1f, 'cmbstyle', 'sparse');
+f1f2f = ft_checkdata(f1f2, 'cmbstyle', 'full');
 
 c3 = f3;
 c3.cohspctrm = f3.crsspctrm;
-c3f = ft_checkdata(c3, 'cmbrepresentation', 'full');
-c3s = ft_checkdata(c3f, 'cmbrepresentation', 'sparse');
+c3f = ft_checkdata(c3, 'cmbstyle', 'full');
+c3s = ft_checkdata(c3f, 'cmbstyle', 'sparse');
 
 c1 = f1f2;
 c1.cohspctrm = c1.crsspctrm;
-c1f = ft_checkdata(c1, 'cmbrepresentation', 'full');
-c1s = ft_checkdata(c1f, 'cmbrepresentation', 'sparse');
+c1f = ft_checkdata(c1, 'cmbstyle', 'full');
+c1s = ft_checkdata(c1f, 'cmbstyle', 'sparse');
 
 cfg = [];
 cfg.method = 'coh';
 cfg.channelcmb = channelcmb(1,:);
 coh = ft_connectivityanalysis(cfg, freq);
-coh2 = ft_checkdata(coh, 'cmbrepresentation', 'sparse');
+coh2 = ft_checkdata(coh, 'cmbstyle', 'sparse');
 
 cfg = [];
 cfg.method = 'granger';
 
 g = ft_connectivityanalysis(cfg, freq);
-g2 = ft_checkdata(g, 'cmbrepresentation', 'sparse');
+g2 = ft_checkdata(g, 'cmbstyle', 'sparse');
 
 %this part tests the code which aims at speeding up the fourier->full conversion if all(freq.cumtapcnt==freq.cumtapcnt(1))
 
@@ -64,4 +64,4 @@ freq.label  = {'a';'b';'c';'d';'e';'f';'g';'h';'i';'j';'k';'l';'m';'n';'o';'p';'
 freq.cumtapcnt = 3*ones(3000,1);
 freq.cfg    = [];
 
-freqx = ft_checkdata(freq, 'cmbrepresentation', 'full');
+freqx = ft_checkdata(freq, 'cmbstyle', 'full');

--- a/test/test_old_ft_multiplotER.m
+++ b/test/test_old_ft_multiplotER.m
@@ -75,9 +75,9 @@ coh2  = ft_connectivityanalysis(cfgc2, freqx);
 
 %plot
 cfg.refchannel = 'Cz';
-coh2 = ft_checkdata(coh2, 'cmbrepresentation', 'full');
+coh2 = ft_checkdata(coh2, 'cmbstyle', 'full');
 ft_multiplotER(cfg, coh2);
-coh2 = ft_checkdata(coh2, 'cmbrepresentation', 'sparse');
+coh2 = ft_checkdata(coh2, 'cmbstyle', 'sparse');
 ft_multiplotER(cfg, coh2);
 
 %create connectivity-data with very sparse linear indexing

--- a/test/test_old_ft_singleplotER.m
+++ b/test/test_old_ft_singleplotER.m
@@ -67,9 +67,9 @@ coh2  = ft_connectivityanalysis(cfgc2, freqx);
 
 %plot
 cfg.refchannel = 'Cz';
-coh2 = ft_checkdata(coh2, 'cmbrepresentation', 'full');
+coh2 = ft_checkdata(coh2, 'cmbstyle', 'full');
 ft_singleplotER(cfg, coh2);
-coh2 = ft_checkdata(coh2, 'cmbrepresentation', 'full');
+coh2 = ft_checkdata(coh2, 'cmbstyle', 'full');
 ft_singleplotER(cfg, coh2);
 
 %create connectivity-data with very sparse linear indexing

--- a/test/test_prepare_freq_matrices.m
+++ b/test/test_prepare_freq_matrices.m
@@ -338,7 +338,7 @@ elseif isfield(freq, 'crsspctrm')
   % think of incorporating 'quickflag' to speed up the
   % computation from fourierspectra when single trial
   % estimates are not required...
-  freq = ft_checkdata(freq, 'cmbrepresentation', 'full');
+  freq = ft_checkdata(freq, 'cmbstyle', 'full');
   
   [dum, sensindx] = match_str(cfg.channel, freq.label);
   powspctrmindx = sensindx;

--- a/test/test_pull1427.m
+++ b/test/test_pull1427.m
@@ -31,7 +31,7 @@ segprob.transform(3,4) = -0.5;
 segindx = ft_datatype_segmentation(segprob, 'segmentationstyle', 'indexed');
 
 cfg = [];
-cfg.funparameter = 'seg';
+cfg.funparameter = 'tissue';
 cfg.method = 'ortho';
 cfg.location = [5 5 5]; % this is the center of the volume, in this plot it will be rounded off to the nearest voxel
 ft_sourceplot(cfg, segindx);
@@ -50,7 +50,7 @@ cfg.method = 'hexahedral';
 mesh_vol_hex1 = ft_prepare_mesh(cfg, segprob);
 
 figure
-ft_plot_ortho(segindx.seg, 'transform', segindx.transform, 'location', [5 5 5], 'style', 'intersect');
+ft_plot_ortho(segindx.tissue, 'transform', segindx.transform, 'location', [5 5 5], 'style', 'intersect');
 hold on
 ft_plot_mesh(mesh_vol_hex1, 'surfaceonly', false, 'facecolor', 'none', 'edgecolor', 'm');
 view(120, 30)
@@ -79,8 +79,8 @@ mesh_vol_hex2 = ft_prepare_mesh(cfg, segprob2);
 
 % this one looks OK in terms of alignment
 figure
-% ft_plot_ortho(segindx.seg, 'transform', segindx.transform, 'location', [5 5 5], 'style', 'intersect');
-ft_plot_ortho(segindx2.seg, 'transform', segindx2.transform, 'location', [5 5 5], 'style', 'intersect'); % this one looks OK in terms of alignment
+% ft_plot_ortho(segindx.tissue, 'transform', segindx.transform, 'location', [5 5 5], 'style', 'intersect');
+ft_plot_ortho(segindx2.tissue, 'transform', segindx2.transform, 'location', [5 5 5], 'style', 'intersect'); % this one looks OK in terms of alignment
 hold on
 ft_plot_mesh(mesh_vol_hex2, 'surfaceonly', false, 'facecolor', 'none', 'edgecolor', 'm');
 view(120, 30)
@@ -108,9 +108,9 @@ cfg.method = 'hexahedral';
 mesh_vol_hex3 = ft_prepare_mesh(cfg, segprob3);
 
 figure
-% ft_plot_ortho(segindx.seg, 'transform', segindx.transform, 'location', [5 5 5], 'style', 'intersect');
-% ft_plot_ortho(segindx2.seg, 'transform', segindx2.transform, 'location', [5 5 5], 'style', 'intersect');
-ft_plot_ortho(segindx3.seg, 'transform', segindx3.transform, 'location', [5 5 5], 'style', 'intersect'); % this one looks OK in terms of alignment
+% ft_plot_ortho(segindx.tissue, 'transform', segindx.transform, 'location', [5 5 5], 'style', 'intersect');
+% ft_plot_ortho(segindx2.tissue, 'transform', segindx2.transform, 'location', [5 5 5], 'style', 'intersect');
+ft_plot_ortho(segindx3.tissue, 'transform', segindx3.transform, 'location', [5 5 5], 'style', 'intersect'); % this one looks OK in terms of alignment
 hold on
 ft_plot_mesh(mesh_vol_hex3, 'surfaceonly', false, 'facecolor', 'none', 'edgecolor', 'm');
 view(120, 30)
@@ -127,7 +127,7 @@ cfg.method = 'tetrahedral';
 mesh_vol_tet = ft_prepare_mesh(cfg, segprob);
 
 figure
-ft_plot_ortho(segindx.seg, 'transform', segindx.transform, 'location', [5 5 5], 'style', 'intersect');
+ft_plot_ortho(segindx.tissue, 'transform', segindx.transform, 'location', [5 5 5], 'style', 'intersect');
 hold on
 ft_plot_mesh(mesh_vol_tet, 'surfaceonly', false, 'facecolor', 'none', 'edgecolor', 'm');
 view(120, 30)

--- a/test/test_pull1663.m
+++ b/test/test_pull1663.m
@@ -11,7 +11,7 @@ function test_pull1663
 % The structure of this script is more or less
 % 1. create input data (dull segmentation, hex and tet meshes, dipoles, sensors)
 % 2. compute and compare MEG leadfield for hex and tet meshes
-%   a. create volume conductor (ft_prepare_headmodel) 
+%   a. create volume conductor (ft_prepare_headmodel)
 %   b. create source grid (ft_prepare_sourcemodel)
 %   c. compute leadfield (ft_prepare_leadfield)
 %   d. compare hex leadfield with tet leadfield
@@ -28,8 +28,8 @@ segprob = [];
 segprob.brain = false(10,10,10); segprob.brain(4:7,4:7,4:7) = true;
 segprob.skull = false(10,10,10); segprob.skull(3:8,3:8,3:8) = true;
 segprob.scalp = false(10,10,10); segprob.scalp(2:9,2:9,2:9) = true;
-% segprob.air = true(10,10,10);
-% segprob.air(2:9,2:9,2:9) = false;
+%segprob.air = true(10,10,10);
+%segprob.air(2:9,2:9,2:9) = false;
 %segprob.brain = false(11,11,11); segprob.brain(4:8,4:8,4:8) = true;
 %segprob.skull = false(11,11,11); segprob.skull(3:9,3:9,3:9) = true;
 %segprob.scalp = false(11,11,11); segprob.scalp(2:10,2:10,2:10) = true;
@@ -41,12 +41,12 @@ segprob.transform(1,4) = -0.5;
 segprob.transform(2,4) = -0.5;
 segprob.transform(3,4) = -0.5;
 
-% visualize the segmentation 
+% visualize the segmentation
 % it is more difficult to visualize a probabilistic segmentation than an indexed one
 segindx = ft_datatype_segmentation(segprob, 'segmentationstyle', 'indexed');
 
 cfg = [];
-cfg.funparameter = 'seg';
+cfg.funparameter = 'tissue';
 cfg.method = 'ortho';
 cfg.location = [5 5 5]; % this is the center of the volume, in this plot it will be rounded off to the nearest voxel
 ft_sourceplot(cfg, segindx);
@@ -58,7 +58,7 @@ cfg.method = 'hexahedral';
 mesh_vol_hex = ft_prepare_mesh(cfg, segprob);
 
 figure
-ft_plot_ortho(segindx.seg, 'transform', segindx.transform, 'location', [5 5 5], 'style', 'intersect');
+ft_plot_ortho(segindx.tissue, 'transform', segindx.transform, 'location', [5 5 5], 'style', 'intersect');
 hold on
 ft_plot_mesh(mesh_vol_hex, 'surfaceonly', false, 'facecolor', 'none', 'edgecolor', 'm');
 view(120, 30)
@@ -71,18 +71,18 @@ mesh_vol_tet = ft_prepare_mesh(cfg, segprob);
 
 
 figure
-ft_plot_ortho(segindx.seg, 'transform', segindx.transform, 'location', [5 5 5], 'style', 'intersect');
+ft_plot_ortho(segindx.tissue, 'transform', segindx.transform, 'location', [5 5 5], 'style', 'intersect');
 hold on
 ft_plot_mesh(mesh_vol_tet, 'surfaceonly', false, 'facecolor', 'none', 'edgecolor', 'm');
 view(120, 30)
 
 %% define sensors
 
-% i manually passed 5 coils and fixed projections 
+% i manually passed 5 coils and fixed projections
 % or maybe take some from a ctf file? something like this (from test_pull1377.m)
 
 % for MEG data + sensor info
-% 
+%
 % load(dccnpath('/home/common/matlab/fieldtrip/data/test/latest/raw/meg/preproc_ctf151.mat'), 'data');
 % datameg = data;
 % clear data
@@ -91,7 +91,7 @@ coils = [5 5 12; 5 12 5; -2 5 5; 12 5 5; 5 -2 5];
 projections = [0 0 1 ; 0 1 0; -1 0 0; 1 0 0; 0 -1 0 ];
 
 figure
-ft_plot_ortho(segindx.seg, 'transform', segindx.transform, 'location', [5 5 5], 'style', 'intersect');
+ft_plot_ortho(segindx.tissue, 'transform', segindx.transform, 'location', [5 5 5], 'style', 'intersect');
 hold on
 quiver3(coils(:,1),coils(:,2),coils(:,3),projections(:,1),projections(:,2),projections(:,3),'bo')
 
@@ -116,7 +116,7 @@ dip_pos = [5.5 6.5 6.5; 5.5 5.5 3.5; 3.5 5.5 5.5];
 dip_mom = [0 1 0; 0 0 -1; -1 0 0 ];
 
 figure
-ft_plot_ortho(segindx.seg, 'transform', segindx.transform, 'location', [5 5 5], 'style', 'intersect');
+ft_plot_ortho(segindx.tissue, 'transform', segindx.transform, 'location', [5 5 5], 'style', 'intersect');
 hold on
 quiver3(dip_pos(:,1),dip_pos(:,2),dip_pos(:,3),dip_mom(:,1),dip_mom(:,2),dip_mom(:,3),'bo')
 view(-200, 15)

--- a/test/test_pull1745.m
+++ b/test/test_pull1745.m
@@ -1,4 +1,4 @@
-% function test_pullXXX
+function test_pull1745
 
 % WALLTIME 00:10:00
 % MEMORY 4gb

--- a/test/test_pull1745.m
+++ b/test/test_pull1745.m
@@ -89,7 +89,7 @@ ft_sourceplot(cfg, parcellation4d);
 %
 
 cfg = [];
-cfg.parcellation = 'seg';
+cfg.parcellation = 'tissue';
 rawdata3d = ft_sourceparcellate(cfg, source3d, parcellation3d);
 rawdata4d = ft_sourceparcellate(cfg, source4d, parcellation4d);
 

--- a/test/test_pullXXX.m
+++ b/test/test_pullXXX.m
@@ -1,4 +1,4 @@
-function test_pull
+% function test_pullXXX
 
 % WALLTIME 00:10:00
 % MEMORY 3gb
@@ -81,10 +81,9 @@ cfg.funparameter = 'seg';
 cfg.funcolormap = 'jet';
 ft_sourceplot(cfg, parcellation4d);
 
-
 %%
 
 cfg = [];
 cfg.parcellation = 'seg';
-source3d_sparse = ft_sourceparcellate(cfg, source3d, parcellation3d);
-source4d_sparse = ft_sourceparcellate(cfg, source4d, parcellation4d);
+rawdata3d = ft_sourceparcellate(cfg, source3d, parcellation3d);
+rawdata4d = ft_sourceparcellate(cfg, source4d, parcellation4d);

--- a/test/test_pullXXX.m
+++ b/test/test_pullXXX.m
@@ -1,0 +1,90 @@
+function test_pull
+
+% WALLTIME 00:10:00
+% MEMORY 3gb
+
+filename3d = dccnpath('/home/common/matlab/fieldtrip/data/test/original/mri/nifti/sub-01_ses-mri_acq-mprage_T1w.nii');                    % 3D anatomical
+filename4d = dccnpath('/home/common/matlab/fieldtrip/data/test/original/mri/nifti/sub-01_ses-mri_task-facerecognition_run-01_bold.nii');  % 4D functional
+
+%%
+
+volume3d = ft_read_mri(filename3d);
+volume4d = ft_read_mri(filename4d, 'outputfield', 'functional');
+
+volume4d.avg = mean(volume4d.functional, 4);
+volume4d.std = std(volume4d.functional, [], 4);
+
+tr = volume4d.hdr.niftihdr.pixdim(4);
+
+volume3d = ft_checkdata(volume3d, 'datatype', 'volume', 'insidestyle', 'logical');
+volume4d = ft_checkdata(volume4d, 'datatype', 'volume', 'insidestyle', 'logical');
+
+%%
+
+figure
+ft_plot_ortho(volume3d.anatomy, 'transform', volume3d.transform, 'style', 'intersect');
+ft_plot_ortho(volume4d.std, 'transform', volume4d.transform, 'style', 'intersect', 'colormap', 'jet');
+
+%%
+
+source3d = ft_checkdata(volume3d, 'datatype', 'source');
+source4d = ft_checkdata(volume4d, 'datatype', 'source'); % note the warning: could not determine dimord of "functional"
+
+% add the time axis that describes the 4th dimension of the functional data
+source4d.time = (0:volume4d.dim(4)-1) * tr;
+% reshape the functional data
+source4d = ft_checkdata(source4d, 'datatype', 'source');
+
+
+%%
+
+cfg = [];
+cfg.anaparameter = [];
+cfg.funparameter = 'std';
+cfg.funcolormap = 'jet';
+ft_sourceplot(cfg, source4d);
+
+%%
+
+% convert the representation into "indexed"
+parcellation3d = rmfield(source3d, 'anatomy');
+
+% make three huge parcels: each is a slab of 33% of the whole volume
+% this first representation is "probabilistic"
+parcellation3d.roi1 = false(parcellation3d.dim); parcellation3d.roi1(1:end,1:end,1:64) = true;
+parcellation3d.roi2 = false(parcellation3d.dim); parcellation3d.roi2(1:end,1:end,65:128) = true;
+parcellation3d.roi3 = false(parcellation3d.dim); parcellation3d.roi3(1:end,1:end,129:192) = true;
+
+parcellation3d = ft_checkdata(parcellation3d, 'type', 'parcellation', 'parcellationstyle', 'indexed')
+
+%%
+
+cfg = [];
+cfg.anaparameter = [];
+cfg.funparameter = 'seg';
+cfg.funcolormap = 'jet';
+ft_sourceplot(cfg, parcellation3d);
+
+%%
+
+% interpolate the 3D parcellation onto the voxel positions of the lower resolution 4D representation
+cfg = [];
+cfg.parameter = 'all';
+cfg.interpmethod = 'nearest';
+parcellation4d = ft_sourceinterpolate(cfg, parcellation3d, source4d)
+
+%%
+
+cfg = [];
+cfg.anaparameter = [];
+cfg.funparameter = 'seg';
+cfg.funcolormap = 'jet';
+ft_sourceplot(cfg, parcellation4d);
+
+
+%%
+
+cfg = [];
+cfg.parcellation = 'seg';
+source3d_sparse = ft_sourceparcellate(cfg, source3d, parcellation3d);
+source4d_sparse = ft_sourceparcellate(cfg, source4d, parcellation4d);

--- a/test/test_pullXXX.m
+++ b/test/test_pullXXX.m
@@ -1,7 +1,7 @@
 % function test_pullXXX
 
 % WALLTIME 00:10:00
-% MEMORY 3gb
+% MEMORY 4gb
 
 filename3d = dccnpath('/home/common/matlab/fieldtrip/data/test/original/mri/nifti/sub-01_ses-mri_acq-mprage_T1w.nii');                    % 3D anatomical
 filename4d = dccnpath('/home/common/matlab/fieldtrip/data/test/original/mri/nifti/sub-01_ses-mri_task-facerecognition_run-01_bold.nii');  % 4D functional
@@ -35,7 +35,6 @@ source4d.time = (0:volume4d.dim(4)-1) * tr;
 % reshape the functional data
 source4d = ft_checkdata(source4d, 'datatype', 'source');
 
-
 %%
 
 cfg = [];
@@ -46,44 +45,72 @@ ft_sourceplot(cfg, source4d);
 
 %%
 
-% convert the representation into "indexed"
+% the next sequence of steps does
+% - define ROIs on basis of the original 3D anatomical data
+% - interpolate the ROIs from the 3D onto the 4D representation
+% - average the non-interpolated functional data over some parcels
+
+% make a structure with subject-specific ROIs from the original 3D anatomical representation
 parcellation3d = rmfield(source3d, 'anatomy');
 
-% make three huge parcels: each is a slab of 33% of the whole volume
+% make three ROIs or parcels: each is a slab that spans 1/3rd of the whole volume
 % this first representation is "probabilistic"
 parcellation3d.roi1 = false(parcellation3d.dim); parcellation3d.roi1(1:end,1:end,1:64) = true;
 parcellation3d.roi2 = false(parcellation3d.dim); parcellation3d.roi2(1:end,1:end,65:128) = true;
 parcellation3d.roi3 = false(parcellation3d.dim); parcellation3d.roi3(1:end,1:end,129:192) = true;
 
+% this converts it to an "indexed" representation
 parcellation3d = ft_checkdata(parcellation3d, 'type', 'parcellation', 'parcellationstyle', 'indexed')
 
-%%
+%
 
 cfg = [];
 cfg.anaparameter = [];
-cfg.funparameter = 'seg';
+cfg.funparameter = 'tissue';
 cfg.funcolormap = 'jet';
 ft_sourceplot(cfg, parcellation3d);
 
-%%
+%
 
-% interpolate the 3D parcellation onto the voxel positions of the lower resolution 4D representation
+% interpolate the 3D tissue parcellation onto the voxel positions of the lower resolution 4D representation
 cfg = [];
 cfg.parameter = 'all';
 cfg.interpmethod = 'nearest';
 parcellation4d = ft_sourceinterpolate(cfg, parcellation3d, source4d)
 
-%%
+%
 
 cfg = [];
 cfg.anaparameter = [];
-cfg.funparameter = 'seg';
+cfg.funparameter = 'tissue';
 cfg.funcolormap = 'jet';
 ft_sourceplot(cfg, parcellation4d);
 
-%%
+%
 
 cfg = [];
 cfg.parcellation = 'seg';
 rawdata3d = ft_sourceparcellate(cfg, source3d, parcellation3d);
 rawdata4d = ft_sourceparcellate(cfg, source4d, parcellation4d);
+
+%%
+
+[ftver, ftpath] = ft_version;
+atlas = ft_read_atlas(fullfile(ftpath, 'template', 'atlas', 'aal', 'ROI_MNI_V4.nii'));
+
+%%
+
+% the next sequence of steps would be to
+% - interpolate the 4D functional data onto the 3D anatomical
+% - spatially transform both the 3D and the 4D to the MNI template
+% - interpolate the atlas onto the 3D and 4D representation
+% - average the interpolated and transformed functional data over some parcels
+
+%%
+
+% the next sequence of steps would be to
+% - spatially transform the atlas to the 3D anatomical
+% - interpolate the atlas onto the 3D and 4D representation
+% - average the non-interpolated functional data over some parcels
+
+

--- a/test/test_tutorial_connectivity.m
+++ b/test/test_tutorial_connectivity.m
@@ -105,7 +105,7 @@ freq          = ft_freqanalysis(cfg, data);
 figure;
 cfg = [];
 cfg.channel = 'signal001';
-ft_singleplotER(cfg, ft_checkdata(freq, 'cmbrepresentation', 'sparsewithpow'))
+ft_singleplotER(cfg, ft_checkdata(freq, 'cmbstyle', 'sparsewithpow'))
 %% connectivityanalysis
 cfg           = [];
 cfg.method    = 'coh';

--- a/utilities/ft_checkdata.m
+++ b/utilities/ft_checkdata.m
@@ -771,13 +771,13 @@ if isequal(current, desired)
   % nothing to do
   
 elseif strcmp(current, 'fourier') && strcmp(desired, 'sparsewithpow')
-  if startsWith(dimord, 'rpttap')
+  if startsWith(data.dimord, 'rpttap')
     nrpt = size(data.cumtapcnt,1);
   else
     nrpt = 1;
   end
-  if contains(dimord, 'freq'), nfrq = length(data.freq); else nfrq = 1; end
-  if contains(dimord, 'time'), ntim = length(data.time); else ntim = 1; end
+  if contains(data.dimord, 'freq'), nfrq = length(data.freq); else nfrq = 1; end
+  if contains(data.dimord, 'time'), ntim = length(data.time); else ntim = 1; end
   
   fastflag = all(data.cumtapcnt(:)==data.cumtapcnt(1));
   flag     = nrpt==1; % needed to truncate the singleton dimension upfront
@@ -859,13 +859,13 @@ elseif strcmp(current, 'fourier') && strcmp(desired, 'sparsewithpow')
   
 elseif strcmp(current, 'fourier') && strcmp(desired, 'sparse')
   if isempty(channelcmb), ft_error('no channel combinations are specified'); end
-  if startsWith(dimord, 'rpttap')
+  if startsWith(data.dimord, 'rpttap')
     nrpt = size(data.cumtapcnt,1);
   else
     nrpt = 1;
   end
-  if contains(dimord, 'freq'), nfrq = length(data.freq); else nfrq = 1; end
-  if contains(dimord, 'time'), ntim = length(data.time); else ntim = 1; end
+  if contains(data.dimord, 'freq'), nfrq = length(data.freq); else nfrq = 1; end
+  if contains(data.dimord, 'time'), ntim = length(data.time); else ntim = 1; end
   
   flag      = nrpt==1; % flag needed to squeeze first dimension if singleton
   ncmb      = size(channelcmb,1);
@@ -947,15 +947,15 @@ elseif strcmp(current, 'fourier') && strcmp(desired, 'sparse')
   
 elseif strcmp(current, 'fourier') && strcmp(desired, 'full')
   % this is how it is currently and the desired functionality of prepare_freq_matrices
-  if startsWith(dimord, 'rpttap')
+  if startsWith(data.dimord, 'rpttap')
     nrpt = size(data.cumtapcnt, 1);
     flag = 0;
   else
     nrpt = 1;
     flag = 1;
   end
-  if contains(dimord, 'freq'), nfrq = length(data.freq); else nfrq = 1; end
-  if contains(dimord, 'time'), ntim = length(data.time); else ntim = 1; end
+  if contains(data.dimord, 'freq'), nfrq = length(data.freq); else nfrq = 1; end
+  if contains(data.dimord, 'time'), ntim = length(data.time); else ntim = 1; end
   if any(data.cumtapcnt(1,:) ~= data.cumtapcnt(1,1)), ft_error('this only works when all frequencies have the same number of tapers'); end
   nchan     = length(data.label);
   crsspctrm = zeros(nrpt,nchan,nchan,nfrq,ntim);
@@ -991,7 +991,7 @@ elseif strcmp(current, 'fourier') && strcmp(desired, 'fullfast')
   nrpt = size(data.fourierspctrm, 1);
   nchn = numel(data.label);
   nfrq = length(data.freq);
-  if contains(dimord, 'time'), ntim = length(data.time); else ntim = 1; end
+  if contains(data.dimord, 'time'), ntim = length(data.time); else ntim = 1; end
   
   data.fourierspctrm = reshape(data.fourierspctrm, [nrpt nchn nfrq*ntim]);
   data.fourierspctrm(~isfinite(data.fourierspctrm)) = 0;
@@ -1051,9 +1051,9 @@ elseif strcmp(current, 'sparse') && strcmp(desired, 'sparsewithpow')
   end
   
 elseif strcmp(current, 'full') && strcmp(desired, 'sparse')
-  if contains(dimord, 'rpt'),  nrpt = size(data.cumtapcnt,1); else nrpt = 1; end
-  if contains(dimord, 'freq'), nfrq = length(data.freq); else nfrq = 1; end
-  if contains(dimord, 'time'), ntim = length(data.time); else ntim = 1; end
+  if contains(data.dimord, 'rpt'),  nrpt = size(data.cumtapcnt,1); else nrpt = 1; end
+  if contains(data.dimord, 'freq'), nfrq = length(data.freq); else nfrq = 1; end
+  if contains(data.dimord, 'time'), ntim = length(data.time); else ntim = 1; end
   nchan    = length(data.label);
   ncmb     = nchan*nchan;
   labelcmb = cell(ncmb, 2);
@@ -1112,9 +1112,9 @@ elseif strcmp(current, 'sparsewithpow') && strcmp(desired, 'sparse')
   data = rmfield(data, 'label');
   
 elseif strcmp(current, 'sparse') && strcmp(desired, 'full')
-  if contains(dimord, 'rpt'),  nrpt = size(data.cumtapcnt,1); else nrpt = 1; end
-  if contains(dimord, 'freq'), nfrq = length(data.freq); else nfrq = 1; end
-  if contains(dimord, 'time'), ntim = length(data.time); else ntim = 1; end
+  if contains(data.dimord, 'rpt'),  nrpt = size(data.cumtapcnt,1); else nrpt = 1; end
+  if contains(data.dimord, 'freq'), nfrq = length(data.freq); else nfrq = 1; end
+  if contains(data.dimord, 'time'), ntim = length(data.time); else ntim = 1; end
   
   if ~isfield(data, 'label')
     % ensure that the bivariate spectral factorization results can be
@@ -1190,9 +1190,9 @@ elseif strcmp(current, 'sparse') && strcmp(desired, 'full')
   end
   
 elseif strcmp(current, 'sparse') && strcmp(desired, 'fullfast')
-  if contains(dimord, 'rpt'),  nrpt = size(data.cumtapcnt,1); else nrpt = 1; end
-  if contains(dimord, 'freq'), nfrq = length(data.freq); else nfrq = 1; end
-  if contains(dimord, 'time'), ntim = length(data.time); else ntim = 1; end
+  if contains(data.dimord, 'rpt'),  nrpt = size(data.cumtapcnt,1); else nrpt = 1; end
+  if contains(data.dimord, 'freq'), nfrq = length(data.freq); else nfrq = 1; end
+  if contains(data.dimord, 'time'), ntim = length(data.time); else ntim = 1; end
   
   if ~isfield(data, 'label')
     data.label = unique(data.labelcmb(:));

--- a/utilities/ft_datatype_parcellation.m
+++ b/utilities/ft_datatype_parcellation.m
@@ -98,25 +98,22 @@ end
 
 switch parcelversion
   case '2012'
-
-    if isfield(parcellation, 'pnt')
-      parcellation.pos = parcellation.pnt;
-      parcellation = rmfield(parcellation, 'pnt');
-    end
-
     % convert the inside/outside fields, they should be logical rather than an index
     if isfield(parcellation, 'inside')
       parcellation = fixinside(parcellation, 'logical');
     end
 
+    % ensure that it has individual source positions
+    parcellation = fixpos(parcellation);
+
     dim = size(parcellation.pos,1);
 
-    % make a list of fields that represent a parcellation
+    % make a list of fields that possibly represent a parcellation
     fn = fieldnames(parcellation);
     fn = setdiff(fn, 'inside'); % exclude the inside field from any conversions
     sel = false(size(fn));
     for i=1:numel(fn)
-      sel(i) = isnumeric(parcellation.(fn{i})) && numel(parcellation.(fn{i}))==dim;
+      sel(i) = (isnumeric(parcellation.(fn{i})) || islogical(parcellation.(fn{i}))) && numel(parcellation.(fn{i}))==dim;
     end
     % only consider numeric fields of the correct size
     fn = fn(sel);

--- a/utilities/ft_datatype_segmentation.m
+++ b/utilities/ft_datatype_segmentation.m
@@ -121,10 +121,23 @@ end
 
 switch segversion
   case '2012'
-    % determine whether the style of the input fields is probabilistic or indexed
+    % convert the inside/outside fields, they should be logical rather than an index
+    if isfield(segmentation, 'inside')
+      segmentation = fixinside(segmentation, 'logical');
+    end
+
+    % make a list of fields that possibly represent a segmentation
     fn = fieldnames(segmentation);
     fn = setdiff(fn, 'inside'); % exclude the inside field from any conversions
-    [indexed, probabilistic] = determine_segmentationstyle(segmentation, fn, segmentation.dim);
+    sel = false(size(fn));
+    for i=1:numel(fn)
+      sel(i) = (isnumeric(segmentation.(fn{i})) || islogical(segmentation.(fn{i}))) && numel(segmentation.(fn{i}))==prod(segmentation.dim(1:3));
+    end
+    % only consider numeric fields of the correct size
+    fn = fn(sel);
+
+    % determine whether the style of the input fields is probabilistic or indexed
+    [indexed, probabilistic] = determine_segmentationstyle(segmentation, fn, segmentation.dim(1:3));
 
     % ignore the fields that do not contain a segmentation
     sel = indexed | probabilistic;

--- a/utilities/ft_datatype_segmentation.m
+++ b/utilities/ft_datatype_segmentation.m
@@ -205,18 +205,18 @@ switch segversion
         if numel(fn)>1
           ft_error('cannot construct a brain mask on the fly; this requires a single indexed representation');
         else
-          seg      = segmentation.(fn{1});
-          seglabel = segmentation.([fn{1} 'label']);
-          if ~any(strcmp(seglabel, 'brain'))
+          tissue      = segmentation.(fn{1});
+          tissuelabel = segmentation.([fn{1} 'label']);
+          if ~any(strcmp(tissuelabel, 'brain'))
             threshold = 0.5;
             smooth    = 5;
             % ensure that the segmentation contains the brain mask, if not then construct it from gray+white+csf
-            if length(intersect(seglabel, {'gray' 'white' 'csf'}))~=3
+            if length(intersect(tissuelabel, {'gray' 'white' 'csf'}))~=3
               ft_error('cannot construct a brain mask on the fly; this requires gray, white and csf');
             end
-            gray  = seg==find(strcmp(seglabel, 'gray'));
-            white = seg==find(strcmp(seglabel, 'white'));
-            csf   = seg==find(strcmp(seglabel, 'csf'));
+            gray  = tissue==find(strcmp(tissuelabel, 'gray'));
+            white = tissue==find(strcmp(tissuelabel, 'white'));
+            csf   = tissue==find(strcmp(tissuelabel, 'csf'));
             brain = gray + white + csf;
             clear gray white csf seg
             brain = volumesmooth(brain,    smooth,    'brain');

--- a/utilities/ft_datatype_source.m
+++ b/utilities/ft_datatype_source.m
@@ -105,9 +105,17 @@ switch version
     % ensure that it has individual source positions
     source = fixpos(source);
     
-    if isfield(source, 'inside')
-      % ensure that it is always logical
-      source = fixinside(source, 'logical');
+    % ensure that it is always logical
+    source = fixinside(source, 'logical');
+    
+    if isfield(source, 'coordsys')
+      % ensure that it is in lower case
+      source.coordsys = lower(source.coordsys);
+    end
+    
+    if isfield(source, 'unit')
+      % ensure that it is in lower case
+      source.unit = lower(source.unit);
     end
     
     % remove obsolete fields

--- a/utilities/ft_datatype_source.m
+++ b/utilities/ft_datatype_source.m
@@ -105,8 +105,10 @@ switch version
     % ensure that it has individual source positions
     source = fixpos(source);
     
-    % ensure that it is always logical
-    source = fixinside(source, 'logical');
+    if isfield(source, 'inside')
+      % ensure that it is always logical
+      source = fixinside(source, 'logical');
+    end
     
     % remove obsolete fields
     if isfield(source, 'method')
@@ -146,14 +148,6 @@ switch version
       source = rmfield(source, 'avg');
     end
     
-    if isfield(source, 'inside')
-      % the inside is by definition logically indexed
-      probe = find(source.inside, 1, 'first');
-    else
-      % just take the first source position
-      probe = 1;
-    end
-    
     if isfield(source, 'trial') && isstruct(source.trial)
       npos = size(source.pos,1);
       
@@ -176,7 +170,11 @@ switch version
         if iscell(dat)
           datsiz(1) = nrpt; % swap the size of pos with the size of rpt
           val  = cell(npos,1);
-          indx = find(source.inside);
+          if isfield(source, 'inside')
+            indx = find(source.inside);
+          else
+            indx = 1:npos;
+          end
           for k=1:length(indx)
             val{indx(k)}          = nan(datsiz);
             val{indx(k)}(1,:,:,:) = dat{indx(k)};

--- a/utilities/ft_datatype_volume.m
+++ b/utilities/ft_datatype_volume.m
@@ -108,6 +108,9 @@ end
 switch version
   case '2014'
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    % ensure that it is always logical
+    volume = fixinside(volume, 'logical');
+    
     if isfield(volume, 'coordsys')
       % ensure that it is in lower case
       volume.coordsys = lower(volume.coordsys);
@@ -116,11 +119,6 @@ switch version
     if isfield(volume, 'unit')
       % ensure that it is in lower case
       volume.unit = lower(volume.unit);
-    end
-    
-    if isfield(volume, 'inside')
-      % ensure that it is always logical
-      volume = fixinside(volume, 'logical');
     end
     
     if isfield(volume, 'dimord')

--- a/utilities/ft_source2full.m
+++ b/utilities/ft_source2full.m
@@ -52,7 +52,7 @@ end
 
 %%
 
-sourcein = ft_checkdata(sourcein, 'inside', 'logical', 'hasdim', true);
+sourcein = ft_checkdata(sourcein, 'insidestyle', 'logical', 'hasdim', true);
 
 % this assumes that the voxel data are ordered as if in a regularly spaced 3D grid,
 % but with only the inside voxels present

--- a/utilities/ft_source2sparse.m
+++ b/utilities/ft_source2sparse.m
@@ -53,7 +53,7 @@ end
 
 %%
 
-sourcein = ft_checkdata(sourcein, 'datatype', 'source', 'inside', 'logical');
+sourcein = ft_checkdata(sourcein, 'datatype', 'source', 'insidestyle', 'logical');
 
 inside  = find( sourcein.inside(:));
 outside = find(~sourcein.inside(:));

--- a/utilities/private/convert_segmentationstyle.m
+++ b/utilities/private/convert_segmentationstyle.m
@@ -1,8 +1,8 @@
 function segmentation = convert_segmentationstyle(segmentation, fn, dim, style)
 
 % CONVERT_SEGMENTATIONSTYLE is a helper function for converting between probabilistic
-% and indexed representations. It is used by ft_datatype_segmentation and
-% ft_datatype_parcellation.
+% and indexed representations. It is used by FT_DATATYPE_SEGMENTATION and
+% FT_DATATYPE_PARCELLATION.
 %
 % See also FIXSEGMENTATION, DETERMINE_SEGMENTATIONSTYLE
 

--- a/utilities/private/convert_segmentationstyle.m
+++ b/utilities/private/convert_segmentationstyle.m
@@ -10,38 +10,38 @@ switch style
   case 'indexed'
     
     % convert the probabilistic representation to an indexed representation
-    threshold = 0.5;
-    seg       = zeros(dim);
-    seglabel  = cell(1,numel(fn));
+    threshold   = 0.5;
+    tissue      = zeros(dim);
+    tissuelabel = cell(1,numel(fn));
     
     for i=1:length(fn)
       tmp = segmentation.(fn{i})>threshold;
-      if any(seg(tmp(:)))
+      if any(tissue(tmp(:)))
         ft_error('overlapping tissue probability maps cannot be converted to an indexed representation');
         % FIXME in principle it is possible to represent two tissue types at one voxel
       else
-        seg(tmp) = i;
-        seglabel{i} = fn{i};
+        tissue(tmp) = i;
+        tissuelabel{i} = fn{i};
       end
     end
-    segmentation          = rmfield(segmentation, fn);
-    segmentation.seg      = seg;
-    segmentation.seglabel = seglabel;
+    segmentation             = rmfield(segmentation, fn);
+    segmentation.tissue      = tissue;
+    segmentation.tissuelabel = tissuelabel;
     
   case 'probabilistic'
     % convert the indexed representation to a probabilistic one
     for i=1:length(fn)
       fprintf('converting %s\n', fn{i});
-      seg      = segmentation.(fn{i});
-      seglabel = segmentation.([fn{i} 'label']);
-      for j=i:length(seglabel)
-        fprintf('creating probabilistic representation for %s\n', seglabel{j});
-        tmp.(fixname(seglabel{j})) = (seg==j);  % avoid overwriting the existing segmentation
+      tissue      = segmentation.(fn{i});
+      tissuelabel = segmentation.([fn{i} 'label']);
+      for j=i:length(tissuelabel)
+        fprintf('creating probabilistic representation for %s\n', tissuelabel{j});
+        tmp.(fixname(tissuelabel{j})) = (tissue==j);  % avoid overwriting the existing segmentation
       end % for j
       segmentation = rmfield(segmentation,  fn{i}         );
       segmentation = rmfield(segmentation, [fn{i} 'label']);
-      for j=i:length(seglabel)
-        segmentation.(fixname(seglabel{j})) = tmp.(fixname(seglabel{j})); % avoid overwriting the existing segmentation
+      for j=i:length(tissuelabel)
+        segmentation.(fixname(tissuelabel{j})) = tmp.(fixname(tissuelabel{j})); % avoid overwriting the existing segmentation
       end
     end % for i
     

--- a/utilities/private/determine_segmentationstyle.m
+++ b/utilities/private/determine_segmentationstyle.m
@@ -1,8 +1,8 @@
 function [indexed, probabilistic] = determine_segmentationstyle(segmentation, fn, dim)
 
 % DETERMINE_SEGMENTATIONSTYLE is a helper function that determines the type of segmentation
-% contained in each of the fields. It is used by ft_datatype_segmentation and
-% ft_datatype_parcellation.
+% contained in each of the fields. It is used by FT_DATATYPE_SEGMENTATION and
+% FT_DATATYPE_PARCELLATION.
 %
 % See also FIXSEGMENTATION, CONVERT_SEGMENTATIONSTYLE
 

--- a/utilities/private/fixinside.m
+++ b/utilities/private/fixinside.m
@@ -1,4 +1,4 @@
-function [source] = fixinside(source, opt)
+function [source] = fixinside(source, target)
 
 % FIXINSIDE ensures that the region of interest (which is indicated by the
 % field "inside") is consistently defined for source structures and volume
@@ -29,9 +29,8 @@ function [source] = fixinside(source, opt)
 %
 % $Id$
 
-
 if nargin<2
-  opt = 'logical';
+  target = 'logical';
 end
 
 if ~isfield(source, 'inside')
@@ -45,9 +44,9 @@ if ~isfield(source, 'inside')
     % assume that all positions are inside the region of interest
     source.inside  = [1:size(source.pos,1)]';
     source.outside = [];
-  elseif isfield(source, 'dim')
+  elseif isfield(source, 'dim') && isfield(source, 'transform')
     % assume that all positions are inside the region of interest
-    source.inside  = [1:prod(source.dim)]';
+    source.inside  = [1:prod(source.dim(1:3))]';
     source.outside = [];
   end
 end
@@ -59,35 +58,41 @@ end
 
 % determine the format
 if isa(source.inside, 'logical')
-  logicalfmt = 1;
+  current = 'logical';
 elseif all(source.inside(:)==0 | source.inside(:)==1)
   source.inside = logical(source.inside);
-  logicalfmt = 1;
+  current = 'logical';
 else
-  logicalfmt = 0;
+  current = 'indexed';
 end
 
-if ~logicalfmt && strcmp(opt, 'logical')
-  % convert to a logical array
-  if ~isfield(source, 'outside')
-    source.outside = [];
-  end
-  if isfield(source, 'pos')
-    tmp  = false(size(source.pos,1),1);
-  elseif isfield(source, 'dim')
-    tmp  = false(prod(source.dim),1);
-  end
-  tmp(source.inside) = true;
+if strcmp(current, 'indexed') && strcmp(target, 'logical')
+  % remove outside
   if isfield(source, 'outside')
-    tmp(source.outside) = false;
     source = rmfield(source, 'outside');
   end
-  source.inside = tmp(:);
-elseif logicalfmt && strcmp(opt, 'index')
+  % convert inside to a logical array
+  if isfield(source, 'pos')
+    tmp = false(size(source.pos,1), 1);
+  elseif isfield(source, 'dim') && isfield(source, 'transform')
+    tmp = false(source.dim(1:3));
+  end
+  tmp(source.inside) = true;
+  source.inside = tmp;
+  
+elseif strcmp(current, 'logical') && strcmp(target, 'index')
   % convert to a vectors with indices
   tmp = source.inside;
   source.inside  = find( tmp(:));
   source.outside = find(~tmp(:));
-else
-  % nothing to do
+end
+
+if strcmp(target, 'logical')
+  if isfield(source, 'pos')
+    % reshape it so that it matches the positions
+    source.inside = reshape(source.inside, size(source.pos,1), 1);
+  elseif isfield(source, 'dim') && isfield(source, 'transform')
+    % reshape it so that it matches the volume dimensions
+    source.inside = reshape(source.inside, source.dim(1:3));
+  end
 end

--- a/utilities/private/fixsegmentation.m
+++ b/utilities/private/fixsegmentation.m
@@ -1,7 +1,7 @@
 function segmentation = fixsegmentation(segmentation, fn, style)
 
 % FIXSEGMENTATION is a helper function that ensures the segmentation to be internally
-% consistent. It is used by ft_datatype_segmentation and ft_datatype_parcellation.
+% consistent. It is used by FT_DATATYPE_SEGMENTATION and FT_DATATYPE_PARCELLATION.
 %
 % % See also CONVERT_SEGMENTATIONSTYLE, DETERMINE_SEGMENTATIONSTYLE
 

--- a/utilities/private/getdimord.m
+++ b/utilities/private/getdimord.m
@@ -610,6 +610,7 @@ if exist('dimord', 'var') && iscell(data.(field))
   end
 end
 
+
 if ~exist('dimord', 'var')
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   % ATTEMPT 4: there is only one way that the dimensions can be interpreted
@@ -641,6 +642,7 @@ if ~exist('dimord', 'var')
     return
   end
 end % if dimord does not exist
+
 
 if ~exist('dimord', 'var')
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -684,6 +686,7 @@ if ~exist('dimord', 'var')
   end
 end % if dimord does not exist
 
+
 if ~exist('dimord', 'var')
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   % ATTEMPT 6: check whether it is a 3-D volume
@@ -691,12 +694,20 @@ if ~exist('dimord', 'var')
   if isequal(datsiz, [ndim1 ndim2 ndim3])
     dimord = 'dim1_dim2_dim3';
     return
+  elseif isequal(datsiz, [ndim1 ndim2 ndim3 ntime])
+    dimord = 'dim1_dim2_dim3_time';
+    return
+  elseif isequal(datsiz, [ndim1 ndim2 ndim3 nfreq])
+    dimord = 'dim1_dim2_dim3_freq';
+    return
+  elseif isequal(datsiz, [ndim1 ndim2 ndim3 nfreq ntime])
+    dimord = 'dim1_dim2_dim3_freq_time';
+    return
   elseif isfield(data, 'pos') && prod(datsiz)==size(data.pos, 1)
     dimord = 'dim1_dim2_dim3';
     return
   end
 end % if dimord does not exist
-
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/utilities/private/parameterselection.m
+++ b/utilities/private/parameterselection.m
@@ -90,7 +90,7 @@ for i=1:length(param)
       select{end+1} = param{i};
     elseif isfield(data, 'pos') && (prod(dim)==size(data.pos, 1) || dim(1)==size(data.pos,1))
       select{end+1} = param{i};
-    elseif isfield(data, 'dimord') && (isfield(data, 'pos') || isfield(data, 'transform')),
+    elseif isfield(data, 'dimord') && (isfield(data, 'pos') || isfield(data, 'transform'))
       dimtok = tokenize(data.dimord, '_');
       nels   = 1;
       for k=1:numel(dimtok)


### PR DESCRIPTION
This pull request started off from a test script that I wrote following the MEG toolkit. 

The idea is that it should be possible (and not too hard) to convert a 4D fMRI representation into a source representation, and from there into a parcellated raw data representation, i.e. with each channel representing the average over a parcel. 

From there on it would be straight-forward to use the time-domain analysis methods. 

But already at the level of the source  representation it should be possible to use ft_sourcestatistics. 

