### PR TITLE
ENH: added volume-based registration of electrodes to ft_electroderealign

### DIFF
--- a/ft_electroderealign.m
+++ b/ft_electroderealign.m
@@ -120,7 +120,7 @@ function [elec_realigned] = ft_electroderealign(cfg, elec_original)
 %   cfg.moveinward     = number, the distance that the electrode should be moved
 %                        inward (negative numbers result in an outward move)
 %
-% If you want to align electrodes to the freesurfer average brain, you should
+% If you want to align ECoG electrodes to the freesurfer average brain, you should
 % specify the path to your headshape (e.g., lh.pial), and ensure you have the
 % corresponding registration file (e.g., lh.sphere.reg) in the same directory.
 % Moreover, the path to the local freesurfer home is required. Note that, because the
@@ -430,7 +430,7 @@ elseif strcmp(cfg.method, 'volume')
   if strcmp(cfg.warp, 'mni')
     norm.elecpos = warp_mni(cfg, elec);
   else
-    error([cfg.warp ' warping method not supported for method volume']);
+    error([cfg.warp ' warp not supported for method volume']);
   end
 
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/private/warp_mni.m
+++ b/private/warp_mni.m
@@ -1,0 +1,41 @@
+function [pos_norm, chan_norm] = warp_mni(cfg, elec)
+
+% WARP_MNI projects electrode channels to the MNI template brain.
+% This volume-based registration technique can be used for the spatial
+% normalization of electrodes based on a normalized anatomical volume. 
+% To perform volume-based normalization, you first need to process the 
+% subject's MRI with ft_volumenormalise.
+%
+% The configuration must contain the following options
+%   cfg.volume         = anatomical volume, normalized with
+%                        ft_volumenormalise
+%
+% See also FT_ELECTRODEREALIGN, FT_PREPARE_MESH
+
+% Copyright (C) 2021, Arjen Stolk
+%
+% This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
+% for the documentation and details.
+%
+%    FieldTrip is free software: you can redistribute it and/or modify
+%    it under the terms of the GNU General Public License as published by
+%    the Free Software Foundation, either version 3 of the License, or
+%    (at your option) any later version.
+%
+%    FieldTrip is distributed in the hope that it will be useful,
+%    but WITHOUT ANY WARRANTY; without even the implied warranty of
+%    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%    GNU General Public License for more details.
+%
+%    You should have received a copy of the GNU General Public License
+%    along with FieldTrip. If not, see <http://www.gnu.org/licenses/>.
+%
+% $Id$
+
+% initial warp performed by ft_convert_coordsys
+pos_norm  = ft_warp_apply(cfg.volume.initial, elec.elecpos, 'homogenous');
+chan_norm = ft_warp_apply(cfg.volume.initial, elec.chanpos, 'homogenous');
+
+% final warp performed by ft_volumenormalise
+pos_norm  = ft_warp_apply(cfg.volume.params, pos_norm, 'individual2sn');
+chan_norm = ft_warp_apply(cfg.volume.params, chan_norm, 'individual2sn');


### PR DESCRIPTION
Due to construction work on ft_convert_coordsys, default behavior of the volume-based registration approach as described in the iEEG analysis protocol had changed. Specifically, ft_volumenormalise calls ft_convert_coordsys to perform an initial rigid body transformation for a better initial alignment of the source and target scans. This initial warp, however, is not reflected in the params field spit out by ft_volumenormalise and used in a subsequent call to ft_warp_apply for normalizing iEEG electrodes per the protocol. As a result, electrodes were no longer correctly mapped onto the template brain when that initial transformation was anything else but identity.

This PR solves the above issue while also housing previous functionality where it belongs, in ft_electroderealign. Following this PR, calls to the lower-level ft_warp_apply are no longer necessary and (iEEG) electrodes can be spatially normalized as follows:

cfg                      = [];
cfg.nonlinear      = 'yes';
cfg.spmversion  = 'spm12';
cfg.spmmethod  = 'new';
mri_norm = ft_volumenormalise(cfg, mri);

cfg                      = [];
cfg.elec              = elec;
cfg.method        = 'volume';
cfg.volume         = mri_norm;
cfg.warp             = 'mni';
elec_norm = ft_electroderealign(cfg);