### PR TITLE
added MNI registration of electrodes to ft_electroderealign

### DIFF
--- a/ft_electroderealign.m
+++ b/ft_electroderealign.m
@@ -29,7 +29,10 @@ function [elec_realigned] = ft_electroderealign(cfg, elec_original)
 % PROJECT - This projects all electrodes to the nearest point on the
 % head surface mesh.
 %
-% MOVEINWARD - This moves all electrodes inward according to their normals
+% MOVEINWARD - This moves all electrodes inward according to their normals.
+%
+% MNI - This transforms the electrodes nonlinearly using the same transformation of
+% the individual anatomical MRI to the MNI template.
 %
 % Use as
 %   [elec_realigned] = ft_electroderealign(cfg)
@@ -45,6 +48,7 @@ function [elec_realigned] = ft_electroderealign(cfg, elec_original)
 %                        'headshape'       realign the electrodes to fit the head surface
 %                        'project'         projects electrodes onto the head surface
 %                        'moveinward'      moves electrodes inward along their normals
+%                        'mni'             transforms electrodes from individual subject to MNI space
 %   cfg.warp          = string describing the spatial transformation for the template and headshape methods
 %                        'rigidbody'       apply a rigid-body warp (default)
 %                        'globalrescale'   apply a rigid-body warp with global rescaling
@@ -59,13 +63,10 @@ function [elec_realigned] = ft_electroderealign(cfg, elec_original)
 %                        'fsaverage'       surface-based realignment with FreeSurfer fsaverage brain (left->left or right->right)
 %                        'fsaverage_sym'   surface-based realignment with FreeSurfer fsaverage_sym left hemisphere (left->left or right->left)
 %                        'fsinflated'      surface-based realignment with FreeSurfer individual subject inflated brain (left->left or right->right)
-%   cfg.channel        = Nx1 cell-array with selection of channels (default = 'all'),
-%                        see  FT_CHANNELSELECTION for details
+%   cfg.channel        = Nx1 cell-array with selection of channels (default = 'all'), see FT_CHANNELSELECTION for details
 %   cfg.keepchannel    = string, 'yes' or 'no' (default = 'no')
-%   cfg.fiducial       = cell-array with the name of three fiducials used for
-%                        realigning (default = {'nasion', 'lpa', 'rpa'})
-%   cfg.casesensitive  = 'yes' or 'no', determines whether string comparisons
-%                        between electrode labels are case sensitive (default = 'yes')
+%   cfg.fiducial       = cell-array with the name of three fiducials used for realigning (default = {'nasion', 'lpa', 'rpa'})
+%   cfg.casesensitive  = 'yes' or 'no', determines whether string comparisons between electrode labels are case sensitive (default = 'yes')
 %   cfg.feedback       = 'yes' or 'no' (default = 'no')
 %
 % The electrode positions can be present in the 2nd input argument or can be specified as
@@ -102,13 +103,13 @@ function [elec_realigned] = ft_electroderealign(cfg, elec_original)
 %                        points
 %   cfg.feedback       = 'yes' or 'no' (default), feedback of the iteration procedure
 %
-% Additional configuration options for cfg.warp = 'dykstra2012'
+% Additional configuration options for cfg.warp='dykstra2012'
 %   cfg.maxiter        = number (default: 50), maximum number of optimization iterations
 %   cfg.pairmethod     = 'pos' (default) or 'label', the method for electrode
 %                        pairing on which the deformation energy is based
 %   cfg.isodistance    = 'yes', 'no' (default) or number, to enforce isotropic
 %                        inter-electrode distances (pairmethod 'label' only)
-%   cfg.deformweight   = number (default: 1), weight of deformation relative 
+%   cfg.deformweight   = number (default: 1), weight of deformation relative
 %                        to shift energy cost (lower increases grid flexibility)
 %
 % If you want to move the electrodes inward, you should specify
@@ -127,10 +128,18 @@ function [elec_realigned] = ft_electroderealign(cfg, elec_original)
 %   cfg.headshape      = string, filename containing subject headshape (e.g. <path to freesurfer/surf/lh.pial>)
 %   cfg.fshome         = string, path to freesurfer
 %
+% If you want to transform electrodes from individual subject coordinates to MNI
+% space, you should specify the following
+%   cfg.mri            = structure with the individual anatomical MRI relative to which electrodes are specified, or the filename of the MRI, see FT_READ_MRI
+%   cfg.templatemri    = string, filename of the MNI template (default = 'T1.mnc' for SPM2 or 'T1.nii' for SPM8 and SPM12)
+%   cfg.spmversion     = string, 'spm2', 'spm8', 'spm12' (default = 'spm12')
+%   cfg.spmmethod      = string, 'old', 'new' or 'mars', see FT_VOLUMENORMALISE
+%   cfg.nonlinear      = string, 'yes' or 'no', see FT_VOLUMENORMALISE
+%
 % See also FT_READ_SENS, FT_VOLUMEREALIGN, FT_INTERACTIVEREALIGN,
 % FT_DETERMINE_COORDSYS, FT_PREPARE_MESH
 
-% Copyright (C) 2005-2019, Robert Oostenveld, Arjen Stolk
+% Copyright (C) 2005-2021, Robert Oostenveld, Arjen Stolk
 %
 % This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
 % for the documentation and details.
@@ -327,13 +336,13 @@ norm = [];
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 if strcmp(cfg.method, 'template')
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
+  
   % determine electrode selection and overlapping subset for warping
   cfg.channel = ft_channelselection(cfg.channel, elec.label);
   for i=1:Ntemplate
     cfg.channel = ft_channelselection(cfg.channel, target(i).label);
   end
-
+  
   % make consistent subselection of electrodes
   [cfgsel, datsel] = match_str(cfg.channel, elec.label);
   elec.label = elec.label(datsel);
@@ -343,18 +352,18 @@ if strcmp(cfg.method, 'template')
     target(i).label   = target(i).label(datsel);
     target(i).elecpos = target(i).elecpos(datsel,:);
   end
-
+  
   % compute the average of the target electrode positions
   average = ft_average_sens(target);
-
+  
   fprintf('warping electrodes to average template... '); % the newline comes later
   [norm.elecpos, norm.m] = ft_warp_optim(elec.elecpos, average.elecpos, cfg.warp);
   norm.label = elec.label;
-
+  
   dpre  = mean(sqrt(sum((average.elecpos - elec.elecpos).^2, 2)));
   dpost = mean(sqrt(sum((average.elecpos - norm.elecpos).^2, 2)));
   fprintf('mean distance prior to warping %f, after warping %f\n', dpre, dpost);
-
+  
   if strcmp(cfg.feedback, 'yes')
     % create an empty figure, continued below...
     figure
@@ -364,31 +373,31 @@ if strcmp(cfg.method, 'template')
     xlabel('x')
     ylabel('y')
     zlabel('z')
-
+    
     % plot all electrodes before warping
     ft_plot_sens(elec, 'r*');
-
+    
     % plot all electrodes after warping
     ft_plot_sens(norm, 'm.', 'label', 'label');
-
+    
     % plot the template electrode locations
     ft_plot_sens(average, 'b.');
-
+    
     % plot lines connecting the input and the realigned electrode locations with the template locations
     my_line3(elec.elecpos, average.elecpos, 'color', 'r');
     my_line3(norm.elecpos, average.elecpos, 'color', 'm');
   end
-
+  
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 elseif strcmp(cfg.method, 'headshape')
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
+  
   % determine electrode selection and overlapping subset for warping
   cfg.channel = ft_channelselection(cfg.channel, elec.label);
   [cfgsel, datsel] = match_str(cfg.channel, elec.label);
   elec.label   = elec.label(datsel);
   elec.elecpos = elec.elecpos(datsel,:);
-
+  
   norm.label = elec.label;
   if strcmp(cfg.warp, 'dykstra2012')
     norm.elecpos = warp_dykstra2012(cfg, elec, headshape);
@@ -403,19 +412,19 @@ elseif strcmp(cfg.method, 'headshape')
   else
     fprintf('warping electrodes to skin surface... '); % the newline comes later
     [norm.elecpos, norm.m] = ft_warp_optim(elec.elecpos, headshape, cfg.warp);
-
+    
     dpre  = ft_warp_error([],     elec.elecpos, headshape, cfg.warp);
     dpost = ft_warp_error(norm.m, elec.elecpos, headshape, cfg.warp);
     fprintf('mean distance prior to warping %f, after warping %f\n', dpre, dpost);
   end
-
+  
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 elseif strcmp(cfg.method, 'fiducial')
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
+  
   % the fiducials have to be present in the electrodes and in the template set
   label = intersect(lower(elec.label), lower(target.label));
-
+  
   if ~isfield(cfg, 'fiducial') || isempty(cfg.fiducial)
     % try to determine the names of the fiducials automatically
     option1 = {'nasion' 'left' 'right'};
@@ -441,17 +450,17 @@ elseif strcmp(cfg.method, 'fiducial')
     end
   end
   fprintf('matching fiducials {''%s'', ''%s'', ''%s''}\n', cfg.fiducial{1}, cfg.fiducial{2}, cfg.fiducial{3});
-
+  
   % determine electrode selection
   cfg.channel = ft_channelselection(cfg.channel, elec.label);
   [cfgsel, datsel] = match_str(cfg.channel, elec.label);
   elec.label     = elec.label(datsel);
   elec.elecpos   = elec.elecpos(datsel,:);
-
+  
   if length(cfg.fiducial)~=3
     ft_error('you must specify exactly three fiducials');
   end
-
+  
   % do case-insensitive search for fiducial locations
   nas_indx = match_str(lower(elec.label), lower(cfg.fiducial{1}));
   lpa_indx = match_str(lower(elec.label), lower(cfg.fiducial{2}));
@@ -462,11 +471,11 @@ elseif strcmp(cfg.method, 'fiducial')
   elec_nas = elec.elecpos(nas_indx,:);
   elec_lpa = elec.elecpos(lpa_indx,:);
   elec_rpa = elec.elecpos(rpa_indx,:);
-
+  
   % FIXME change the flow in the remainder
   % if one or more template electrode sets are specified, then align to the average of those
   % if no template is specified, then align so that the fiducials are along the axis
-
+  
   % find the matching fiducials in the template and average them
   tmpl_nas = nan(Ntemplate,3);
   tmpl_lpa = nan(Ntemplate,3);
@@ -485,21 +494,21 @@ elseif strcmp(cfg.method, 'fiducial')
   tmpl_nas = mean(tmpl_nas,1);
   tmpl_lpa = mean(tmpl_lpa,1);
   tmpl_rpa = mean(tmpl_rpa,1);
-
+  
   % realign both to a common coordinate system
   elec2common  = ft_headcoordinates(elec_nas, elec_lpa, elec_rpa);
   templ2common = ft_headcoordinates(tmpl_nas, tmpl_lpa, tmpl_rpa);
-
+  
   % compute the combined transform
   norm         = [];
   norm.m       = templ2common \ elec2common;
-
+  
   % apply the transformation to the fiducials as sanity check
   norm.elecpos(1,:) = ft_warp_apply(norm.m, elec_nas, 'homogeneous');
   norm.elecpos(2,:) = ft_warp_apply(norm.m, elec_lpa, 'homogeneous');
   norm.elecpos(3,:) = ft_warp_apply(norm.m, elec_rpa, 'homogeneous');
   norm.label        = cfg.fiducial;
-
+  
   nas_indx = match_str(lower(elec.label), lower(cfg.fiducial{1}));
   lpa_indx = match_str(lower(elec.label), lower(cfg.fiducial{2}));
   rpa_indx = match_str(lower(elec.label), lower(cfg.fiducial{3}));
@@ -509,7 +518,7 @@ elseif strcmp(cfg.method, 'fiducial')
   rpa_indx = match_str(lower(norm.label), lower(cfg.fiducial{3}));
   dpost = mean(sqrt(sum((norm.elecpos([nas_indx lpa_indx rpa_indx],:) - [tmpl_nas; tmpl_lpa; tmpl_rpa]).^2, 2)));
   fprintf('mean distance between fiducials prior to realignment %f, after realignment %f\n', dpre, dpost);
-
+  
   if strcmp(cfg.feedback, 'yes')
     % create an empty figure, continued below...
     figure
@@ -519,7 +528,7 @@ elseif strcmp(cfg.method, 'fiducial')
     xlabel('x')
     ylabel('y')
     zlabel('z')
-
+    
     % plot the first three electrodes before transformation
     my_plot3(elec.elecpos(1,:), 'r*');
     my_plot3(elec.elecpos(2,:), 'r*');
@@ -527,7 +536,7 @@ elseif strcmp(cfg.method, 'fiducial')
     my_text3(elec.elecpos(1,:), elec.label{1}, 'color', 'r');
     my_text3(elec.elecpos(2,:), elec.label{2}, 'color', 'r');
     my_text3(elec.elecpos(3,:), elec.label{3}, 'color', 'r');
-
+    
     % plot the template fiducials
     my_plot3(tmpl_nas, 'b*');
     my_plot3(tmpl_lpa, 'b*');
@@ -535,7 +544,7 @@ elseif strcmp(cfg.method, 'fiducial')
     my_text3(tmpl_nas, ' nas', 'color', 'b');
     my_text3(tmpl_lpa, ' lpa', 'color', 'b');
     my_text3(tmpl_rpa, ' rpa', 'color', 'b');
-
+    
     % plot all electrodes after transformation
     my_plot3(norm.elecpos, 'm.');
     my_plot3(norm.elecpos(1,:), 'm*');
@@ -545,11 +554,11 @@ elseif strcmp(cfg.method, 'fiducial')
     my_text3(norm.elecpos(2,:), norm.label{2}, 'color', 'm');
     my_text3(norm.elecpos(3,:), norm.label{3}, 'color', 'm');
   end
-
+  
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 elseif strcmp(cfg.method, 'interactive')
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
+  
   tmpcfg = [];
   tmpcfg.individual.elec = elec;
   if isfield(cfg, 'headshape') && ~isempty(cfg.headshape)
@@ -569,13 +578,12 @@ elseif strcmp(cfg.method, 'interactive')
     tmpcfg.template.elecstyle = {'facecolor', 'blue'};
     ft_info('plotting the target electrodes in blue');
   end
-
+  
   % use the more generic ft_interactiverealign for the actual work
   tmpcfg = ft_interactiverealign(tmpcfg);
   % only keep the transformation, it will be applied to the electrodes further down
   norm.m = tmpcfg.m;
-
-
+  
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 elseif strcmp(cfg.method, 'project')
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -584,10 +592,10 @@ elseif strcmp(cfg.method, 'project')
   [cfgsel, datsel] = match_str(cfg.channel, elec.label);
   elec.label     = elec.label(datsel);
   elec.elecpos   = elec.elecpos(datsel,:);
-
+  
   norm.label = elec.label;
   [dum, norm.elecpos] = project_elec(elec.elecpos, headshape.pos, headshape.tri);
-
+  
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 elseif strcmp(cfg.method, 'moveinward')
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -596,10 +604,37 @@ elseif strcmp(cfg.method, 'moveinward')
   [cfgsel, datsel] = match_str(cfg.channel, elec.label);
   elec.label     = elec.label(datsel);
   elec.elecpos   = elec.elecpos(datsel,:);
-
+  
   norm.label = elec.label;
   norm.elecpos = moveinward(elec.elecpos, cfg.moveinward);
-
+  
+  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+elseif strcmp(cfg.method, 'mni')
+  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  
+  % get the anatomical mri
+  if ischar(cfg.mri)
+    mri = ft_read_mri(cfg.mri);
+  else
+    mri = cfg.mri;
+  end
+  
+  % ensure consistent units of the electrodes and individual anatomical MRI with the template MRI (assumed to be in mm)
+  mri  = ft_convert_units(mri,  'mm');
+  elec = ft_convert_units(elec, 'mm');
+  
+  % spatial normalisation of the MRI to the template
+  tmpcfg           = keepfields(cfg, {'spmversion', 'spmmethod', 'nonlinear'});
+  if isfield(cfg, 'templatemri')
+    % this option is called differently for the two functions
+    tmpcfg.template = cfg.templatemri;
+  end
+  normalise = ft_volumenormalise(tmpcfg, mri);
+  
+  % the normalisation from original subject head coordinates to MNI consists of an initial rigid body transformation, followed by a more precise (non)linear transformation
+  norm.label = elec.label;
+  norm.elecpos = ft_warp_apply(normalise.params, ft_warp_apply(normalise.initial, elec.elecpos, 'homogeneous'), 'individual2sn');
+  
 else
   ft_error('unknown method');
 end % if method
@@ -629,19 +664,19 @@ switch cfg.method
       % remember the transformation
       elec_realigned.(cfg.warp) = norm.m;
     end
-
+    
   case  {'fiducial' 'interactive'}
     % the transformation is a 4x4 homogenous matrix
     % apply the transformation to the original complete set of sensors
     elec_realigned = ft_transform_geometry(norm.m, elec_original);
     % remember the transformation
     elec_realigned.homogeneous = norm.m;
-
+    
   case {'project', 'moveinward'}
     % nothing to be done
     elec_realigned = norm;
     elec_realigned.label = label_original;
-
+    
   otherwise
     ft_error('unknown method');
 end

--- a/ft_prepare_sourcemodel.m
+++ b/ft_prepare_sourcemodel.m
@@ -30,8 +30,8 @@ function [sourcemodel, cfg] = ft_prepare_sourcemodel(cfg)
 %   cfg.zgrid         = vector (e.g.   0:1:20) or 'auto' (default = 'auto')
 %   cfg.resolution    = number (e.g. 1 cm) for automatic grid generation
 %
-% BASEDONPOS - places sources on positions that you explicitly specify,
-% according to the following configuration options:
+% BASEDONPOS - places sources on positions that you explicitly specify, according to
+% the following configuration options:
 %   cfg.sourcemodel.pos       = N*3 matrix with position of each source
 %   cfg.sourcemodel.inside    = N*1 vector with boolean value whether position is inside brain (optional)
 %   cfg.sourcemodel.dim       = [Nx Ny Nz] vector with dimensions in case of 3D grid (optional)
@@ -42,13 +42,17 @@ function [sourcemodel, cfg] = ft_prepare_sourcemodel(cfg)
 %   cfg.sourcemodel.subspace
 %   cfg.sourcemodel.lbex
 %
-% BASEDONMNI - uses source positions from a template sourcemodel that is
-% inversely warped from MNI coordinates to the individual subjects MRI.
-% It uses the following configuration options:
-%   cfg.mri             = structure with anatomical MRI model or filename, see FT_READ_MRI
+% BASEDONMNI - uses source positions from a template sourcemodel that is inversely
+% warped from MNI coordinates to the individual subjects MRI. It uses the following
+% configuration options:
+%   cfg.mri             = structure with the anatomical MRI, or the filename of the MRI, see FT_READ_MRI
 %   cfg.nonlinear       = 'no' (or 'yes'), use non-linear normalization
 %   cfg.resolution      = number (e.g. 6) of the resolution of the template MNI grid, defined in mm
-%   cfg.template        = specification of a template sourcemodel as structure, or the filename of a template sourcemodel (defined in MNI space)
+%   cfg.template        = structure with the template sourcemodel, or the filename of a template sourcemodel (defined in MNI space)
+%   cfg.templatemri     = string, filename of the MNI template (default = 'T1.mnc' for SPM2 or 'T1.nii' for SPM8 and SPM12)
+%   cfg.spmversion      = string, 'spm2', 'spm8', 'spm12' (default = 'spm12')
+%   cfg.spmmethod       = string, 'old', 'new' or 'mars', see FT_VOLUMENORMALISE
+%   cfg.nonlinear       = string, 'yes' or 'no', see FT_VOLUMENORMALISE
 % Either cfg.resolution or cfg.template needs to be defined; if both are defined, cfg.template prevails.
 %
 % BASEDONMRI - makes a segmentation of the individual anatomical MRI and places
@@ -104,7 +108,7 @@ function [sourcemodel, cfg] = ft_prepare_sourcemodel(cfg)
 % See also FT_PREPARE_LEADFIELD, FT_PREPARE_HEADMODEL, FT_SOURCEANALYSIS,
 % FT_DIPOLEFITTING, FT_MEGREALIGN
 
-% Copyright (C) 2004-2020, Robert Oostenveld
+% Copyright (C) 2004-2021, Robert Oostenveld
 %
 % This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
 % for the documentation and details.
@@ -648,7 +652,7 @@ switch cfg.method
     % ensure that it is specified with logical inside
     mnigrid = fixinside(mnigrid);
     
-    % spatial normalisation of mri and construction of subject specific sourcemodel positions
+    % spatial normalisation of the MRI to the template
     tmpcfg           = keepfields(cfg, {'spmversion', 'spmmethod', 'nonlinear'});
     if isfield(cfg, 'templatemri')
       % this option is called differently for the two functions
@@ -656,16 +660,11 @@ switch cfg.method
     end
     normalise = ft_volumenormalise(tmpcfg, mri);
     
-    if ~isfield(normalise, 'params') && ~isfield(normalise, 'initial')
-      % this is for older implementations of FT_VOLUMENORMALISE
-      fprintf('applying an inverse warp based on a linear transformation only\n');
-      sourcemodel.pos = ft_warp_apply(inv(normalise.cfg.final), mnigrid.pos);
-    else
-      % the normalisation from original subject head coordinates to MNI consists of an initial linear, followed by a nonlinear transformation
-      % the reverse transformations need to be done to get from MNI to the original subject head coordinates
-      % first apply the inverse of the nonlinear transformation, followed by the inverse of the initial linear transformation
-      sourcemodel.pos = ft_warp_apply(inv(normalise.initial), ft_warp_apply(normalise.params, mnigrid.pos, 'sn2individual'));
-    end
+    % the normalisation from original subject head coordinates to MNI consists of an initial rigid body transformation, followed by a more precise (non)linear transformation
+    % the reverse transformations are used to get from MNI to the original subject head coordinates
+    % first apply the inverse of the nonlinear transformation, followed by the inverse of the initial rigid body transformation
+    sourcemodel.pos = ft_warp_apply(inv(normalise.initial), ft_warp_apply(normalise.params, mnigrid.pos, 'sn2individual'), 'homogeneous');
+    
     % copy some of the fields over from the input arguments
     sourcemodel = copyfields(mri,       sourcemodel, {'unit', 'coordsys'});
     sourcemodel = copyfields(mnigrid,   sourcemodel, {'dim', 'tri', 'inside'});

--- a/ft_volumenormalise.m
+++ b/ft_volumenormalise.m
@@ -19,7 +19,7 @@ function [normalised] = ft_volumenormalise(cfg, mri)
 %                          template MRI specified in cfg.template.
 %   cfg.opts             = structure with normalisation options, see SPM documentation for details
 %   cfg.template         = string, filename of the template anatomical MRI (default = 'T1.mnc'
-%                          for spm2 or 'T1.nii' for spm8 and for spm12).
+%                          for SPM2 or 'T1.nii' for SPM8 and SPM12).
 %   cfg.templatecoordsys = the coordinate system of the template when using a template other
 %                          than the default
 %   cfg.tpm              = string, file name of the SPM tissue probablility map to use in
@@ -181,13 +181,20 @@ end
 
 % Ensure that the input MRI has interpretable units and that it is expressed in a
 % coordinate system which is in approximate agreement with the template.
-ft_notice('Doing initial alignment...')
 mri  = ft_convert_units(mri, 'mm'); % this assumes that the template is expressed in mm
-orig = mri.transform;
-mri  = ft_convert_coordsys(mri, cfg.templatecoordsys, 2, cfg.template);
 
-% keep track of an initial transformation matrix that does the approximate co-registration
-initial = mri.transform / orig;
+if ~isfield(cfg, 'initial')
+  ft_notice('Doing initial alignment...')
+  orig = mri.transform;
+  mri  = ft_convert_coordsys(mri, cfg.templatecoordsys, 2, cfg.template);
+  % keep track of the initial rigid body transformation that does the approximate co-registration
+  initial = mri.transform / orig;
+else
+  ft_notice('Skipping the initial alignment, using the alignment specified in the configuration');
+  initial = cfg.initial;
+  % apply the initial rigid body transformation to the input data
+  mri.transform = initial * mri.transform; 
+end
 
 % use NIFTI whenever possible
 if strcmpi(cfg.spmversion, 'spm2')
@@ -237,13 +244,13 @@ if ~isfield(cfg, 'spmparams')
   if strcmp(cfg.spmmethod, 'old') && strcmp(cfg.nonlinear, 'yes')
     ft_info('Warping the individual anatomy to the template anatomy, using non-linear transformations');
     % compute the parameters by warping the individual anatomy
-    params    = spm_normalise(VG, VF(1));
+    params = spm_normalise(VG, VF(1));
     
   elseif strcmp(cfg.spmmethod, 'old') && strcmp(cfg.nonlinear, 'no')
     ft_info('Warping the individual anatomy to the template anatomy, using only linear transformations');
     % compute the parameters by warping the individual anatomy
     cfg.opts.nits = ft_getopt(cfg.opts, 'nits', 0); % put number of non-linear iterations to zero
-    params    = spm_normalise(VG, VF(1), [], [], [], cfg.opts);
+    params = spm_normalise(VG, VF(1), [], [], [], cfg.opts);
     
   elseif strcmp(cfg.spmmethod, 'new') || strcmp(cfg.spmmethod, 'mars')
     ft_info('Warping the individual anatomy to the template anatomy, using the %s-style segmentation', cfg.spmmethod);
@@ -344,9 +351,6 @@ for k=1:length(Vout)
   normalised = setsubfield(normalised, cfg.parameter{k}, spm_read_vols(Vout(k)));
 end
 
-% determine the affine coordinate transformation from individual head coordinates to template coordinates
-final = VG.mat * inv(params.Affine) * inv(VF(1).mat) * initial;
-
 normalised.transform = Vout(1).mat;
 normalised.dim       = size(normalised.anatomy);
 normalised.params    = params;  % this holds the normalization parameters
@@ -384,10 +388,13 @@ end
 ft_postamble debug
 ft_postamble trackconfig
 
-% remember the normalisation parameters in the configuration
-% maintain this order for the time being to prevent them to be removed when doing the trackconfig
+% Remember the initial and normalisation parameters in the configuration, this allows
+% redoing the transformations without any computations (e.g. estimating them on a T1
+% and applying them on a T2)
+%
+% they are added only here to prevent them to be removed when doing the trackconfig
+cfg.initial   = initial;
 cfg.spmparams = params;
-cfg.final     = final;
 
 ft_postamble previous   mri
 ft_postamble provenance normalised


### PR DESCRIPTION
See #1873, this is a reimplementation according to the comments there.

- the input cfg to ft_volumenormalise can now also have `cfg.initial`, just like `cfg.spmparams`
- the output of ft_volumenormalise does not have the `final` 4x4 matrix any more, since it is not being used elsewhere in FT