### PR TITLE
add support for the scanras/nifti and scanlps/dicom coordinate system

### DIFF
--- a/plotting/private/coordsys2label.m
+++ b/plotting/private/coordsys2label.m
@@ -74,7 +74,9 @@ if ~isempty(coordsys) && ~strcmp(coordsys, 'unknown')
     
   else
     switch lower(coordsys)
-      case {'ras' 'neuromag' 'itab' 'acpc' 'spm' 'mni' 'tal'}
+      case {'ras' 'scanras' 'nifti' 'neuromag' 'itab' 'acpc' 'spm' 'mni' 'tal'}
+        % the nifti coordinate system is defined according to https://doi.org/10.1016/j.jneumeth.2016.03.001 and https://github.com/fieldtrip/website/pull/444
+        % but see also https://brainder.org/2012/09/23/the-nifti-file-format/ which shows that it can be more complex than that
         labelx = {'-X (left)'      '+X (right)'   };
         labely = {'-Y (posterior)' '+Y (anterior)'};
         labelz = {'-Z (inferior)'  '+Z (superior)'};
@@ -82,17 +84,17 @@ if ~isempty(coordsys) && ~strcmp(coordsys, 'unknown')
         labelx = {'-X (posterior)' '+X (anterior)'};
         labely = {'-Y (right)'     '+Y (left)'};
         labelz = {'-Z (inferior)'  '+Z (superior)'};
+      case {'lps' 'scanlps' 'dicom'}
+        labelx = {'-X (right)'     '+X (left)'};
+        labely = {'-Y (anterior)'  '+Y (posterior)'};
+        labelz = {'-Z (inferior)'  '+Z (superior)'};
       case {'rsp' 'paxinos'}
         labelx = {'-X (left)'      '+X (right)'};
         labely = {'-Y (inferior)'  '+Y (superior)'};
         labelz = {'-Z (anterior)'  '+Z (posterior)'};
-      case {'lps'}
-        labelx = {'-X (right)'      '+X (left)'};
-        labely = {'-Y (anterior)'  '+Y (posterior)'};
-        labelz = {'-Z (inferior)'  '+Z (superior)'};
       otherwise
         % the coordinate system is unknown
-        ft_warning('unknown coordsys ''%s''', coordsys);
+        ft_warning('cannot determine the labels for the axes of the "%s" coordinate system', coordsys);
         labelx = {'-X (unknown)' '+X (unknown)'};
         labely = {'-Y (unknown)' '+Y (unknown)'};
         labelz = {'-Z (unknown)' '+Z (unknown)'};

--- a/private/coordsys2label.m
+++ b/private/coordsys2label.m
@@ -74,7 +74,9 @@ if ~isempty(coordsys) && ~strcmp(coordsys, 'unknown')
     
   else
     switch lower(coordsys)
-      case {'ras' 'neuromag' 'itab' 'acpc' 'spm' 'mni' 'tal'}
+      case {'ras' 'scanras' 'nifti' 'neuromag' 'itab' 'acpc' 'spm' 'mni' 'tal'}
+        % the nifti coordinate system is defined according to https://doi.org/10.1016/j.jneumeth.2016.03.001 and https://github.com/fieldtrip/website/pull/444
+        % but see also https://brainder.org/2012/09/23/the-nifti-file-format/ which shows that it can be more complex than that
         labelx = {'-X (left)'      '+X (right)'   };
         labely = {'-Y (posterior)' '+Y (anterior)'};
         labelz = {'-Z (inferior)'  '+Z (superior)'};
@@ -82,17 +84,17 @@ if ~isempty(coordsys) && ~strcmp(coordsys, 'unknown')
         labelx = {'-X (posterior)' '+X (anterior)'};
         labely = {'-Y (right)'     '+Y (left)'};
         labelz = {'-Z (inferior)'  '+Z (superior)'};
+      case {'lps' 'scanlps' 'dicom'}
+        labelx = {'-X (right)'     '+X (left)'};
+        labely = {'-Y (anterior)'  '+Y (posterior)'};
+        labelz = {'-Z (inferior)'  '+Z (superior)'};
       case {'rsp' 'paxinos'}
         labelx = {'-X (left)'      '+X (right)'};
         labely = {'-Y (inferior)'  '+Y (superior)'};
         labelz = {'-Z (anterior)'  '+Z (posterior)'};
-      case {'lps'}
-        labelx = {'-X (right)'      '+X (left)'};
-        labely = {'-Y (anterior)'  '+Y (posterior)'};
-        labelz = {'-Z (inferior)'  '+Z (superior)'};
       otherwise
         % the coordinate system is unknown
-        ft_warning('unknown coordsys ''%s''', coordsys);
+        ft_warning('cannot determine the labels for the axes of the "%s" coordinate system', coordsys);
         labelx = {'-X (unknown)' '+X (unknown)'};
         labely = {'-Y (unknown)' '+Y (unknown)'};
         labelz = {'-Z (unknown)' '+Z (unknown)'};

--- a/private/fixcoordsys.m
+++ b/private/fixcoordsys.m
@@ -28,7 +28,7 @@ function data = fixcoordsys(data)
 
 data.coordsys = lower(data.coordsys);
 
-% see also http://www.fieldtriptoolbox.org/faq/how_are_the_different_head_and_mri_coordinate_systems_defined
+% see also http://www.fieldtriptoolbox.org/faq/coordsys
 if any(strcmpi(data.coordsys, {'mni', 'spm'}))
   data.coordsys = 'mni';
 elseif any(strcmpi(data.coordsys, {'ctf', '4d', 'bti', 'eeglab'}))

--- a/private/setviewpoint.m
+++ b/private/setviewpoint.m
@@ -26,7 +26,7 @@ switch viewpoint
 end
 
 switch lower(coordsys)
-  case {'ras' 'neuromag' 'itab' 'acpc' 'spm' 'mni' 'tal'}
+  case {'ras' 'scanras' 'nifti' 'neuromag' 'itab' 'acpc' 'spm' 'mni' 'tal'}
     switch viewpoint
       case 'superior'
         view(ax, [0 0 1]); % the nose is pointing up
@@ -56,6 +56,21 @@ switch lower(coordsys)
       case 'posterior'
         view(ax, [-1 0 0]);
     end % switch viewpoint
+  case {'lps' 'scanlps' 'dicom'}
+    switch viewpoint
+      case 'superior'
+        view(ax, [180 90]); % not exactly the same as [0 0 1], this causes the nose pointing up
+      case 'inferior'
+        view(ax, [0 -90]); % not exactly the same as [0 0 -1], this causes the noise pointing up
+      case 'left'
+        view(ax, [1 0 0]);
+      case 'right'
+        view(ax, [-1 0 0]);
+      case 'anterior'
+        view(ax, [0 -1 0]);
+      case 'posterior'
+        view(ax, [0 1 0]);
+    end % switch viewpoint
   case {'rsp' 'paxinos'}
     switch viewpoint
       case 'superior'
@@ -71,21 +86,6 @@ switch lower(coordsys)
       case 'posterior'
         view(ax, [0 0 1]);
     end % switch viewpoint
-  case {'lps'}
-    switch viewpoint
-      case 'superior'
-        view(ax, [0 0 1]);
-      case 'inferior'
-        view(ax, [0 0 -1]);
-      case 'left'
-        view(ax, [1 0 0]);
-      case 'right'
-        view(ax, [-1 0 0]);
-      case 'anterior'
-        view(ax, [0 -1 0]);
-      case 'posterior'
-        view(ax, [0 1 0]);
-    end % switch viewpoint
   otherwise
-    ft_warning('cannot change the viewpoint for "%s" coordinate system', coordsys);
+    ft_warning('cannot change the viewpoint for the "%s" coordinate system', coordsys);
 end % switch coordsys

--- a/utilities/ft_convert_coordsys.m
+++ b/utilities/ft_convert_coordsys.m
@@ -138,7 +138,7 @@ generic = {
   'lsa'; 'lia'; 'rsa'; 'ria';...
   'lsp'; 'lip'; 'rsp'; 'rip'}';
 
-specific = {'ctf', 'bti', 'fourd', 'yokogawa', 'eeglab', 'neuromag', 'itab', 'acpc', 'spm', 'mni', 'fsaverage', 'tal'};
+specific = {'ctf', 'bti', 'fourd', 'yokogawa', 'eeglab', 'neuromag', 'itab', 'acpc', 'spm', 'mni', 'fsaverage', 'tal', 'scanras', 'scanlps', 'dicom', 'nifti'};
 
 % generic orientation triplets (like RAS and ALS) are not specific with regard to the origin
 if ismember(object.coordsys, generic) && strcmp(target, 'acpc')
@@ -163,7 +163,7 @@ end
 % this is based on the ear canals, see ALIGN_CTF2ACPC
 acpc2ctf = [
   0.0000  0.9987  0.0517  34.7467
- -1.0000  0.0000  0.0000   0.0000
+  -1.0000  0.0000  0.0000   0.0000
   0.0000 -0.0517  0.9987  52.2749
   0.0000  0.0000  0.0000   1.0000
   ];
@@ -180,7 +180,7 @@ acpc2neuromag = [
 fsaverage2mni = [
   0.9975   -0.0073    0.0176   -0.0429
   0.0146    1.0009   -0.0024    1.5496
- -0.0130   -0.0093    0.9971    1.1840
+  -0.0130   -0.0093    0.9971    1.1840
   0.0000    0.0000    0.0000    1.0000
   ];
 
@@ -210,20 +210,20 @@ mni2tal = [
   0.0000    0.0000    0.0000    1.0000
   ];
 
-% the CTF and BTI coordinate system are the same, see http://www.fieldtriptoolbox.org/faq/how_are_the_different_head_and_mri_coordinate_systems_defined/
+% the CTF and BTI coordinate system are the same, see http://www.fieldtriptoolbox.org/faq/coordsys/
 ctf2bti = eye(4);
 
-% the CTF and EEGLAB coordinate system are the same, see http://www.fieldtriptoolbox.org/faq/how_are_the_different_head_and_mri_coordinate_systems_defined/
+% the CTF and EEGLAB coordinate system are the same, see http://www.fieldtriptoolbox.org/faq/coordsys/
 ctf2eeglab = eye(4);
 
-% the Neuromag and Itab coordinate system are the same, see http://www.fieldtriptoolbox.org/faq/how_are_the_different_head_and_mri_coordinate_systems_defined/#details-of-the-ctf-coordinate-system
+% the Neuromag and Itab coordinate system are the same, see http://www.fieldtriptoolbox.org/faq/coordsys/
 neuromag2itab = eye(4);
 
-% BTI and 4D are different names for exactly the same system
+% BTI and 4D are different names for exactly the same system, see http://www.fieldtriptoolbox.org/faq/coordsys/
 bti2fourd = eye(4);
 
 % the Yokogawa system expresses positions relative to the dewar, not relative to the head
-% see https://www.fieldtriptoolbox.org/faq/how_are_the_different_head_and_mri_coordinate_systems_defined/#details-of-the-yokogawa-coordinate-system
+% see https://www.fieldtriptoolbox.org/faq/coordsys/#details-of-the-yokogawa-coordinate-system
 yokogawa2als = eye(4);
 
 % the SPM and MNI coordinate system are the same, see http://www.fieldtriptoolbox.org/faq/acpc/
@@ -248,6 +248,17 @@ mni2ras       = eye(4);
 spm2ras       = eye(4);
 fsaverage2ras = eye(4);
 tal2ras       = eye(4);
+
+% the NIFTI, and SCANRAS coordinate system are the same
+% the DICOM and SCANALS coordinate system are the same, and rotated 180 degrees from SCANRAS
+nifti2scanras   = eye(4);
+nifti2ras       = eye(4);
+scanras2ras     = eye(4);
+dicom2scanlps   = eye(4);
+dicom2lps       = eye(4);
+scanlps2lps     = eye(4);
+scanlps2scanras = lps2ras; % this is a 180 degree rotation around the z-axis
+dicom2nifti     = lps2ras; % this is a 180 degree rotation around the z-axis
 
 % make the combined and the inverse transformations where possible
 coordsys = [specific generic];
@@ -373,7 +384,7 @@ if method>0
   end
   if ~any(ismember(object.coordsys, {'acpc', 'spm', 'mni', 'fsaverage', 'tal'}))
     % this constraint could be relaxed if we would know that the template is expressed in another coordinate system
-%     ft_error('affine or non-linear transformation is only supported for data in an SPM-like coordinate systems');
+    %     ft_error('affine or non-linear transformation is only supported for data in an SPM-like coordinate systems');
   end
   
   % this requires SPM to be on the path. However, this is not the proper place to
@@ -464,7 +475,7 @@ elseif method==2
         end
         fprintf('using ''OldNorm'' normalisation\n');
       otherwise
-          ft_error('unsupported SPM version');
+        ft_error('unsupported SPM version');
     end
   end
   template = ft_read_mri(templatefile);

--- a/utilities/ft_determine_coordsys.m
+++ b/utilities/ft_determine_coordsys.m
@@ -8,7 +8,8 @@ function [data] = ft_determine_coordsys(data, varargin)
 %   [dataout] = ft_determine_coordsys(datain, ...)
 % where the input data structure can be either
 %  - an anatomical MRI
-%  - an electrode or gradiometer definition
+%  - a cortical or head surface mesh
+%  - an electrode, gradiometer or optode definition
 %  - a volume conduction model of the head
 % or most other FieldTrip structures that represent geometrical information.
 %
@@ -30,7 +31,7 @@ function [data] = ft_determine_coordsys(data, varargin)
 %
 % See also FT_CONVERT_COORDSYS, FT_DETERMINE_UNITS, FT_CONVERT_UNITS, FT_PLOT_AXES, FT_PLOT_XXX
 
-% Copyright (C) 2015, Jan-Mathijs Schoffelen
+% Copyright (C) 2015-2021, Jan-Mathijs Schoffelen
 %
 % This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
 % for the documentation and details.
@@ -217,18 +218,23 @@ if istrue(dointeractive)
 
   % interactively determine origin
   origin = ' ';
-  while ~any(strcmp(origin, {'a', 'i', 'n'}))
-    origin = input('Is the origin of the coordinate system at the a(nterior commissure), i(nterauricular), n(ot a landmark)? ', 's');
+  while ~any(strcmp(origin, {'a', 'i', 's', 'n'}))
+    origin = input('Is the origin of the coordinate system at the a(nterior commissure), i(nterauricular), s(scanner origin), n(ot a landmark)? ', 's');
   end
 
+  % some coordinate systems are identical or very similar, see https://www.fieldtriptoolbox.org/faq/coordsys
   if origin=='a' && strcmp(orientation, 'ras')
     coordsys = 'acpc'; % also used for spm, mni, tal
   elseif origin=='i' && strcmp(orientation, 'als')
     coordsys = 'ctf'; % also used for 4d, bti, eeglab
   elseif origin=='i' && strcmp(orientation, 'ras')
     coordsys = 'neuromag'; % also used for itab
+  elseif origin=='s' && strcmp(orientation, 'ras')
+    coordsys = 'scanras'; % also used for nifti
+  elseif origin=='s' && strcmp(orientation, 'lps')
+    coordsys = 'scanlps'; % also used for dicom
   else
-    % just use the orientation
+    % only use the orientation, not the origin
     coordsys = orientation;
   end
 

--- a/utilities/private/coordsys2label.m
+++ b/utilities/private/coordsys2label.m
@@ -74,7 +74,9 @@ if ~isempty(coordsys) && ~strcmp(coordsys, 'unknown')
     
   else
     switch lower(coordsys)
-      case {'ras' 'neuromag' 'itab' 'acpc' 'spm' 'mni' 'tal'}
+      case {'ras' 'scanras' 'nifti' 'neuromag' 'itab' 'acpc' 'spm' 'mni' 'tal'}
+        % the nifti coordinate system is defined according to https://doi.org/10.1016/j.jneumeth.2016.03.001 and https://github.com/fieldtrip/website/pull/444
+        % but see also https://brainder.org/2012/09/23/the-nifti-file-format/ which shows that it can be more complex than that
         labelx = {'-X (left)'      '+X (right)'   };
         labely = {'-Y (posterior)' '+Y (anterior)'};
         labelz = {'-Z (inferior)'  '+Z (superior)'};
@@ -82,17 +84,17 @@ if ~isempty(coordsys) && ~strcmp(coordsys, 'unknown')
         labelx = {'-X (posterior)' '+X (anterior)'};
         labely = {'-Y (right)'     '+Y (left)'};
         labelz = {'-Z (inferior)'  '+Z (superior)'};
+      case {'lps' 'scanlps' 'dicom'}
+        labelx = {'-X (right)'     '+X (left)'};
+        labely = {'-Y (anterior)'  '+Y (posterior)'};
+        labelz = {'-Z (inferior)'  '+Z (superior)'};
       case {'rsp' 'paxinos'}
         labelx = {'-X (left)'      '+X (right)'};
         labely = {'-Y (inferior)'  '+Y (superior)'};
         labelz = {'-Z (anterior)'  '+Z (posterior)'};
-      case {'lps'}
-        labelx = {'-X (right)'      '+X (left)'};
-        labely = {'-Y (anterior)'  '+Y (posterior)'};
-        labelz = {'-Z (inferior)'  '+Z (superior)'};
       otherwise
         % the coordinate system is unknown
-        ft_warning('unknown coordsys ''%s''', coordsys);
+        ft_warning('cannot determine the labels for the axes of the "%s" coordinate system', coordsys);
         labelx = {'-X (unknown)' '+X (unknown)'};
         labely = {'-Y (unknown)' '+Y (unknown)'};
         labelz = {'-Z (unknown)' '+Z (unknown)'};


### PR DESCRIPTION
Following investigations in https://github.com/fieldtrip/website/pull/444, these have been determined to have their origin in the MRI scanner origin (at the center of the gradient coil) and the direction of the axes is well defined. 

`ft_read_mri`, `ft_convert_coordsys`, and `ft_determine_coordsys` now all know how to work with these. Some private functions have also been updated. 
