### PR TITLE
Update ft_redefinetrial.m

### DIFF
--- a/ft_redefinetrial.m
+++ b/ft_redefinetrial.m
@@ -197,7 +197,7 @@ elseif ~isempty(cfg.offset)
   % shift the time axis from each trial
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   offset = cfg.offset(:);
-  offset = round(offset);
+  offset = round(offset); % this is in samples and hence it must be expressed as integers
   if length(cfg.offset)==1
     offset = repmat(offset, Ntrial, 1);
   end

--- a/ft_redefinetrial.m
+++ b/ft_redefinetrial.m
@@ -197,6 +197,7 @@ elseif ~isempty(cfg.offset)
   % shift the time axis from each trial
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   offset = cfg.offset(:);
+  offset = round(offset);
   if length(cfg.offset)==1
     offset = repmat(offset, Ntrial, 1);
   end


### PR DESCRIPTION
Round offset to integer samples (to avoid unintended random additional offset in the new time arrays after redefining trials).

Optionally, one could give a warning if the difference between offset and round(offset) is larger than some threshold, e.g. on the line before
```
if mean(abs(offset - round(offset))) > .1; warning('Non-integer samples provided as offset, check your data'); end
```

See also issue #1750 .