### PR TITLE
added multitaper feature to ft_connectivity_powcorr_ortho.m

### DIFF
--- a/connectivity/ft_connectivity_powcorr_ortho.m
+++ b/connectivity/ft_connectivity_powcorr_ortho.m
@@ -82,7 +82,7 @@ for k = 1:numel(refindx) % for each source/channel
     zX(:,idx)     = standardise(log10(powX(:,idx)), 2);
   end
   
-  c1 = mean(zX.*zYorth, 2); % take correlation and average over trials+tapers
+  c1 = mean(zX.*zYorth, 2); % take correlation averaging over trials+tapers
   
   %% in the other direction: orthogonalize X wrt Y
   cYnorm = conj(Y./abs(Y));

--- a/test/test_pull1757.m
+++ b/test/test_pull1757.m
@@ -1,4 +1,4 @@
-%function test_pull1757
+function test_pull1757
 
 %addpath('..');
 

--- a/test/test_pull1757.m
+++ b/test/test_pull1757.m
@@ -1,0 +1,47 @@
+%function test_pull1757
+
+%addpath('..');
+
+%% generate data (from test_bug2148)
+cfg             = [];
+cfg.ntrials     = 500;
+cfg.triallength = 1;
+cfg.fsample     = 200;
+cfg.nsignal     = 4;
+cfg.method      = 'ar';
+cfg.params(:,:,1) = [.8   0   0 .2;
+    0  .9  .5  0;
+    .4   0  .5 .3;
+    0  .2   0 .7];
+cfg.params(:,:,2) = [-.5   0   0  0;
+    0 -.8   0  0;
+    0   0 -.2  0;
+    0   0   0 .1];
+cfg.noisecov      = [.3 0  0  0;
+    0 1  0  0;
+    0 0 .2  0;
+    0 0  0  .4];
+[data] = ft_connectivitysimulation(cfg);
+
+%% get multitaper fourierspctr
+cfg = [];
+cfg.method     = 'mtmfft';
+cfg.taper      = 'dpss';      % multitaper
+cfg.output     = 'fourier';
+cfg.keeptapers = 'yes';       % fourier requires keeping tapers
+cfg.keeptrials = 'yes';       % and trials
+cfg.pad        ='nextpow2';
+
+cfg.foi        = 12;
+cfg.tapsmofrq  = 4;
+data_FFT = ft_freqanalysis(cfg, data);
+% fourierspctrm size = ntaper*ntrial x nchan = 7*500 x 4
+
+
+%% use new version of powcorr_ortho
+cfg = [];
+cfg.method = 'powcorr_ortho';
+stat = ft_connectivityanalysis(cfg, data_FFT);
+imagesc(stat.powcorrspctrm);
+
+


### PR DESCRIPTION
As of Jan-Mathijs Schoffelen's 2012 version, orthogonalized power correlation was not implemented for multiple tapers. Instead, multiple tapers were simply averaged and then orthogonalized, which discarded important phase information. Here, we propose to orthogonalize and correlate tapers individually and only then average. Our code was tested in a project in the Siegel lab. Credits to Andrea Ibarra-Chaoul.