### PR TITLE
enh: organize output of ft_electroderealign with method-mni

### DIFF
--- a/ft_electroderealign.m
+++ b/ft_electroderealign.m
@@ -672,7 +672,7 @@ switch cfg.method
     % remember the transformation
     elec_realigned.homogeneous = norm.m;
     
-  case {'project', 'moveinward'}
+  case {'project', 'moveinward', 'mni'}
     % nothing to be done
     elec_realigned = norm;
     elec_realigned.label = label_original;
@@ -716,6 +716,13 @@ switch cfg.method
     if isfield(elec_original, 'coordsys')
       elec_realigned.coordsys = elec_original.coordsys;
     end
+  case {'mni'}
+    % the coordinate system remains the same
+    if isfield(normalise, 'coordsys')
+      elec_realigned.coordsys = normalise.coordsys;
+    else
+      elec_realigned.coordsys = 'mni';
+    end  
   otherwise
     ft_error('unknown method');
 end


### PR DESCRIPTION
See https://github.com/fieldtrip/fieldtrip/pull/1875, this addition handles the output from cfg.method=mni.

As for the handling the coordsys, the coordsys from the templatemri is used, which is 'spm' for the default. Otherwise, 'mni' is chosen, that is the method's name. 