### PR TITLE
Issue #1841

### DIFF
--- a/ft_channelrepair.m
+++ b/ft_channelrepair.m
@@ -395,8 +395,13 @@ switch cfg.method
     
     % interpolate
     fprintf('computing weight matrix...');
-    repair = sphericalSplineInterpolate(chanpos(goodindx(sensidx), :)', chanpos', cfg.lambda, cfg.order, cfg.method);
+    [pot,lap] = sphsplint(chanpos(goodindx(sensidx), :), chanpos, cfg.order, 500, cfg.lambda);
     fprintf(' done!\n');
+    
+    % Chooses the right output.
+    if strcmp(cfg.method, 'spline'), repair = pot;
+    else, repair = lap;
+    end
     
     if ~allchans
       % only use the rows corresponding to the channels that actually need interpolation

--- a/ft_scalpcurrentdensity.m
+++ b/ft_scalpcurrentdensity.m
@@ -185,24 +185,32 @@ end
 
 allchanpos = elec.chanpos(elecindx,:);    % the position of all channels, ordered according to the data
 goodchanpos = allchanpos(goodindx,:);     % the position of good channels
-anychanpos  = [0 0 1];                    % random channel, will be used in case there are no bad channels
 
 % compute SCD for each trial
 if strcmp(cfg.method, 'spline')
+  
+  fprintf('Checking spherical fit... ');
+  [c, r] = fitsphere(chanpos);
+  d = chanpos - repmat(c, numel(find(sensidx)), 1);
+  d = sqrt(sum(d.^2, 2));
+  d = mean(abs(d) / r);
+  if abs(d-1) > 0.1
+    ft_warning('bad spherical fit (residual: %.2f%%). The interpolation will be inaccurate.', 100*(d-1));
+  elseif abs(d-1) < 0.01
+    fprintf('perfect spherical fit (residual: %.1f%%)\n', 100*(d-1));
+  else
+    fprintf('good spherical fit (residual: %.1f%%)\n', 100*(d-1));
+  end
+  
+  % Builds the spatial filter only once.
+  fprintf('Calculating the filter to build the SCD.\n');
+  [WVo,WLo]=sphsplint(goodchanpos, allchanpos, cfg.order, cfg.degree, cfg.lambda);
+  
   ft_progress('init', cfg.feedback, 'computing SCD for trial...')
   for trlop=1:Ntrials
     % do compute interpolation
     ft_progress(trlop/Ntrials, 'computing SCD for trial %d of %d', trlop, Ntrials);
-    if ~isempty(cfg.badchannel)
-      % compute scd for all channels, also for the bad ones
-      fprintf('computing scd also at locations of bad channels');
-      [V2, L2, L1] = splint(goodchanpos, data.trial{trlop}(goodindx,:), allchanpos, cfg.order, cfg.degree, cfg.lambda);
-      scd.trial{trlop} = L2;
-    else
-      % just compute scd for input channels, specify arbitrary channel to-be-discarded for interpolation to save computation time
-      [V2, L2, L1] = splint(goodchanpos, data.trial{trlop}(goodindx,:), anychanpos, cfg.order, cfg.degree, cfg.lambda);
-      scd.trial{trlop} = L1;
-    end
+    scd.trial{trlop} = WLo*data.trial{trlop}(goodindx,:);
   end
   ft_progress('close');
 

--- a/ft_scalpcurrentdensity.m
+++ b/ft_scalpcurrentdensity.m
@@ -204,13 +204,13 @@ if strcmp(cfg.method, 'spline')
   
   % Builds the spatial filter only once.
   fprintf('Calculating the filter to build the SCD.\n');
-  [WVo,WLo]=sphsplint(goodchanpos, allchanpos, cfg.order, cfg.degree, cfg.lambda);
+  [WVo, WLo] = sphsplint(goodchanpos, allchanpos, cfg.order, cfg.degree, cfg.lambda);
   
   ft_progress('init', cfg.feedback, 'computing SCD for trial...')
   for trlop=1:Ntrials
     % do compute interpolation
     ft_progress(trlop/Ntrials, 'computing SCD for trial %d of %d', trlop, Ntrials);
-    scd.trial{trlop} = WLo*data.trial{trlop}(goodindx,:);
+    scd.trial{trlop} = WLo * data.trial{trlop}(goodindx,:);
   end
   ft_progress('close');
 

--- a/private/mplgndr.m
+++ b/private/mplgndr.m
@@ -1,0 +1,72 @@
+function plgndr = mplgndr ( degree, order, x )
+
+% MPLGNDR associated Legendre functions
+%
+% y = mplgndr(n,k,x) computes the values of the associated Legendre
+% functions of order K up to degree N.
+% 
+% The input x can be a matrix, and the result is of size numel(x) by N+1.
+% The i-th column is the associated Legendre function of order K and
+% degree i-1.
+
+% Copyright (C) 2002, Robert Oostenveld
+% Copyright (C) 2021, Ricardo Bruña
+% 
+% This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
+% for the documentation and details.
+%
+%    FieldTrip is free software: you can redistribute it and/or modify
+%    it under the terms of the GNU General Public License as published by
+%    the Free Software Foundation, either version 3 of the License, or
+%    (at your option) any later version.
+%
+%    FieldTrip is distributed in the hope that it will be useful,
+%    but WITHOUT ANY WARRANTY; without even the implied warranty of
+%    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%    GNU General Public License for more details.
+%
+%    You should have received a copy of the GNU General Public License
+%    along with FieldTrip. If not, see <http://www.gnu.org/licenses/>.
+%
+% $Id$
+
+
+% Checks the input.
+if order < 0 || round ( order ) ~= order
+    error ( 'The order must be a positive integer or zero.' )
+end
+if degree < order || round ( degree ) ~= degree
+    error ( 'The degree must be a positive integer equal or greated than m.' )
+end
+if any ( abs ( x ) > 1 )
+    error ( 'abs (x) vannot be greater than 1.' )
+end
+
+
+% Initializes the output.
+plgndr = zeros ( numel ( x ), degree + 1 );
+
+
+% Gets the solution at degree = order analitically.
+root   = sqrt ( 1 - x (:) .* x (:) );
+plgndr ( :, order + 1 ) = prod ( 1: 2: 2 * order - 1 ) * root .^ order;
+
+% Corrects the sign.
+if rem ( abs ( order ), 2 )
+    plgndr ( :, order + 1 ) = -plgndr ( :, order + 1 );
+end
+
+% If the degree equals the order, returns.
+if degree == order, return, end
+
+
+% Uses a simplified version of the formula for the second iteration.
+plgndr ( :, order + 2 ) = x (:) .* ( 2 * ( order + 1 ) - 1 ) .* plgndr ( :, order + 1 );
+
+
+% Uses the iterative formula for the rest of iterations.
+for dindex = order + 2: degree
+    
+    % Calculates the value of the polynomial in the current iteration.
+    plgndr ( :, dindex + 1 ) = ( x (:) .* ( 2 * dindex - 1 ) .* plgndr ( :, dindex ) - ( dindex + order - 1 ) .* plgndr ( :, dindex - 1 ) ) ./ ( dindex - order );
+end

--- a/private/mplgndr.m
+++ b/private/mplgndr.m
@@ -33,13 +33,13 @@ function plgndr = mplgndr ( degree, order, x )
 
 % Checks the input.
 if order < 0 || round ( order ) ~= order
-    error ( 'The order must be a positive integer or zero.' )
+  error ( 'The order must be a positive integer or zero.' )
 end
 if degree < order || round ( degree ) ~= degree
-    error ( 'The degree must be a positive integer equal or greated than m.' )
+  error ( 'The degree must be a positive integer equal or greated than m.' )
 end
 if any ( abs ( x ) > 1 )
-    error ( 'abs (x) vannot be greater than 1.' )
+  error ( 'abs (x) vannot be greater than 1.' )
 end
 
 
@@ -53,7 +53,7 @@ plgndr ( :, order + 1 ) = prod ( 1: 2: 2 * order - 1 ) * root .^ order;
 
 % Corrects the sign.
 if rem ( abs ( order ), 2 )
-    plgndr ( :, order + 1 ) = -plgndr ( :, order + 1 );
+  plgndr ( :, order + 1 ) = -plgndr ( :, order + 1 );
 end
 
 % If the degree equals the order, returns.
@@ -66,7 +66,7 @@ plgndr ( :, order + 2 ) = x (:) .* ( 2 * ( order + 1 ) - 1 ) .* plgndr ( :, orde
 
 % Uses the iterative formula for the rest of iterations.
 for dindex = order + 2: degree
-    
-    % Calculates the value of the polynomial in the current iteration.
-    plgndr ( :, dindex + 1 ) = ( x (:) .* ( 2 * dindex - 1 ) .* plgndr ( :, dindex ) - ( dindex + order - 1 ) .* plgndr ( :, dindex - 1 ) ) ./ ( dindex - order );
+  
+  % Calculates the value of the polynomial in the current iteration.
+  plgndr ( :, dindex + 1 ) = ( x (:) .* ( 2 * dindex - 1 ) .* plgndr ( :, dindex ) - ( dindex + order - 1 ) .* plgndr ( :, dindex - 1 ) ) ./ ( dindex - order );
 end

--- a/private/sphsplint.m
+++ b/private/sphsplint.m
@@ -49,6 +49,7 @@ function [ WVo, WLo ] = sphsplint ( elc1, elc2, order, degree, lambda )
 
 
 % Sets the defaults.
+if ( nargin < 2 ), elc2 = elc1; end
 if ( nargin < 3 || isempty ( order ) ),  order  = 4;    end
 if ( nargin < 4 || isempty ( degree ) ), degree = [];   end
 if ( nargin < 5 || isempty ( lambda ) ), lambda = 1e-5; end

--- a/private/sphsplint.m
+++ b/private/sphsplint.m
@@ -1,0 +1,146 @@
+function [ WVo, WLo ] = sphsplint ( elc1, elc2, order, degree, lambda )
+
+% SPHSPLINT computes the spherical spline interpolation and the surface
+% laplacian of an EEG potential distribution
+% 
+% Use as
+%   [WVo, WLo] = sphsplint(elc1, elc2)
+%   [WVo, WLo] = sphsplint(elc1, elc2, order, degree, lambda)
+% where
+%   elc1    electrode positions where potential is known
+%   elc2    electrode positions where potential is not known
+% and
+%   WVo     filter for the potential at electrode locations in elc2
+%   WLo     filter for the laplacian at electrode locations in elc2
+%   order   order of splines
+%   degree  degree of Legendre polynomials
+%   lambda  regularization parameter
+%
+% See also LAPINT, LAPINTMAT, LAPCAL
+% This implements
+%   F. Perrin, J. Pernier, O. Bertrand, and J. F. Echallier.
+%   Spherical splines for scalp potential and curernt density mapping.
+%   Electroencephalogr Clin Neurophysiol, 72:184-187, 1989.
+% including their corrections in 
+%   F. Perrin, J. Pernier, O. Bertrand, and J. F. Echallier.
+%   Corrigenda: EEG 02274, Electroencephalography and Clinical
+%   Neurophysiology 76:565.
+
+% Copyright (C) 2003, Robert Oostenveld
+% Copyright (C) 2021, Ricardo Bruña
+% 
+% This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
+% for the documentation and details.
+%
+%    FieldTrip is free software: you can redistribute it and/or modify
+%    it under the terms of the GNU General Public License as published by
+%    the Free Software Foundation, either version 3 of the License, or
+%    (at your option) any later version.
+%
+%    FieldTrip is distributed in the hope that it will be useful,
+%    but WITHOUT ANY WARRANTY; without even the implied warranty of
+%    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%    GNU General Public License for more details.
+%
+%    You should have received a copy of the GNU General Public License
+%    along with FieldTrip. If not, see <http://www.gnu.org/licenses/>.
+%
+% $Id$
+
+
+% Sets the defaults.
+if ( nargin < 3 || isempty ( order ) ),  order  = 4;    end
+if ( nargin < 4 || isempty ( degree ) ), degree = [];   end
+if ( nargin < 5 || isempty ( lambda ) ), lambda = 1e-5; end
+
+% Gets the size of the input set of electrodes.
+siz1 = size ( elc1, 1 );
+
+% Sets the default degree, if no provided.
+if isempty ( degree )
+    if     siz1 <= 32,  degree = 9;
+    elseif siz1 <= 64,  degree = 14;
+    elseif siz1 <= 128, degree = 20;
+    else,               degree = 32;
+    end
+end
+
+
+% Creates a single set with all the electrodes.
+elcs = unique ( cat ( 1, elc1, elc2 ), 'rows' );
+[ ~, ind1 ] = ismember ( elc1, elcs, 'rows' );
+[ ~, ind2 ] = ismember ( elc2, elcs, 'rows' );
+
+% Fits a sphere to the electrodes and centers them.
+[ center, radius ] = my_fitsphere ( elcs );
+elcs = elcs - center;
+
+% % Checks the spherical fitting.
+% err    = mean ( sqrt ( sum ( elcs .^2, 2 ) ) ) / radius - 1;
+% if err < 0.01
+%     fprintf ( 'Perfect spherical fit (residual: %.1f%%).\n', 100 * err );
+% elseif err < 0.1
+%     fprintf ( 'Good spherical fit (residual: %.1f%%).\n', 100 * err );
+% else
+%     ft_warning ( 'Bad spherical fit (residual: %.2f%%). The interpolation will be inaccurate.', 100 * err );
+% end
+
+% Projects the electrodes over a unit-sphere.
+elcs = elcs ./ sqrt ( sum ( elcs .^ 2, 2 ) );
+
+
+% Gets the cosine of the angle (projection) between electrodes (Eq. 4).
+CosE = min ( max ( elcs * elcs ( ind1, : )', -1 ), 1 );
+
+% Solves the g(x) and h(x) equations (Eqs. 3 and 5b).
+[ gx, hx ] = perrin_gh ( CosE, order, degree );
+
+
+% Gets the g(x) submatrix for the input set alone.
+gxii = gx ( ind1, : );
+
+% We can rewrite the simultaneous Eq. 2:
+%   G * C + T * c0 = Z;
+%   T' * C = 0;
+% as:
+%   H * [ c0 C ]' = [ 0 Z ]'
+% with:
+%   H = [ 0 1 ]
+%       [ 1 G ]
+
+% Builds the composite matrix H (with Tikhonov regularization for g).
+H    = ones ( siz1 + 1, siz1 + 1 );
+H ( 1, 1 ) = 0;
+H ( 2: end, 2: end ) = gxii + eye ( siz1 ) * lambda;
+
+% Fits the solution for the input electrodes using SVD.
+iH   = pinv ( H );
+
+
+% Gets the g(x) and h(x) submatrices for the output set.
+gxio = gx ( ind2, : );
+hxio = hx ( ind2, : );
+
+% Computes the filter to interpolate the potential in the output set.
+WVo  = cat ( 2, ones ( siz1, 1 ), gxio ) * iH ( :, 2: end );
+
+% Computes the filter to interpolate the Laplacian in the output set.
+WLo  = hxio * iH ( 2: end, 2: end );
+
+% Scales the Laplacian to the original geometrical dimensions.
+WLo  = WLo / ( radius ^ 2 );
+
+
+function [ gx, hx ] = perrin_gh ( x, order, degree )
+
+% Calculates the Legendre polynomials up to the requested degree.
+lpol    = mplgndr ( degree, 0, x );
+lpol    = lpol ( :, 2: end );
+
+% Gets the g(x) and h(x) functions (Eqs. 3 and 5b).
+gx      =  sum ( ( 2 * ( 1: degree ) + 1 ) ./ ( ( 1: degree ) .* ( ( 1: degree ) + 1 ) ) .^ order .* lpol, 2 ) / ( 4 * pi );
+hx      = -sum ( ( 2 * ( 1: degree ) + 1 ) ./ ( ( 1: degree ) .* ( ( 1: degree ) + 1 ) ) .^ ( order - 1 ) .* lpol, 2 ) / ( 4 * pi );
+
+% Reshapes the g(x) and h(x) functions as matrices.
+gx      = reshape ( gx, size ( x ) );
+hx      = reshape ( hx, size ( x ) );

--- a/private/sphsplint.m
+++ b/private/sphsplint.m
@@ -72,7 +72,7 @@ elcs = unique ( cat ( 1, elc1, elc2 ), 'rows' );
 [ ~, ind2 ] = ismember ( elc2, elcs, 'rows' );
 
 % Fits a sphere to the electrodes and centers them.
-[ center, radius ] = my_fitsphere ( elcs );
+[ center, radius ] = fitsphere ( elcs );
 elcs = elcs - center;
 
 % % Checks the spherical fitting.

--- a/private/sphsplint.m
+++ b/private/sphsplint.m
@@ -59,11 +59,11 @@ siz1 = size ( elc1, 1 );
 
 % Sets the default degree, if no provided.
 if isempty ( degree )
-    if     siz1 <= 32,  degree = 9;
-    elseif siz1 <= 64,  degree = 14;
-    elseif siz1 <= 128, degree = 20;
-    else,               degree = 32;
-    end
+  if     siz1 <= 32,  degree = 9;
+  elseif siz1 <= 64,  degree = 14;
+  elseif siz1 <= 128, degree = 20;
+  else,               degree = 32;
+  end
 end
 
 
@@ -79,11 +79,11 @@ elcs = elcs - center;
 % % Checks the spherical fitting.
 % err    = mean ( sqrt ( sum ( elcs .^2, 2 ) ) ) / radius - 1;
 % if err < 0.01
-%     fprintf ( 'Perfect spherical fit (residual: %.1f%%).\n', 100 * err );
+%   fprintf ( 'Perfect spherical fit (residual: %.1f%%).\n', 100 * err );
 % elseif err < 0.1
-%     fprintf ( 'Good spherical fit (residual: %.1f%%).\n', 100 * err );
+%   fprintf ( 'Good spherical fit (residual: %.1f%%).\n', 100 * err );
 % else
-%     ft_warning ( 'Bad spherical fit (residual: %.2f%%). The interpolation will be inaccurate.', 100 * err );
+%   ft_warning ( 'Bad spherical fit (residual: %.2f%%). The interpolation will be inaccurate.', 100 * err );
 % end
 
 % Projects the electrodes over a unit-sphere.
@@ -135,13 +135,13 @@ WLo  = WLo / ( radius ^ 2 );
 function [ gx, hx ] = perrin_gh ( x, order, degree )
 
 % Calculates the Legendre polynomials up to the requested degree.
-lpol    = mplgndr ( degree, 0, x );
-lpol    = lpol ( :, 2: end );
+lpol = mplgndr ( degree, 0, x );
+lpol = lpol ( :, 2: end );
 
 % Gets the g(x) and h(x) functions (Eqs. 3 and 5b).
-gx      =  sum ( ( 2 * ( 1: degree ) + 1 ) ./ ( ( 1: degree ) .* ( ( 1: degree ) + 1 ) ) .^ order .* lpol, 2 ) / ( 4 * pi );
-hx      = -sum ( ( 2 * ( 1: degree ) + 1 ) ./ ( ( 1: degree ) .* ( ( 1: degree ) + 1 ) ) .^ ( order - 1 ) .* lpol, 2 ) / ( 4 * pi );
+gx   =  sum ( ( 2 * ( 1: degree ) + 1 ) ./ ( ( 1: degree ) .* ( ( 1: degree ) + 1 ) ) .^ order .* lpol, 2 ) / ( 4 * pi );
+hx   = -sum ( ( 2 * ( 1: degree ) + 1 ) ./ ( ( 1: degree ) .* ( ( 1: degree ) + 1 ) ) .^ ( order - 1 ) .* lpol, 2 ) / ( 4 * pi );
 
 % Reshapes the g(x) and h(x) functions as matrices.
-gx      = reshape ( gx, size ( x ) );
-hx      = reshape ( hx, size ( x ) );
+gx   = reshape ( gx, size ( x ) );
+hx   = reshape ( hx, size ( x ) );

--- a/test/test_issue1841.m
+++ b/test/test_issue1841.m
@@ -9,6 +9,8 @@ function test_issue1841
 [ftver, ftdir] = ft_version;
 elec = ft_read_sens(fullfile(ftdir, 'template/electrode/standard_1020.elc'));
 
+cd(fullfile(ftdir, 'private')); % this needs to be done, otherwise private functions cannot be tested
+
 % Centers the sensor definition.
 center = fitsphere ( elec.chanpos );
 elec.chanpos = elec.chanpos - center;

--- a/test/test_issue1841.m
+++ b/test/test_issue1841.m
@@ -1,0 +1,35 @@
+function test_issue1841
+
+% WALLTIME 00:30:00
+% MEM 4gb
+% DEPENDENCY ft_scalpcurrentdensity ft_channelrepair
+
+%%
+% Loads the 10-20 sensor definition.
+[ftver, ftdir] = ft_version;
+elec = ft_read_sens(fullfile(ftdir, 'template/electrode/standard_1020.elc'));
+
+% Centers the sensor definition.
+center = fitsphere ( elec.chanpos );
+elec.chanpos = elec.chanpos - center;
+
+% Sets the parameters.
+order  = 4;
+lambda = 1e-5;
+Vi     = randn(size(elec.chanpos,1),1);
+
+% Runs all the functions.
+[Vo, Lo, ~]   = splint(elec.chanpos, Vi, elec.chanpos, order, 500, lambda);
+[WV, ~, ~, ~] = sphericalSplineInterpolate(elec.chanpos', elec.chanpos', lambda, order, 'spline');
+[WL, ~, ~, ~] = sphericalSplineInterpolate(elec.chanpos', elec.chanpos', lambda, order, 'slap');
+[WVo, WLo]    = sphsplint(elec.chanpos, elec.chanpos, order, 500, lambda);
+
+% Compares the output of the original functions.
+figure
+subplot 121,plot(Vo, WV*Vi, 'o'),title('Potential')
+subplot 122,plot(Lo, WL*Vi, 'o'),title('Laplacian')
+
+% Compares with the output of the new function.
+figure
+subplot 121,plot(Vo, WVo*Vi, 'o'),title('Potential')
+subplot 122,plot(Lo, WLo*Vi, 'o'),title('Laplacian')

--- a/test/test_issue1841.m
+++ b/test/test_issue1841.m
@@ -26,10 +26,14 @@ Vi     = randn(size(elec.chanpos,1),1);
 
 % Compares the output of the original functions.
 figure
-subplot 121,plot(Vo, WV*Vi, 'o'),title('Potential')
-subplot 122,plot(Lo, WL*Vi, 'o'),title('Laplacian')
+subplot 121
+plot(Vo, WV*Vi, 'o'),title('Potential')
+subplot 122
+plot(Lo, WL*Vi, 'o'),title('Laplacian')
 
 % Compares with the output of the new function.
 figure
-subplot 121,plot(Vo, WVo*Vi, 'o'),title('Potential')
-subplot 122,plot(Lo, WLo*Vi, 'o'),title('Laplacian')
+subplot 121
+plot(Vo, WVo*Vi, 'o'),title('Potential')
+subplot 122
+plot(Lo, WLo*Vi, 'o'),title('Laplacian')


### PR DESCRIPTION
Pull request to solve issue #1841:
* Creates a new function sphsplint to replace both splint and sphericalSplineInterpolate.
* Creates a test file to check that the output is similar.
* Replaces the call for the previous functions in ft_channelrepair and ft_scalpcurrentdensity.
* Adds a new function mplgndr to calculate the Legendre polynomials (and associated functions) more efficiently.

In addition, the new sphsplint function center the electrode set in the origin of the best fitting sphere, to get a more accurate spherical interpolation.