### PR TITLE
add option cfg.keepchannel

### DIFF
--- a/external/artinis/ft_nirs_scalpcouplingindex.m
+++ b/external/artinis/ft_nirs_scalpcouplingindex.m
@@ -199,29 +199,30 @@ end
 % remove the bad channels on the original datain (default) or replaces with
 % nans
 chanidx = sci > cfg.threshold;
-chansel=datain.label(chanidx);
-bad_channels=datain.label(~chanidx);
+goodchannel = datain.label( chanidx);
+badchannel  = datain.label(~chanidx);
 
 switch cfg.keepchannel
   case 'no'
     selcfg = [];
-    selcfg.channel = chansel;
+    selcfg.channel = goodchannel;
     dataout = ft_selectdata(selcfg, datain);
-    fprintf('the following channels were removed: ');
+    fprintf('the following channels were removed: '); % to be continued below ...
   case 'nan'
-    dataout=datain;
+    dataout = datain;
     for i = 1:length(datain.trial)
       dataout.trial{i}(~chanidx,:) = nan;
     end
-    % show the user which channels are removed
-    fprintf('the following channels were filled with NaNs: '); 
+    fprintf('the following channels were filled with NaNs: '); % to be continued below ...
+  otherwise
+    error('invalid option for cfg.keepchannel');
 end
 
-% provide the channel feedback
-for i=1:(length(bad_channels)-1)
-  fprintf('\n%s', bad_channels{i});
+% show which channels were removed or filled with NaNs
+for i=1:(length(badchannel)-1)
+  fprintf('\n%s', badchannel{i});
 end
-fprintf('\n%s\n', bad_channels{end});
+fprintf('\n%s\n', badchannel{end});
 
 % this might involve more active checking of whether the input options
 % are consistent with the data and with each other

--- a/external/artinis/ft_nirs_scalpcouplingindex.m
+++ b/external/artinis/ft_nirs_scalpcouplingindex.m
@@ -10,6 +10,9 @@ function dataout = ft_nirs_scalpcouplingindex(cfg, datain)
 %
 %   cfg.threshold    = scalar, the correlation value which has to be
 %                      exceeded to be labelled a 'good' channel (default = 0.75)
+%   cfg.keepchannel = string, determines how to deal with channels that are not selected, can be
+%                      'no'          completely remove deselected channels from the data (default)
+%                      'nan'         fill the channels that are deselected with NaNs
 %
 % To facilitate data-handling and distributed computing you can use
 %   cfg.inputfile   =  ...
@@ -110,6 +113,7 @@ datain = ft_checkdata(datain, 'datatype', 'raw', 'senstype', 'nirs');
 
 % get the options
 cfg.threshold    = ft_getopt(cfg, 'threshold', 0.75);
+cfg.keepchannel = ft_getopt(cfg, 'keepchannel', 'no');
 
 % ensure that the options are valid
 cfg = ft_checkopt(cfg, 'threshold', 'doublescalar');
@@ -192,11 +196,32 @@ while i<nChans
   
 end
 
-% remove the bad channels on the original datain
+% remove the bad channels on the original datain (default) or replaces with
+% nans
 chanidx = sci > cfg.threshold;
-selcfg = [];
-selcfg.channel = datain.label(chanidx);
-dataout = ft_selectdata(selcfg, datain);
+chansel=datain.label(chanidx);
+bad_channels=datain.label(~chanidx);
+
+switch cfg.keepchannel
+  case 'no'
+    selcfg = [];
+    selcfg.channel = chansel;
+    dataout = ft_selectdata(selcfg, datain);
+    fprintf('the following channels were removed: ');
+  case 'nan'
+    dataout=datain;
+    for i = 1:length(datain.trial)
+      dataout.trial{i}(~chanidx,:) = nan;
+    end
+    % show the user which channels are removed
+    fprintf('the following channels were filled with NaNs: '); 
+end
+
+% provide the channel feedback
+for i=1:(length(bad_channels)-1)
+  fprintf('\n%s', bad_channels{i});
+end
+fprintf('\n%s\n', bad_channels{end});
 
 % this might involve more active checking of whether the input options
 % are consistent with the data and with each other


### PR DESCRIPTION
ft_nirs_scalpcouplingindex has now the option cfg.keepchannel. Can be set to 'no' (default, previous behaviour) to remove the bad channels, or to 'nan' to fill the bad channels with nan's.