### PR TITLE
implemented multiple skin colors

### DIFF
--- a/ft_interactiverealign.m
+++ b/ft_interactiverealign.m
@@ -391,18 +391,12 @@ if ~isempty(individual.grad)
   ft_plot_sens(individual.grad, individual.gradstyle{:});
 end
 
-% FIXME this only works for boundary element models
-if isstruct(template.headmodel) && isfield(template.headmodel, 'bnd')
-  for i = 1:numel(template.headmodel.bnd)
-    ft_plot_mesh(template.headmodel.bnd(i), template.headmodelstyle{:});
-  end
+if isstruct(template.headmodel)
+  ft_plot_headmodel(template.headmodel, template.headmodelstyle{:});
 end
 
-% FIXME this only works for boundary element models
-if isstruct(individual.headmodel) && isfield(individual.headmodel, 'bnd')
-  for i = 1:numel(individual.headmodel.bnd)
-    ft_plot_mesh(individual.headmodel.bnd(i), individual.headmodelstyle{:});
-  end
+if isstruct(individual.headmodel)
+  ft_plot_headmodel(individual.headmodel, individual.headmodelstyle{:});
 end
 
 if isstruct(template.headshape) && isfield(template.headshape, 'pos') && ~isempty(template.headshape.pos)

--- a/plotting/ft_plot_headmodel.m
+++ b/plotting/ft_plot_headmodel.m
@@ -60,6 +60,7 @@ facecolor   = ft_getopt(varargin, 'facecolor', 'white');
 vertexcolor = ft_getopt(varargin, 'vertexcolor', 'none');
 edgecolor   = ft_getopt(varargin, 'edgecolor'); % the default for this is set below
 facealpha   = ft_getopt(varargin, 'facealpha', 1);
+edgealpha   = ft_getopt(varargin, 'edgealpha', 1);
 surfaceonly = ft_getopt(varargin, 'surfaceonly');
 unit        = ft_getopt(varargin, 'unit');
 grad        = ft_getopt(varargin, 'grad');
@@ -152,9 +153,9 @@ end
 
 % plot the triangulated surfaces of the volume conduction model
 for i=1:length(mesh)
-  ft_plot_mesh(mesh(i), 'faceindex', faceindex, 'vertexindex', vertexindex, ...
-    'vertexsize', vertexsize, 'facecolor', facecolor, 'edgecolor', edgecolor, ...
-    'vertexcolor', vertexcolor, 'facealpha', facealpha, 'surfaceonly', surfaceonly);
+  ft_plot_mesh(mesh(i), 'faceindex', faceindex, 'vertexindex', vertexindex, 'vertexsize', vertexsize, ...
+    'facecolor', facecolor, 'edgecolor', edgecolor, 'vertexcolor', vertexcolor, ...
+    'facealpha', facealpha, 'edgealpha', edgealpha, 'surfaceonly', surfaceonly);
 end
 
 % revert to original state

--- a/plotting/private/black.m
+++ b/plotting/private/black.m
@@ -1,18 +1,25 @@
 function rgb = black
 
-% returns a predefined color as [red green blue] values
+% This returns a predefined color as [red green blue] values
+%   red               = [255   0   0]/255;
+%   green             = [  0 192   0]/255;
+%   blue              = [  0   0 255]/255;
+%   magenta           = [255 255   0]/255;
+%   cyan              = [  0 255 255]/255;
+%   yellow            = [255 255   0]/255;
+%   white             = [255 255 255]/255;
+%   black             = [  0   0   0]/255;
 %
-% black        = [  0   0   0]/255;
-% blue         = [  0   0 255]/255;
-% cortex       = [255 213 119]/255;
-% cortex_dark  = [100  97  85]/255;
-% cortex_light = [199 194 169]/255;
-% green        = [  0 192   0]/255;
-% skull        = [140  85  85]/255
-% red          = [255   0   0]/255;
-% skin         = [255 213 119]/255;
-% white        = [255 255 255]/255;
-% yellow       = [255 255   0]/255;
+%   skull             = [140  85  85]/255
+%   cortex            = [255 213 119]/255;
+%   cortex_light      = [199 194 169]/255;
+%   cortex_dark       = [100  97  85]/255;
+%   skin              = [249 223 192]/255;
+%   skin_light        = [249 223 192]/255;
+%   skin_medium_light = [225 194 158]/255;
+%   skin_medium       = [188 142 106]/255;
+%   skin_medium_dark  = [155 102	65]/255;
+%   skin_dark         = [ 91  71  61]/255;
 
 rgb = [0 0 0]/255;
 

--- a/plotting/private/blue.m
+++ b/plotting/private/blue.m
@@ -1,18 +1,25 @@
 function rgb = blue
 
-% returns a predefined color as [red green blue] values
+% This returns a predefined color as [red green blue] values
+%   red               = [255   0   0]/255;
+%   green             = [  0 192   0]/255;
+%   blue              = [  0   0 255]/255;
+%   magenta           = [255 255   0]/255;
+%   cyan              = [  0 255 255]/255;
+%   yellow            = [255 255   0]/255;
+%   white             = [255 255 255]/255;
+%   black             = [  0   0   0]/255;
 %
-% black        = [  0   0   0]/255;
-% blue         = [  0   0 255]/255;
-% cortex       = [255 213 119]/255;
-% cortex_dark  = [100  97  85]/255;
-% cortex_light = [199 194 169]/255;
-% green        = [  0 192   0]/255;
-% skull        = [140  85  85]/255
-% red          = [255   0   0]/255;
-% skin         = [255 213 119]/255;
-% white        = [255 255 255]/255;
-% yellow       = [255 255   0]/255;
+%   skull             = [140  85  85]/255
+%   cortex            = [255 213 119]/255;
+%   cortex_light      = [199 194 169]/255;
+%   cortex_dark       = [100  97  85]/255;
+%   skin              = [249 223 192]/255;
+%   skin_light        = [249 223 192]/255;
+%   skin_medium_light = [225 194 158]/255;
+%   skin_medium       = [188 142 106]/255;
+%   skin_medium_dark  = [155 102	65]/255;
+%   skin_dark         = [ 91  71  61]/255;
 
 rgb = [0 0 255]/255;
 

--- a/plotting/private/cortex.m
+++ b/plotting/private/cortex.m
@@ -1,18 +1,25 @@
 function rgb = cortex
 
-% returns a predefined color as [red green blue] values
+% This returns a predefined color as [red green blue] values
+%   red               = [255   0   0]/255;
+%   green             = [  0 192   0]/255;
+%   blue              = [  0   0 255]/255;
+%   magenta           = [255 255   0]/255;
+%   cyan              = [  0 255 255]/255;
+%   yellow            = [255 255   0]/255;
+%   white             = [255 255 255]/255;
+%   black             = [  0   0   0]/255;
 %
-% black        = [  0   0   0]/255;
-% blue         = [  0   0 255]/255;
-% cortex       = [255 213 119]/255;
-% cortex_dark  = [100  97  85]/255;
-% cortex_light = [199 194 169]/255;
-% green        = [  0 192   0]/255;
-% skull        = [140  85  85]/255
-% red          = [255   0   0]/255;
-% skin         = [255 213 119]/255;
-% white        = [255 255 255]/255;
-% yellow       = [255 255   0]/255;
+%   skull             = [140  85  85]/255
+%   cortex            = [255 213 119]/255;
+%   cortex_light      = [199 194 169]/255;
+%   cortex_dark       = [100  97  85]/255;
+%   skin              = [249 223 192]/255;
+%   skin_light        = [249 223 192]/255;
+%   skin_medium_light = [225 194 158]/255;
+%   skin_medium       = [188 142 106]/255;
+%   skin_medium_dark  = [155 102	65]/255;
+%   skin_dark         = [ 91  71  61]/255;
 
 rgb = [255 213 119]/255;
 

--- a/plotting/private/cortex_dark.m
+++ b/plotting/private/cortex_dark.m
@@ -1,18 +1,25 @@
 function rgb = cortex_dark
 
-% returns a predefined color as [red green blue] values
+% This returns a predefined color as [red green blue] values
+%   red               = [255   0   0]/255;
+%   green             = [  0 192   0]/255;
+%   blue              = [  0   0 255]/255;
+%   magenta           = [255 255   0]/255;
+%   cyan              = [  0 255 255]/255;
+%   yellow            = [255 255   0]/255;
+%   white             = [255 255 255]/255;
+%   black             = [  0   0   0]/255;
 %
-% black        = [  0   0   0]/255;
-% blue         = [  0   0 255]/255;
-% cortex       = [255 213 119]/255;
-% cortex_dark  = [100  97  85]/255;
-% cortex_light = [199 194 169]/255;
-% green        = [  0 192   0]/255;
-% skull        = [140  85  85]/255
-% red          = [255   0   0]/255;
-% skin         = [255 213 119]/255;
-% white        = [255 255 255]/255;
-% yellow       = [255 255   0]/255;
+%   skull             = [140  85  85]/255
+%   cortex            = [255 213 119]/255;
+%   cortex_light      = [199 194 169]/255;
+%   cortex_dark       = [100  97  85]/255;
+%   skin              = [249 223 192]/255;
+%   skin_light        = [249 223 192]/255;
+%   skin_medium_light = [225 194 158]/255;
+%   skin_medium       = [188 142 106]/255;
+%   skin_medium_dark  = [155 102	65]/255;
+%   skin_dark         = [ 91  71  61]/255;
 
 rgb = [100 97 85]/255;
 

--- a/plotting/private/cortex_light.m
+++ b/plotting/private/cortex_light.m
@@ -1,18 +1,25 @@
 function rgb = cortex_light
 
-% returns a predefined color as [red green blue] values
+% This returns a predefined color as [red green blue] values
+%   red               = [255   0   0]/255;
+%   green             = [  0 192   0]/255;
+%   blue              = [  0   0 255]/255;
+%   magenta           = [255 255   0]/255;
+%   cyan              = [  0 255 255]/255;
+%   yellow            = [255 255   0]/255;
+%   white             = [255 255 255]/255;
+%   black             = [  0   0   0]/255;
 %
-% black        = [  0   0   0]/255;
-% blue         = [  0   0 255]/255;
-% cortex       = [255 213 119]/255;
-% cortex_dark  = [100  97  85]/255;
-% cortex_light = [199 194 169]/255;
-% green        = [  0 192   0]/255;
-% skull        = [140  85  85]/255
-% red          = [255   0   0]/255;
-% skin         = [255 213 119]/255;
-% white        = [255 255 255]/255;
-% yellow       = [255 255   0]/255;
+%   skull             = [140  85  85]/255
+%   cortex            = [255 213 119]/255;
+%   cortex_light      = [199 194 169]/255;
+%   cortex_dark       = [100  97  85]/255;
+%   skin              = [249 223 192]/255;
+%   skin_light        = [249 223 192]/255;
+%   skin_medium_light = [225 194 158]/255;
+%   skin_medium       = [188 142 106]/255;
+%   skin_medium_dark  = [155 102	65]/255;
+%   skin_dark         = [ 91  71  61]/255;
 
 rgb = [199 194 169]/255;
 

--- a/plotting/private/cyan.m
+++ b/plotting/private/cyan.m
@@ -1,18 +1,25 @@
 function rgb = cyan
 
-% returns a predefined color as [red green blue] values
+% This returns a predefined color as [red green blue] values
+%   red               = [255   0   0]/255;
+%   green             = [  0 192   0]/255;
+%   blue              = [  0   0 255]/255;
+%   magenta           = [255 255   0]/255;
+%   cyan              = [  0 255 255]/255;
+%   yellow            = [255 255   0]/255;
+%   white             = [255 255 255]/255;
+%   black             = [  0   0   0]/255;
 %
-% black        = [  0   0   0]/255;
-% blue         = [  0   0 255]/255;
-% cortex       = [255 213 119]/255;
-% cortex_dark  = [100  97  85]/255;
-% cortex_light = [199 194 169]/255;
-% green        = [  0 192   0]/255;
-% skull        = [140  85  85]/255
-% red          = [255   0   0]/255;
-% skin         = [255 213 119]/255;
-% white        = [255 255 255]/255;
-% yellow       = [255 255   0]/255;
+%   skull             = [140  85  85]/255
+%   cortex            = [255 213 119]/255;
+%   cortex_light      = [199 194 169]/255;
+%   cortex_dark       = [100  97  85]/255;
+%   skin              = [249 223 192]/255;
+%   skin_light        = [249 223 192]/255;
+%   skin_medium_light = [225 194 158]/255;
+%   skin_medium       = [188 142 106]/255;
+%   skin_medium_dark  = [155 102	65]/255;
+%   skin_dark         = [ 91  71  61]/255;
 
 rgb = [0 255 255]/255;
 

--- a/plotting/private/green.m
+++ b/plotting/private/green.m
@@ -1,18 +1,25 @@
 function rgb = green
 
-% returns a predefined color as [red green blue] values
+% This returns a predefined color as [red green blue] values
+%   red               = [255   0   0]/255;
+%   green             = [  0 192   0]/255;
+%   blue              = [  0   0 255]/255;
+%   magenta           = [255 255   0]/255;
+%   cyan              = [  0 255 255]/255;
+%   yellow            = [255 255   0]/255;
+%   white             = [255 255 255]/255;
+%   black             = [  0   0   0]/255;
 %
-% black        = [  0   0   0]/255;
-% blue         = [  0   0 255]/255;
-% cortex       = [255 213 119]/255;
-% cortex_dark  = [100  97  85]/255;
-% cortex_light = [199 194 169]/255;
-% green        = [  0 192   0]/255;
-% skull        = [140  85  85]/255
-% red          = [255   0   0]/255;
-% skin         = [255 213 119]/255;
-% white        = [255 255 255]/255;
-% yellow       = [255 255   0]/255;
+%   skull             = [140  85  85]/255
+%   cortex            = [255 213 119]/255;
+%   cortex_light      = [199 194 169]/255;
+%   cortex_dark       = [100  97  85]/255;
+%   skin              = [249 223 192]/255;
+%   skin_light        = [249 223 192]/255;
+%   skin_medium_light = [225 194 158]/255;
+%   skin_medium       = [188 142 106]/255;
+%   skin_medium_dark  = [155 102	65]/255;
+%   skin_dark         = [ 91  71  61]/255;
 
 rgb = [0 192 0]/255;
 

--- a/plotting/private/magenta.m
+++ b/plotting/private/magenta.m
@@ -1,18 +1,25 @@
 function rgb = magenta
 
-% returns a predefined color as [red green blue] values
+% This returns a predefined color as [red green blue] values
+%   red               = [255   0   0]/255;
+%   green             = [  0 192   0]/255;
+%   blue              = [  0   0 255]/255;
+%   magenta           = [255 255   0]/255;
+%   cyan              = [  0 255 255]/255;
+%   yellow            = [255 255   0]/255;
+%   white             = [255 255 255]/255;
+%   black             = [  0   0   0]/255;
 %
-% black        = [  0   0   0]/255;
-% blue         = [  0   0 255]/255;
-% cortex       = [255 213 119]/255;
-% cortex_dark  = [100  97  85]/255;
-% cortex_light = [199 194 169]/255;
-% green        = [  0 192   0]/255;
-% skull        = [140  85  85]/255
-% red          = [255   0   0]/255;
-% skin         = [255 213 119]/255;
-% white        = [255 255 255]/255;
-% yellow       = [255 255   0]/255;
+%   skull             = [140  85  85]/255
+%   cortex            = [255 213 119]/255;
+%   cortex_light      = [199 194 169]/255;
+%   cortex_dark       = [100  97  85]/255;
+%   skin              = [249 223 192]/255;
+%   skin_light        = [249 223 192]/255;
+%   skin_medium_light = [225 194 158]/255;
+%   skin_medium       = [188 142 106]/255;
+%   skin_medium_dark  = [155 102	65]/255;
+%   skin_dark         = [ 91  71  61]/255;
 
 rgb = [255 0 255]/255;
 

--- a/plotting/private/red.m
+++ b/plotting/private/red.m
@@ -1,18 +1,25 @@
 function rgb = red
 
-% returns a predefined color as [red green blue] values
+% This returns a predefined color as [red green blue] values
+%   red               = [255   0   0]/255;
+%   green             = [  0 192   0]/255;
+%   blue              = [  0   0 255]/255;
+%   magenta           = [255 255   0]/255;
+%   cyan              = [  0 255 255]/255;
+%   yellow            = [255 255   0]/255;
+%   white             = [255 255 255]/255;
+%   black             = [  0   0   0]/255;
 %
-% black        = [  0   0   0]/255;
-% blue         = [  0   0 255]/255;
-% cortex       = [255 213 119]/255;
-% cortex_dark  = [100  97  85]/255;
-% cortex_light = [199 194 169]/255;
-% green        = [  0 192   0]/255;
-% skull        = [140  85  85]/255
-% red          = [255   0   0]/255;
-% skin         = [255 213 119]/255;
-% white        = [255 255 255]/255;
-% yellow       = [255 255   0]/255;
+%   skull             = [140  85  85]/255
+%   cortex            = [255 213 119]/255;
+%   cortex_light      = [199 194 169]/255;
+%   cortex_dark       = [100  97  85]/255;
+%   skin              = [249 223 192]/255;
+%   skin_light        = [249 223 192]/255;
+%   skin_medium_light = [225 194 158]/255;
+%   skin_medium       = [188 142 106]/255;
+%   skin_medium_dark  = [155 102	65]/255;
+%   skin_dark         = [ 91  71  61]/255;
 
 rgb = [255 0 0]/255;
 

--- a/plotting/private/skin.m
+++ b/plotting/private/skin.m
@@ -1,20 +1,37 @@
 function rgb = skin
 
-% returns a predefined color as [red green blue] values
+% This returns a predefined color as [red green blue] values
+%   red               = [255   0   0]/255;
+%   green             = [  0 192   0]/255;
+%   blue              = [  0   0 255]/255;
+%   magenta           = [255 255   0]/255;
+%   cyan              = [  0 255 255]/255;
+%   yellow            = [255 255   0]/255;
+%   white             = [255 255 255]/255;
+%   black             = [  0   0   0]/255;
 %
-% black        = [  0   0   0]/255;
-% blue         = [  0   0 255]/255;
-% cortex       = [255 213 119]/255;
-% cortex_dark  = [100  97  85]/255;
-% cortex_light = [199 194 169]/255;
-% green        = [  0 192   0]/255;
-% skull        = [140  85  85]/255
-% red          = [255   0   0]/255;
-% skin         = [255 213 119]/255;
-% white        = [255 255 255]/255;
-% yellow       = [255 255   0]/255;
+%   skull             = [140  85  85]/255
+%   cortex            = [255 213 119]/255;
+%   cortex_light      = [199 194 169]/255;
+%   cortex_dark       = [100  97  85]/255;
+%   skin              = [249 223 192]/255;
+%   skin_light        = [249 223 192]/255;
+%   skin_medium_light = [225 194 158]/255;
+%   skin_medium       = [188 142 106]/255;
+%   skin_medium_dark  = [155 102	65]/255;
+%   skin_dark         = [ 91  71  61]/255;
+%
+% The different skin-based colors follow the Fitzpatrick scale with type I and II
+% combined, and return RGB values that approximate those used by Apple in the emoji
+% skin tones. See also https://emojipedia.org/emoji-modifier-sequence/
+%
+% If no specific skin tone is specified, this function returns a light skin color.
+% This corresponds with that of one of the developers who approximated his own skin
+% color more than 15 years ago upon the first implementation of this function.
 
-% see http://www.color-hex.com/color-palette/737
+msgId = 'FieldTrip:plotting:private:skin';
+ft_notice('once', msgId);
+ft_notice(msgId, 'this returns a light skin, you can also explicitly specify ''skin_light'','' skin_medium_light'', ''skin_medium'', ''skin_medium_dark'', or ''skin_dark''');
 
-rgb = [255 224 189]/255;
-
+% returns a predefined color as [red green blue] values
+rgb = skin_light;

--- a/plotting/private/skin_dark.m
+++ b/plotting/private/skin_dark.m
@@ -1,0 +1,33 @@
+function rgb = skin_dark
+
+% This returns a predefined color as [red green blue] values
+%   red               = [255   0   0]/255;
+%   green             = [  0 192   0]/255;
+%   blue              = [  0   0 255]/255;
+%   magenta           = [255 255   0]/255;
+%   cyan              = [  0 255 255]/255;
+%   yellow            = [255 255   0]/255;
+%   white             = [255 255 255]/255;
+%   black             = [  0   0   0]/255;
+%
+%   skull             = [140  85  85]/255
+%   cortex            = [255 213 119]/255;
+%   cortex_light      = [199 194 169]/255;
+%   cortex_dark       = [100  97  85]/255;
+%   skin              = [249 223 192]/255;
+%   skin_light        = [249 223 192]/255;
+%   skin_medium_light = [225 194 158]/255;
+%   skin_medium       = [188 142 106]/255;
+%   skin_medium_dark  = [155 102	65]/255;
+%   skin_dark         = [ 91  71  61]/255;
+%
+% The different skin-based colors follow the Fitzpatrick scale with type I and II
+% combined, and return RGB values that approximate those used by Apple in the emoji
+% skin tones. See also https://emojipedia.org/emoji-modifier-sequence/
+%
+% If no specific skin tone is specified, this function returns a light skin color.
+% This corresponds with that of one of the developers who approximated his own skin
+% color more than 15 years ago upon the first implementation of this function.
+
+% returns a predefined color as [red green blue] values
+rgb = [ 91	 71	 61]/255;

--- a/plotting/private/skin_light.m
+++ b/plotting/private/skin_light.m
@@ -1,0 +1,33 @@
+function rgb = skin_light
+
+% This returns a predefined color as [red green blue] values
+%   red               = [255   0   0]/255;
+%   green             = [  0 192   0]/255;
+%   blue              = [  0   0 255]/255;
+%   magenta           = [255 255   0]/255;
+%   cyan              = [  0 255 255]/255;
+%   yellow            = [255 255   0]/255;
+%   white             = [255 255 255]/255;
+%   black             = [  0   0   0]/255;
+%
+%   skull             = [140  85  85]/255
+%   cortex            = [255 213 119]/255;
+%   cortex_light      = [199 194 169]/255;
+%   cortex_dark       = [100  97  85]/255;
+%   skin              = [249 223 192]/255;
+%   skin_light        = [249 223 192]/255;
+%   skin_medium_light = [225 194 158]/255;
+%   skin_medium       = [188 142 106]/255;
+%   skin_medium_dark  = [155 102	65]/255;
+%   skin_dark         = [ 91  71  61]/255;
+%
+% The different skin-based colors follow the Fitzpatrick scale with type I and II
+% combined, and return RGB values that approximate those used by Apple in the emoji
+% skin tones. See also https://emojipedia.org/emoji-modifier-sequence/
+%
+% If no specific skin tone is specified, this function returns a light skin color.
+% This corresponds with that of one of the developers who approximated his own skin
+% color more than 15 years ago upon the first implementation of this function.
+
+% returns a predefined color as [red green blue] values
+rgb = [249	223	192]/255;

--- a/plotting/private/skin_medium.m
+++ b/plotting/private/skin_medium.m
@@ -1,0 +1,33 @@
+function rgb = skin_medium
+
+% This returns a predefined color as [red green blue] values
+%   red               = [255   0   0]/255;
+%   green             = [  0 192   0]/255;
+%   blue              = [  0   0 255]/255;
+%   magenta           = [255 255   0]/255;
+%   cyan              = [  0 255 255]/255;
+%   yellow            = [255 255   0]/255;
+%   white             = [255 255 255]/255;
+%   black             = [  0   0   0]/255;
+%
+%   skull             = [140  85  85]/255
+%   cortex            = [255 213 119]/255;
+%   cortex_light      = [199 194 169]/255;
+%   cortex_dark       = [100  97  85]/255;
+%   skin              = [249 223 192]/255;
+%   skin_light        = [249 223 192]/255;
+%   skin_medium_light = [225 194 158]/255;
+%   skin_medium       = [188 142 106]/255;
+%   skin_medium_dark  = [155 102	65]/255;
+%   skin_dark         = [ 91  71  61]/255;
+%
+% The different skin-based colors follow the Fitzpatrick scale with type I and II
+% combined, and return RGB values that approximate those used by Apple in the emoji
+% skin tones. See also https://emojipedia.org/emoji-modifier-sequence/
+%
+% If no specific skin tone is specified, this function returns a light skin color.
+% This corresponds with that of one of the developers who approximated his own skin
+% color more than 15 years ago upon the first implementation of this function.
+
+% returns a predefined color as [red green blue] values
+rgb = [188	142	106]/255;

--- a/plotting/private/skin_medium_dark.m
+++ b/plotting/private/skin_medium_dark.m
@@ -1,0 +1,33 @@
+function rgb = skin_medium_dark
+
+% This returns a predefined color as [red green blue] values
+%   red               = [255   0   0]/255;
+%   green             = [  0 192   0]/255;
+%   blue              = [  0   0 255]/255;
+%   magenta           = [255 255   0]/255;
+%   cyan              = [  0 255 255]/255;
+%   yellow            = [255 255   0]/255;
+%   white             = [255 255 255]/255;
+%   black             = [  0   0   0]/255;
+%
+%   skull             = [140  85  85]/255
+%   cortex            = [255 213 119]/255;
+%   cortex_light      = [199 194 169]/255;
+%   cortex_dark       = [100  97  85]/255;
+%   skin              = [249 223 192]/255;
+%   skin_light        = [249 223 192]/255;
+%   skin_medium_light = [225 194 158]/255;
+%   skin_medium       = [188 142 106]/255;
+%   skin_medium_dark  = [155 102	65]/255;
+%   skin_dark         = [ 91  71  61]/255;
+%
+% The different skin-based colors follow the Fitzpatrick scale with type I and II
+% combined, and return RGB values that approximate those used by Apple in the emoji
+% skin tones. See also https://emojipedia.org/emoji-modifier-sequence/
+%
+% If no specific skin tone is specified, this function returns a light skin color.
+% This corresponds with that of one of the developers who approximated his own skin
+% color more than 15 years ago upon the first implementation of this function.
+
+% returns a predefined color as [red green blue] values
+rgb = [155	102	 65]/255;

--- a/plotting/private/skin_medium_light.m
+++ b/plotting/private/skin_medium_light.m
@@ -1,0 +1,33 @@
+function rgb = skin_medium_light
+
+% This returns a predefined color as [red green blue] values
+%   red               = [255   0   0]/255;
+%   green             = [  0 192   0]/255;
+%   blue              = [  0   0 255]/255;
+%   magenta           = [255 255   0]/255;
+%   cyan              = [  0 255 255]/255;
+%   yellow            = [255 255   0]/255;
+%   white             = [255 255 255]/255;
+%   black             = [  0   0   0]/255;
+%
+%   skull             = [140  85  85]/255
+%   cortex            = [255 213 119]/255;
+%   cortex_light      = [199 194 169]/255;
+%   cortex_dark       = [100  97  85]/255;
+%   skin              = [249 223 192]/255;
+%   skin_light        = [249 223 192]/255;
+%   skin_medium_light = [225 194 158]/255;
+%   skin_medium       = [188 142 106]/255;
+%   skin_medium_dark  = [155 102	65]/255;
+%   skin_dark         = [ 91  71  61]/255;
+%
+% The different skin-based colors follow the Fitzpatrick scale with type I and II
+% combined, and return RGB values that approximate those used by Apple in the emoji
+% skin tones. See also https://emojipedia.org/emoji-modifier-sequence/
+%
+% If no specific skin tone is specified, this function returns a light skin color.
+% This corresponds with that of one of the developers who approximated his own skin
+% color more than 15 years ago upon the first implementation of this function.
+
+% returns a predefined color as [red green blue] values
+rgb = [225	194	158]/255;

--- a/plotting/private/skull.m
+++ b/plotting/private/skull.m
@@ -1,18 +1,25 @@
 function rgb = skull
 
-% returns a predefined color as [red green blue] values
+% This returns a predefined color as [red green blue] values
+%   red               = [255   0   0]/255;
+%   green             = [  0 192   0]/255;
+%   blue              = [  0   0 255]/255;
+%   magenta           = [255 255   0]/255;
+%   cyan              = [  0 255 255]/255;
+%   yellow            = [255 255   0]/255;
+%   white             = [255 255 255]/255;
+%   black             = [  0   0   0]/255;
 %
-% black        = [  0   0   0]/255;
-% blue         = [  0   0 255]/255;
-% cortex       = [255 213 119]/255;
-% cortex_dark  = [100  97  85]/255;
-% cortex_light = [199 194 169]/255;
-% green        = [  0 192   0]/255;
-% skull        = [140  85  85]/255
-% red          = [255   0   0]/255;
-% skin         = [255 213 119]/255;
-% white        = [255 255 255]/255;
-% yellow       = [255 255   0]/255;
+%   skull             = [140  85  85]/255
+%   cortex            = [255 213 119]/255;
+%   cortex_light      = [199 194 169]/255;
+%   cortex_dark       = [100  97  85]/255;
+%   skin              = [249 223 192]/255;
+%   skin_light        = [249 223 192]/255;
+%   skin_medium_light = [225 194 158]/255;
+%   skin_medium       = [188 142 106]/255;
+%   skin_medium_dark  = [155 102	65]/255;
+%   skin_dark         = [ 91  71  61]/255;
 
 rgb = [140 85 85]/255;
 

--- a/plotting/private/white.m
+++ b/plotting/private/white.m
@@ -1,18 +1,25 @@
 function rgb = white
 
-% returns a predefined color as [red green blue] values
+% This returns a predefined color as [red green blue] values
+%   red               = [255   0   0]/255;
+%   green             = [  0 192   0]/255;
+%   blue              = [  0   0 255]/255;
+%   magenta           = [255 255   0]/255;
+%   cyan              = [  0 255 255]/255;
+%   yellow            = [255 255   0]/255;
+%   white             = [255 255 255]/255;
+%   black             = [  0   0   0]/255;
 %
-% black        = [  0   0   0]/255;
-% blue         = [  0   0 255]/255;
-% cortex       = [255 213 119]/255;
-% cortex_dark  = [100  97  85]/255;
-% cortex_light = [199 194 169]/255;
-% green        = [  0 192   0]/255;
-% skull        = [140  85  85]/255
-% red          = [255   0   0]/255;
-% skin         = [255 213 119]/255;
-% white        = [255 255 255]/255;
-% yellow       = [255 255   0]/255;
+%   skull             = [140  85  85]/255
+%   cortex            = [255 213 119]/255;
+%   cortex_light      = [199 194 169]/255;
+%   cortex_dark       = [100  97  85]/255;
+%   skin              = [249 223 192]/255;
+%   skin_light        = [249 223 192]/255;
+%   skin_medium_light = [225 194 158]/255;
+%   skin_medium       = [188 142 106]/255;
+%   skin_medium_dark  = [155 102	65]/255;
+%   skin_dark         = [ 91  71  61]/255;
 
 rgb = [255 255 255]/255;
 

--- a/plotting/private/yellow.m
+++ b/plotting/private/yellow.m
@@ -1,18 +1,25 @@
 function rgb = yellow
 
-% returns a predefined color as [red green blue] values
+% This returns a predefined color as [red green blue] values
+%   red               = [255   0   0]/255;
+%   green             = [  0 192   0]/255;
+%   blue              = [  0   0 255]/255;
+%   magenta           = [255 255   0]/255;
+%   cyan              = [  0 255 255]/255;
+%   yellow            = [255 255   0]/255;
+%   white             = [255 255 255]/255;
+%   black             = [  0   0   0]/255;
 %
-% black        = [  0   0   0]/255;
-% blue         = [  0   0 255]/255;
-% cortex       = [255 213 119]/255;
-% cortex_dark  = [100  97  85]/255;
-% cortex_light = [199 194 169]/255;
-% green        = [  0 192   0]/255;
-% skull        = [140  85  85]/255
-% red          = [255   0   0]/255;
-% skin         = [255 213 119]/255;
-% white        = [255 255 255]/255;
-% yellow       = [255 255   0]/255;
+%   skull             = [140  85  85]/255
+%   cortex            = [255 213 119]/255;
+%   cortex_light      = [199 194 169]/255;
+%   cortex_dark       = [100  97  85]/255;
+%   skin              = [249 223 192]/255;
+%   skin_light        = [249 223 192]/255;
+%   skin_medium_light = [225 194 158]/255;
+%   skin_medium       = [188 142 106]/255;
+%   skin_medium_dark  = [155 102	65]/255;
+%   skin_dark         = [ 91  71  61]/255;
 
 rgb = [255 255 0]/255;
 


### PR DESCRIPTION
While making some updates to ft_interactiverealign, I came across ft_plot_headmodel and realized that the default `skin` color is light. This PR implements multiple skin colors, taking inspiration from those used in emojis and the https://en.wikipedia.org/wiki/Fitzpatrick_scale.