### PR TITLE
Update xdf2fieldtrip so that it also return events

### DIFF
--- a/test/test_pull1209.m
+++ b/test/test_pull1209.m
@@ -1,0 +1,42 @@
+function test_pull1209
+
+% WALLTIME 00:10:00
+% MEM 2gb
+% DEPENDENCY xdf2fieldtrip
+
+filename = dccnpath('/home/common/matlab/fieldtrip/data/test/pull1209.xdf');
+
+% read the data and events
+[data, event] = xdf2fieldtrip(filename);
+
+% pull the EEG signals towards the baseline
+data.trial{1} = ft_preproc_baselinecorrect(data.trial{1});
+
+% start the time axis at t=0
+data.time{1} = data.time{1} - data.time{1}(1);
+
+%%
+
+figure
+plot(data.time{1}, data.trial{1});
+ax = axis;
+
+%%
+
+for i=1:numel(event)
+  % compute the sample number corresponding to the LSL timestamp
+  event(i).sample = round((event(i).timestamp - data.hdr.FirstTimeStamp)/data.hdr.TimeStampPerSample) + 1;
+  
+  try
+    x(1) = data.time{1}(event(i).sample);
+    x(2) = data.time{1}(event(i).sample);
+    y(1) = ax(3);
+    y(2) = ax(4);
+    
+    h = line(x, y);
+    set(h, 'Color', 'r')
+  catch
+    % events can fall outside the range of the continuous data
+  end
+  
+end

--- a/xdf2fieldtrip.m
+++ b/xdf2fieldtrip.m
@@ -1,4 +1,4 @@
-function data = xdf2fieldtrip(filename, varargin)
+function [data, event] = xdf2fieldtrip(filename, varargin)
 
 % XDF2FIELDTRIP reads continuously sampled data from a XDF file with multiple
 % streams. It upsamples the data of all streams to the highest sampling rate and
@@ -6,24 +6,24 @@ function data = xdf2fieldtrip(filename, varargin)
 % compatible with the output of FT_PREPROCESSING.
 %
 % Use as
-%   data = xdf2fieldtrip(filename, ...)
+%   [data, events] = xdf2fieldtrip(filename, ...)
 %
 % Optional arguments should come in key-value pairs and can include
-%   streamindx      = list, indices of the streams to read (default is all)
-%   sraterange      = range of sampling rate in Hz in data streams to read [lowerbound, upperbound] 
-%   streamkeywords  = cell array of keywords in stream names to index streams to read {keyword1, keyword2}
+%   streamindx      = number or list, indices of the streams to read (default is all)
+%   streamrate      = [lowerbound upperbound], read only data streams within this range of sampling rates (in Hz)
+%   streamkeywords  = cell-array with strings, keywords contained in the stream to read
 %
 % You can also use the standard procedure with FT_DEFINETRIAL and FT_PREPROCESSING
 % for XDF files. This will return (only) the continuously sampled stream with the
 % highest sampling rate, which is typically the EEG.
 %
-% You can use FT_READ_EVENT to read the events from the non-continuous data streams.
-% To get them aligned with the samples in one of the specific data streams, you
-% should specify the corresponding header structure.
+% You can also use FT_READ_EVENT to read the events from the non-continuous data
+% streams. To get them aligned with the samples in one of the specific data streams,
+% you should specify the corresponding header structure.
 %
 % See also FT_PREPROCESSING, FT_DEFINETRIAL, FT_REDEFINETRIAL
 
-% Copyright (C) 2019, Robert Oostenveld
+% Copyright (C) 2019-2021, Robert Oostenveld
 %
 % This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
 % for the documentation and details.
@@ -46,10 +46,21 @@ function data = xdf2fieldtrip(filename, varargin)
 % process the options
 streamindx      = ft_getopt(varargin, 'streamindx');
 streamkeywords  = ft_getopt(varargin, 'streamkeywords');
-sraterange      = ft_getopt(varargin, 'sraterange');
+streamrate      = ft_getopt(varargin, 'streamrate');
 
-% for choosing streams, not more than one method can be selected
-assert(sum(~cellfun(@isempty, {streamindx, streamkeywords, sraterange}))<=1, 'More than one method entered for stream selection: please use only one');
+if isempty(streamrate)
+  % this option used to be called sraterange
+  % on 10 June 2021 it was changed into streamrate for consistency with the other options
+  streamrate = ft_getopt(varargin, 'sraterange');
+end
+
+if length(streamrate)==1
+  % it should be specified as [low high]
+  streamrate = [streamrate streamrate];
+end
+
+% not more than one method can be selected for choosing streams
+assert(sum(~cellfun(@isempty, {streamindx, streamkeywords, streamrate}))<=1, 'you can only use a single method for stream selection');
 
 % ensure this is on the path
 ft_hastoolbox('xdf', 1);
@@ -59,39 +70,33 @@ streams = load_xdf(filename);
 
 % initialize an array of booleans indicating whether the streams are continuous
 iscontinuous = false(size(streams));
- 
-% figure out which streams contain continuous/regular and discrete/irregular data
-for i=1:numel(streams)
-    
-    % if the nominal srate is non-zero, the stream is considered continuous
-    if ~strcmpi(streams{i}.info.nominal_srate, '0')
-        
-       iscontinuous(i) =  true;  
-       
-       if ~isfield(streams{i}.info, 'effective_srate') 
-          
-           % in case effective srate field value is missing, add one
-           num_samples  = numel(streams{i}.time_stamps);
-           t_begin      = streams{i}.time_stamps(1);
-           t_end        = streams{i}.time_stamps(end);
-           duration     = t_end - t_begin;
-           streams{i}.info.effective_srate = (num_samples - 1) / duration;
-           
-           
-       elseif isempty(streams{i}.info.effective_srate)
-           
-           % in case effective srate field value is missing, add one
-           num_samples  = numel(streams{i}.time_stamps);
-           t_begin      = streams{i}.time_stamps(1);
-           t_end        = streams{i}.time_stamps(end);
-           duration     = t_end - t_begin;
-           streams{i}.info.effective_srate = (num_samples - 1) / duration;
-           
-       end 
-       
-    end
 
-end
+% figure out which streams contain continuous/regular, and which ones contain discrete/irregular data
+for i=1:numel(streams)
+  % the stream is considered continuous if the nominal srate is non-zero
+  if str2double(streams{i}.info.nominal_srate)~=0
+    iscontinuous(i) = true;
+    
+    if ~isfield(streams{i}.info, 'effective_srate')
+      % in case effective srate field value is missing, add one
+      num_samples  = numel(streams{i}.time_stamps);
+      t_begin      = streams{i}.time_stamps(1);
+      t_end        = streams{i}.time_stamps(end);
+      duration     = t_end - t_begin;
+      streams{i}.info.effective_srate = (num_samples - 1) / duration;
+      
+    elseif isempty(streams{i}.info.effective_srate)
+      % in case effective srate field value is missing, add one
+      num_samples  = numel(streams{i}.time_stamps);
+      t_begin      = streams{i}.time_stamps(1);
+      t_end        = streams{i}.time_stamps(end);
+      duration     = t_end - t_begin;
+      streams{i}.info.effective_srate = (num_samples - 1) / duration;
+      
+    end
+    
+  end % if nonzero nominal sampling rate
+end % for all streams
 
 % give some feedback
 for i=1:numel(streams)
@@ -102,43 +107,61 @@ for i=1:numel(streams)
   end
 end
 
-% select the streams to continue working with
+% select the streams to continue working based on keywords
 if isempty(streamindx) && isempty(streamkeywords)
-  selected = true(size(streams));
+  haskeyword = true(size(streams));
 else
-  selected = false(size(streams));
+  haskeyword = false(size(streams));
   if ~isempty(streamindx)
-      selected(streamindx) = true;
+    haskeyword(streamindx) = true;
   end
   if ~isempty(streamkeywords)
-      for si = 1:numel(streams)
-          if contains(streams{si}.info.name, streamkeywords)
-               selected(si) = true;
-          end
-      end
+    for i=1:numel(streams)
+      haskeyword(i) = contains(streams{i}.info.name, streamkeywords);
+    end
   end
 end
 
-% select the streams to continue working with by srate
-if isempty(sraterange)
+% select the streams to continue working based on sampling rate
+if isempty(streamrate)
   inrange = true(size(streams));
 else
-  inrange = false(size(streams));  
+  inrange = false(size(streams));
   for i = 1:numel(streams)
-      if isfield(streams{i}.info, 'effective_srate')
-          if streams{i}.info.effective_srate >= sraterange(1) && streams{i}.info.effective_srate <= sraterange(2)
-              inrange(i) = true;
-          end
+    if isfield(streams{i}.info, 'effective_srate')
+      if streams{i}.info.effective_srate >= streamrate(1) && streams{i}.info.effective_srate <= streamrate(2)
+        inrange(i) = true;
       end
+    end
   end
 end
 
+% convert the non-continuous streams to events
+event = [];
+for i=1:numel(streams)
+  if iscontinuous(i)
+    continue
+  end
+  for k=1:length(streams{i}.time_stamps)
+    try
+      event(end+1).type      = streams{1}.info.type;
+      event(end  ).value     = streams{i}.time_series{k}; % this is a cell-array with strings
+      event(end  ).sample    = nan;   % not defined, as it is not clear to which continuous stream the event relates
+      event(end  ).duration  = [];    % not specified
+      event(end  ).offset    = [];    % not specified
+      event(end  ).timestamp = streams{i}.time_stamps(k); % this is a scalar array
+    catch
+      % skip this event, the formatting might be different than assumed in the code above
+    end
+  end
+end
 
-% discard the non-continuous streams
-streams = streams(iscontinuous & selected & inrange);
+% continue with the continuous streams
+streams = streams(iscontinuous & haskeyword & inrange);
 
-if isempty(streams)
-  ft_error('no continuous streams were selected');
+if isempty(streams) && nargout==1
+  % in case of two output arguments it will return the events
+  ft_error('no continuous streams were present or selected');
 end
 
 % convert each continuous stream into a FieldTrip raw data structure
@@ -200,49 +223,55 @@ for i=1:numel(streams)
   
 end % for all continuous streams
 
-% determine the continuous stream with the highest sampling rate
-srate = nan(size(streams));
-for i=1:numel(streams)
-  srate(i) = streams{i}.info.effective_srate;
-end
-[dum, indx] = max(srate);
-
-
-% copy the header from the stream with max srate
-keephdr         = data{indx}.hdr;
-keephdr.nChans  = 0; 
-keephdr.label   = {};
-keephdr.chantype = {};
-keephdr.chanunit = {}; 
 
 if numel(data)>1
-    % resample all data structures, except the one with the max sampling rate
-    % this will also align the time axes
-    for i=1:numel(data)   
-        
-        % append channel information to the header
-        keephdr.nChans      = keephdr.nChans + data{i}.hdr.nChans;
-        keephdr.label       = [keephdr.label;       data{i}.hdr.label];
-        keephdr.chantype    = [keephdr.chantype;    data{i}.hdr.chantype];
-        keephdr.chanunit    = [keephdr.chanunit;    data{i}.hdr.chanunit];
-                
-        if i==indx
-            continue
-        end
-
-        ft_notice('resampling %s', streams{i}.info.name);
-        cfg = [];
-        cfg.time = data{indx}.time;
-        data{i} = ft_resampledata(cfg, data{i});
-        
+  % determine the continuous stream with the highest sampling rate
+  srate = nan(size(streams));
+  for i=1:numel(streams)
+    srate(i) = streams{i}.info.effective_srate;
+  end
+  [dum, highest] = max(srate);
+  
+  % copy the header from the stream with the highest sampling rate
+  keephdr          = data{highest}.hdr;
+  keephdr.nChans   = 0;
+  keephdr.label    = {};
+  keephdr.chantype = {};
+  keephdr.chanunit = {};
+  
+  % resample all data structures, except the one with the max sampling rate
+  % this will also align the time axes
+  for i=1:numel(data)
+    
+    % append this stream channel information to the combined header
+    keephdr.nChans   = keephdr.nChans + data{i}.hdr.nChans;
+    keephdr.label    = [keephdr.label;       data{i}.hdr.label];
+    keephdr.chantype = [keephdr.chantype;    data{i}.hdr.chantype];
+    keephdr.chanunit = [keephdr.chanunit;    data{i}.hdr.chanunit];
+    
+    if i==highest
+      continue
     end
     
-    % append all data structures
-    data = ft_appenddata([], data{:});
+    ft_notice('resampling %s', streams{i}.info.name);
     
-    % modify some fields in the header
-    data.hdr = keephdr; 
-else
-  % simply return the first and only one
+    cfg = [];
+    cfg.time = data{highest}.time;
+    data{i} = ft_resampledata(cfg, data{i});
+    
+  end
+  
+  % append all data structures
+  data = ft_appenddata([], data{:});
+  
+  % modify some fields in the header
+  data.hdr = keephdr;
+  
+elseif numel(data)==1
+  % simply return the first (and only) data structure
   data = data{1};
+  
+else
+  % do not return any data, but possibly return events
+  data = [];
 end


### PR DESCRIPTION
This follows the idea of #1209 but implements it differently. I tested it with an LSL recorder file from one of our NIRS experiments.