### PR TITLE
improve handling of coordsys for nifti files

### DIFF
--- a/fileio/ft_read_mri.m
+++ b/fileio/ft_read_mri.m
@@ -192,9 +192,9 @@ switch dataformat
     
     try
       % The nifti header allows three methods for specifying the coordinates of the
-      % voxels. For two of the methods (sform and qform), the header contains a
-      % numerical code from 0 to 4 that specifies the coordinate system. SPM8 and
-      % SPM12 use a field in the private header of the nifti object to code this.
+      % voxels. For two of them (sform and qform), the header contains a numerical
+      % code from 0 to 4 that specifies the coordinate system. SPM8 and SPM12 use a
+      % field in the private header of the nifti object to code this.
       switch hdr.private.mat_intent
         case 'UNKNOWN'
           coordsys = 'unknown';
@@ -210,7 +210,7 @@ switch dataformat
       
       % We cannot trust it yet, see https://github.com/fieldtrip/fieldtrip/issues/1879
       ft_notice('the coordinate system from the NIfTI file appears to be ''%s''\n', coordsys);
-      coordsys = 'unknown';
+      clear coordsys
     end
     
     
@@ -453,8 +453,8 @@ switch dataformat
     
     if isfield(hdr, 'niftihdr')
       % The nifti header allows three methods for specifying the coordinates of the
-      % voxels. For two of the methods (sform and qform), the header contains a
-      % numerical code that specifies the coordinate system.
+      % voxels. For two of them (sform and qform), the header contains a numerical
+      % code that specifies the coordinate system.
       coordsys = {'unknown', 'scanras', 'aligned', 'tal', 'mni152'}; % corresponding to 0, 1, 2, 3, 4
       if isequal(hdr.vox2ras0, hdr.niftihdr.sform)
         coordsys = coordsys{hdr.niftihdr.sform_code + 1};
@@ -466,7 +466,7 @@ switch dataformat
       
       % We cannot trust it yet, see https://github.com/fieldtrip/fieldtrip/issues/1879
       ft_notice('the coordinate system from the NIfTI file appears to be ''%s''\n', coordsys);
-      coordsys = 'unknown';
+      clear coordsys
     end
     
   case 'yokogawa_mri'

--- a/fileio/ft_read_mri.m
+++ b/fileio/ft_read_mri.m
@@ -11,7 +11,7 @@ function [mri] = ft_read_mri(filename, varargin)
 %   'dataformat'  = string specifying the file format, determining the low-level
 %                   reading routine to be used. If no explicit format is given,
 %                   it is determined automatically from the filename.
-%   'volumes'     = vector with the volume indices to read from a 4-D nifti (only for 'nifti_spm')
+%   'volumes'     = vector with the volume indices to read from a 4D nifti (only for 'nifti_spm')
 %   'outputfield' = string specifying the name of the field in the structure in which the
 %                   numeric data is stored (only for 'mrtrix_mif', default = 'anatomy')
 %   'fixel2voxel' = string, the operation to apply to the fixels belonging to the

--- a/fileio/ft_read_mri.m
+++ b/fileio/ft_read_mri.m
@@ -18,6 +18,7 @@ function [mri] = ft_read_mri(filename, varargin)
 %                  same voxel, can be 'max', 'min', 'mean' (only for 'mrtrix_mif', default = 'max')
 %   'indexfile'   = string, pointing to a fixel index file, if not present in the same directory
 %                   as the functional data (only for 'mrtrix_mif')
+%   'spmversion'  = string, version of SPM to be used (default = 'spm12')
 %
 % The supported dataformats are
 %   'afni_head'/'afni_brik'      uses AFNI code
@@ -94,6 +95,7 @@ filename = fetch_url(filename);
 % get the options
 dataformat  = ft_getopt(varargin, 'dataformat');
 outputfield = ft_getopt(varargin, 'outputfield', 'anatomy');
+spmversion  = ft_getopt(varargin, 'spmversion', 'spm12'); % this default is not used for minc files
 
 % the following is added for backward compatibility of using 'format' rather than 'dataformat'
 format    = ft_getopt(varargin, 'format');
@@ -110,8 +112,8 @@ if isempty(dataformat)
 end
 
 if strcmp(dataformat, 'compressed') || (strcmp(dataformat, 'freesurfer_mgz') && ispc) || any(filetype_check_extension(filename, {'gz', 'zip', 'tar', 'tgz'}))
-  % the file is compressed, unzip on the fly, 
-  % freesurfer mgz files get special treatment only on a pc  
+  % the file is compressed, unzip on the fly,
+  % freesurfer mgz files get special treatment only on a pc
   inflated = true;
   filename = inflate_file(filename);
   if strcmp(dataformat, 'freesurfer_mgz')
@@ -175,7 +177,7 @@ switch dataformat
   case 'nifti_spm'
     if ~(hasspm5 || hasspm8 || hasspm12)
       fprintf('the SPM5 or newer toolbox is required to read *.nii files\n');
-      ft_hastoolbox('spm12', 1);
+      ft_hastoolbox(spmversion, 1);
     end
     volumes = ft_getopt(varargin, 'volumes', []);
     
@@ -209,7 +211,7 @@ switch dataformat
       end
       
       % We cannot trust it yet, see https://github.com/fieldtrip/fieldtrip/issues/1879
-      ft_notice('the coordinate system from the NIfTI file appears to be ''%s''\n', coordsys);
+      ft_notice('the coordinate system appears to be ''%s''\n', coordsys);
       clear coordsys
     end
     
@@ -217,7 +219,7 @@ switch dataformat
   case {'analyze_img' 'analyze_hdr'}
     if ~(hasspm8 || hasspm12)
       fprintf('the SPM8 or newer toolbox is required to read analyze files\n');
-      ft_hastoolbox('spm8up', 1);
+      ft_hastoolbox(spmversion, 1);
     end
     
     % use the image file instead of the header
@@ -465,7 +467,7 @@ switch dataformat
       end
       
       % We cannot trust it yet, see https://github.com/fieldtrip/fieldtrip/issues/1879
-      ft_notice('the coordinate system from the NIfTI file appears to be ''%s''\n', coordsys);
+      ft_notice('the coordinate system appears to be ''%s''\n', coordsys);
       clear coordsys
     end
     

--- a/fileio/ft_read_mri.m
+++ b/fileio/ft_read_mri.m
@@ -95,7 +95,12 @@ filename = fetch_url(filename);
 % get the options
 dataformat  = ft_getopt(varargin, 'dataformat');
 outputfield = ft_getopt(varargin, 'outputfield', 'anatomy');
-spmversion  = ft_getopt(varargin, 'spmversion', 'spm12'); % this default is not used for minc files
+spmversion  = ft_getopt(varargin, 'spmversion');
+
+% use the version that is on the path, or default to spm12
+if ~ft_hastoolbox('spm') && isempty(spmversion)
+  spmversion = 'spm12';
+end
 
 % the following is added for backward compatibility of using 'format' rather than 'dataformat'
 format    = ft_getopt(varargin, 'format');

--- a/fileio/ft_read_mri.m
+++ b/fileio/ft_read_mri.m
@@ -5,21 +5,21 @@ function [mri] = ft_read_mri(filename, varargin)
 % FT_DATATYPE_VOLUME.
 %
 % Use as
-%   [mri] = ft_read_mri(filename)
+%   [mri] = ft_read_mri(filename, ...)
 %
 % Additional options should be specified in key-value pairs and can include
 %   'dataformat'  = string specifying the file format, determining the low-level
 %                   reading routine to be used. If no explicit format is given,
 %                   it is determined automatically from the filename.
-%   'volumes'     = vector with the volume indices to read from a 4D nifti (only for nifti_spm)
+%   'volumes'     = vector with the volume indices to read from a 4-D nifti (only for 'nifti_spm')
 %   'outputfield' = string specifying the name of the field in the structure in which the
-%                   numeric data is stored (only for mrtrix_mif, default = 'anatomy')
+%                   numeric data is stored (only for 'mrtrix_mif', default = 'anatomy')
 %   'fixel2voxel' = string, the operation to apply to the fixels belonging to the
-%                  same voxel, can be 'max', 'min', 'mean' (only for mrtrix_mif, default = 'max')
+%                  same voxel, can be 'max', 'min', 'mean' (only for 'mrtrix_mif', default = 'max')
 %   'indexfile'   = string, pointing to a fixel index file, if not present in the same directory
-%                   as the functional data (only for mrtrix_mif)
+%                   as the functional data (only for 'mrtrix_mif')
 %
-% The following values apply for the dataformat
+% The supported dataformats are
 %   'afni_head'/'afni_brik'      uses AFNI code
 %   'analyze_img'/'analyze_hdr'  uses SPM code
 %   'analyze_old'                uses Darren Webber's code

--- a/fileio/ft_write_mri.m
+++ b/fileio/ft_write_mri.m
@@ -7,23 +7,31 @@ function [V] = ft_write_mri(filename, dat, varargin)
 %   ft_write_mri(filename, dat, ...)
 % where the input argument dat represents the 3-D array with the values.
 %
+% The 3-D array with the values can be further described with 
+%   'transform'    = 4x4 homogenous transformation matrix, specifying the transformation from voxel coordinates to head or world coordinates
+%   'unit'         = string, geometrical units of the coordinate system
+%   'coordsys'     = string, description of the coordinate system
+%
 % Additional options should be specified in key-value pairs and can be
 %   'dataformat'   = string, see below
-%   'transform'    = 4x4 homogenous transformation matrix, specifying the transformation from voxel coordinates to head coordinates
-%   'unit'         = string, desired units for the image data on disk, for example 'mm'
-%   'spmversion'   = version of SPM to be used, in case data needs to be written in analyze format
+%   'spmversion'   = string, version of SPM to be used (default = 'spm12')
 %   'scl_slope'    = slope parameter for nifti files
 %   'scl_inter'    = intersect parameter for nifti files
+%   'vmpversion'   = 1 or 2, version of the vmp format to use (default = 2)
 %
-% The specified filename can already contain the filename extention, but that is not
-% required since it will be added automatically.
+% The specified filename can already contain the filename extention. If not present,
+% it will be added automatically.
 %
 % The supported dataformats are
-%   'vmr', 'vmp' (Brainvoyager specific file formats)
-%   'analyze'
-%   'nifti', 'nifti2', 'nifti_gz'
-%   'vista' (simbio specific file formats)
-%   'mgz', 'mgh' (freesurfer specific file formats)
+%   'analyze'   outdated format and not recommended
+%   'mgz'       FreeSurfer specific format
+%   'mgh'       FreeSurfer specific format
+%   'nifti'
+%   'nifti2'
+%   'nifti_gz'
+%   'vista'     SIMBIO specific format
+%   'vmr'       Brainvoyager specific format
+%   'vmp'       Brainvoyager specific format
 %
 % See also FT_READ_MRI, FT_WRITE_DATA, FT_WRITE_HEADSHAPE
 

--- a/fileio/ft_write_mri.m
+++ b/fileio/ft_write_mri.m
@@ -60,10 +60,15 @@ function [V] = ft_write_mri(filename, dat, varargin)
 transform     = ft_getopt(varargin, 'transform');   % this complements the input data when specified as a 3D array
 unit          = ft_getopt(varargin, 'unit');        % this complements the input data when specified as a 3D array
 coordsys      = ft_getopt(varargin, 'coordsys');    % this complements the input data when specified as a 3D array
-spmversion    = ft_getopt(varargin, 'spmversion', 'spm12');
+spmversion    = ft_getopt(varargin, 'spmversion');
 dataformat    = ft_getopt(varargin, 'dataformat');
 scl_slope     = ft_getopt(varargin, 'scl_slope', 1);
 scl_inter     = ft_getopt(varargin, 'scl_inter', 0);
+
+% use the version that is on the path, or default to spm12
+if ~ft_hastoolbox('spm') && isempty(spmversion)
+  spmversion = 'spm12';
+end
 
 %% ensure that the input data is consistent
 if isnumeric(dat)

--- a/ft_volumewrite.m
+++ b/ft_volumewrite.m
@@ -127,8 +127,6 @@ cfg.markorigin   = ft_getopt(cfg, 'markorigin',   'no');
 cfg.markfiducial = ft_getopt(cfg, 'markfiducial', 'no');
 cfg.markcorner   = ft_getopt(cfg, 'markcorner',   'no');
 cfg.spmversion   = ft_getopt(cfg, 'spmversion',   'spm12');
-
-
 cfg.datatype     = ft_getopt(cfg, 'datatype');
 cfg.scaling      = ft_getopt(cfg, 'scaling');
 

--- a/ft_volumewrite.m
+++ b/ft_volumewrite.m
@@ -15,7 +15,7 @@ function ft_volumewrite(cfg, volume)
 %
 % The configuration structure should contain the following elements
 %   cfg.parameter     = string, describing the functional data to be processed,
-%                         e.g. 'pow', 'coh', 'nai' or 'anatomy'
+%                       e.g. 'pow', 'coh', 'nai' or 'anatomy'
 %   cfg.filename      = filename without the extension
 %
 % To determine the file format, the following option can be specified 
@@ -23,16 +23,17 @@ function ft_volumewrite(cfg, volume)
 %                       'nifti_spm', 'nifti_gz', 'mgz', 'mgh', 'vmp' or 'vmr'
 %
 % Depending on the filetype, the cfg should also contain
-%   cfg.vmpversion    = 1 or 2 (default) version of the vmp-format to use
-%   cfg.spmversion    = 'spm12' (default) version of spm to use
+%   cfg.vmpversion    = 1 or 2, version of the vmp format to use (default = 2)
+%   cfg.spmversion    = string, version of SPM to be used (default = 'spm12')
 %
-% The default filetype is 'nifti', which means that a single *.nii file
-% will be written using code from the freesurfer toolbox. The 'nifti_img' filetype
-% uses SPM for a dual file (*.img/*.hdr) nifti-format file. The 'nifti_spm'
-% filetype uses SPM for a single 'nifti' file. 
-% The analyze, analyze_spm, nifti, nifti_img, nifti_spm and mgz filetypes support a homogeneous
-% transformation matrix, the other filetypes do not support a homogeneous transformation
-% matrix and hence will be written in their native coordinate system.
+% The default filetype is 'nifti', which means that a single *.nii file will be
+% written using code from the freesurfer toolbox. The 'nifti_img' filetype uses SPM
+% for a dual file (*.img/*.hdr) nifti-format file. The 'nifti_spm' filetype uses SPM
+% for a single 'nifti' file.
+%
+% The analyze, analyze_spm, nifti, nifti_img, nifti_spm and mgz filetypes support a
+% homogeneous transformation matrix, the other filetypes do not support a homogeneous
+% transformation matrix and hence will be written in their native coordinate system.
 %
 % You can specify the datatype for the nifti, analyze_spm and analyze_old
 % formats. If not specified, the class of the input data will be preserved,
@@ -227,32 +228,32 @@ if istrue(cfg.scaling)
   % scale the data so that it fits in the desired numerical data format
   switch lower(cfg.datatype)    
     case 'uint8'
-      slope  = (maxval-minval)/(2^8-1);
-      offset = minval; 
+      scl_slope = (maxval-minval)/(2^8-1);
+      scl_inter = minval; 
     case 'int8'
-      slope  = maxval/(2^7-1);
-      offset = 0;
+      scl_slope = maxval/(2^7-1);
+      scl_inter = 0;
     case 'int16'
-      slope  = maxval/(2^15-1);
-      offset = 0;
+      scl_slope = maxval/(2^15-1);
+      scl_inter = 0;
     case 'int32'
-      slope  = maxval/(2^31-1);
-      offset = 0;
+      scl_slope = maxval/(2^31-1);
+      scl_inter = 0;
     case 'single'
-      slope  = maxval;
-      offset = 0;
+      scl_slope = maxval;
+      scl_inter = 0;
     case 'double'
-      slope  = maxval;
-      offset = 0;
+      scl_slope = maxval;
+      scl_inter = 0;
     otherwise
       ft_error('unknown datatype');
   end
-  data = (data - offset)./slope;
+  data = (data - scl_inter)./scl_slope;
 else
-  % thesea are parameters that can be written to a nifti file, and can be
+  % these are parameters that can be written to a nifti file, and can be
   % used to get the data back (close to) its original values
-  slope  = [];
-  offset = [];
+  scl_slope = [];
+  scl_inter = [];
 end
 
 if ~isequal(datatype, cfg.datatype)
@@ -336,7 +337,7 @@ switch cfg.filetype
     if isempty(ext)
       cfg.filename = sprintf('%s.nii', cfg.filename);
     end
-    ft_write_mri(cfg.filename, data, 'dataformat', 'nifti', 'transform', transform, 'scl_slope', slope, 'scl_inter', offset);
+    ft_write_mri(cfg.filename, data, 'dataformat', 'nifti', 'transform', transform, 'scl_slope', scl_slope, 'scl_inter', scl_inter);
   
   case 'nifti_gz'
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -346,7 +347,7 @@ switch cfg.filetype
     if isempty(ext)
       cfg.filename = sprintf('%s.nii.gz', cfg.filename);
     end
-    ft_write_mri(cfg.filename, data, 'dataformat', 'nifti_gz', 'transform', transform, 'scl_slope', slope, 'scl_inter', offset);
+    ft_write_mri(cfg.filename, data, 'dataformat', 'nifti_gz', 'transform', transform, 'scl_slope', scl_slope, 'scl_inter', scl_inter);
 
   case 'nifti_img'
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/private/fixcoordsys.m
+++ b/private/fixcoordsys.m
@@ -29,8 +29,10 @@ function data = fixcoordsys(data)
 data.coordsys = lower(data.coordsys);
 
 % see also http://www.fieldtriptoolbox.org/faq/coordsys
-if any(strcmpi(data.coordsys, {'mni', 'spm'}))
+if any(strcmpi(data.coordsys, {'mni', 'mni152', 'spm'}))
   data.coordsys = 'mni';
 elseif any(strcmpi(data.coordsys, {'ctf', '4d', 'bti', 'eeglab'}))
   data.coordsys = 'ctf';
+elseif any(strcmpi(data.coordsys, {'dicom', 'scanlps'}))
+  data.coordsys = 'dicom';
 end

--- a/test/test_ft_read_mri.m
+++ b/test/test_ft_read_mri.m
@@ -4,6 +4,8 @@ function test_ft_read_mri
 % MEM 2gb
 % DEPENDENCY ft_read_mri
 
+%%
+
 files = {
   'afni/anat+orig.BRIK'
   'afni/anat+orig.HEAD'
@@ -25,3 +27,24 @@ for k = 1:numel(files)
   filename = dccnpath(fullfile(datadir,files{k}));
   ft_read_mri(filename);
 end
+
+%%
+
+[v, p] = ft_version;
+filename = fullfile(p, 'template', 'anatomy', 'single_subj_T1.nii');
+
+mri0 = ft_read_mri(filename, 'dataformat', 'nifti');
+
+rmpath(fileparts(which('spm')))
+mri1 = ft_read_mri(filename, 'dataformat', 'nifti_spm', 'spmversion', 'spm8');
+
+rmpath(fileparts(which('spm')))
+mri2 = ft_read_mri(filename, 'dataformat', 'nifti_spm', 'spmversion', 'spm12');
+
+% they should all be the same
+assert(isequal(mri0.anatomy, mri1.anatomy));
+assert(isequal(mri0.anatomy, mri2.anatomy));
+
+% they should all be the same
+assert(isequal(mri0.transform, mri1.transform));
+assert(isequal(mri0.transform, mri2.transform));

--- a/test/test_ft_write_mri.m
+++ b/test/test_ft_write_mri.m
@@ -1,0 +1,75 @@
+function test_ft_write_mri
+
+% WALLTIME 00:10:00
+% MEM 2gb
+% DEPENDENCY ft_read_mri ft_write_mri
+
+mri = ft_read_mri(dccnpath('/home/common/matlab/fieldtrip/data/Subject01.mri'));
+mri = ft_convert_units(mri, 'mm');
+
+%%
+
+dataformat = {
+  'analyze'
+  'analyze_hdr'
+  'analyze_img'
+  'analyze_old'
+  'freesurfer_mgz'
+  'mgh'
+  'mgz'
+  'nifti'
+  'nifti2'
+  'nifti_gz'
+  'nifti_img'
+  'nifti_spm'
+  'vmp'
+  'vmr'
+  };
+
+%%
+
+p = tempname;
+
+for i=1:numel(dataformat)
+  filename = fullfile(p, ['Subject01_' dataformat{i}]);
+  % pass it as separate fields
+  ft_write_mri(filename, mri.anatomy, 'dataformat', dataformat{i}, 'transform', mri.transform, 'unit', mri.unit, 'coordsys', mri.coordsys);
+end
+
+% remove the temporary directory with all files inside it
+rmdir(p, 's');
+
+%%
+
+p = tempname;
+
+for i=1:numel(dataformat)
+  filename = fullfile(p, ['Subject01_' dataformat{i}]);
+  % pass it as a structure
+  ft_write_mri(filename, mri, 'dataformat', dataformat{i});
+end
+
+% remove the temporary directory with all files inside it
+rmdir(p, 's');
+
+%%
+
+p = tempname;
+
+% scale between -1 and 1, we will skip the unsigned formats
+dat = double(mri.anatomy);
+dat = dat./max(abs(dat(:)));
+
+mri.anatomy = double(dat);                         filename = fullfile(p, 'Subject01_double'); ft_write_mri(filename, mri, 'dataformat', 'analyze_old');
+mri.anatomy = single(dat);                         filename = fullfile(p, 'Subject01_single'); ft_write_mri(filename, mri, 'dataformat', 'analyze_old');
+mri.anatomy = int32(dat.*double(intmax('int32'))); filename = fullfile(p, 'Subject01_int32');  ft_write_mri(filename, mri, 'dataformat', 'analyze_old');
+mri.anatomy = int16(dat.*double(intmax('int16'))); filename = fullfile(p, 'Subject01_int16');  ft_write_mri(filename, mri, 'dataformat', 'analyze_old');
+
+mri.anatomy = double(dat);                         filename = fullfile(p, 'Subject01_double'); ft_write_mri(filename, mri, 'dataformat', 'nifti');
+mri.anatomy = single(dat);                         filename = fullfile(p, 'Subject01_single'); ft_write_mri(filename, mri, 'dataformat', 'nifti');
+mri.anatomy = int32(dat.*double(intmax('int32'))); filename = fullfile(p, 'Subject01_int32');  ft_write_mri(filename, mri, 'dataformat', 'nifti');
+mri.anatomy = int16(dat.*double(intmax('int16'))); filename = fullfile(p, 'Subject01_int16');  ft_write_mri(filename, mri, 'dataformat', 'nifti');
+mri.anatomy = uint8(dat.*double(intmax('int8')));  filename = fullfile(p, 'Subject01_int8');   ft_write_mri(filename, mri, 'dataformat', 'nifti');
+
+% remove the temporary directory with all files inside it
+rmdir(p, 's');

--- a/utilities/ft_convert_coordsys.m
+++ b/utilities/ft_convert_coordsys.m
@@ -28,7 +28,7 @@ function [object] = ft_convert_coordsys(object, target, varargin)
 % Recognized and supported coordinate systems are 'ctf', 'bti', '4d', 'yokogawa',
 % 'eeglab', 'neuromag', 'itab', 'acpc', 'spm', 'mni', 'fsaverage', 'tal', 'scanras',
 % 'scanlps', 'dicom'.
-% 
+%
 % Furthermore, supported coordinate systems that do not specify the origin are 'ras',
 % 'als', 'lps', etc. See https://www.fieldtriptoolbox.org/faq/coordsys for more
 % details.
@@ -259,7 +259,7 @@ tal2ras       = eye(4);
 % the SCANRAS coordinate system is RAS with the origin at the center opf the gradient coil
 scanras2ras     = eye(4);
 
-% the DICOM and SCANALS coordinate system are the same, and rotated 180 degrees from SCANRAS
+% the DICOM and SCANLPS coordinate system are the same, and rotated 180 degrees from SCANRAS
 dicom2scanlps   = eye(4);
 dicom2lps       = eye(4);
 scanlps2lps     = eye(4);

--- a/utilities/ft_convert_coordsys.m
+++ b/utilities/ft_convert_coordsys.m
@@ -25,8 +25,13 @@ function [object] = ft_convert_coordsys(object, target, varargin)
 %   segmented mri, see FT_DATATYPE_SEGMENTATION
 %   anatomical or functional atlas, see FT_READ_ATLAS
 %
-% Possible input coordinate systems are 'ctf', '4d', 'bti', 'yokogawa', 'eeglab', 'neuromag' and 'itab'.
-% Possible target coordinate systems are 'acpc', 'ras', 'als', etc.
+% Recognized and supported coordinate systems are 'ctf', 'bti', '4d', 'yokogawa',
+% 'eeglab', 'neuromag', 'itab', 'acpc', 'spm', 'mni', 'fsaverage', 'tal', 'scanras',
+% 'scanlps', 'dicom'.
+% 
+% Furthermore, supported coordinate systems that do not specify the origin are 'ras',
+% 'als', 'lps', etc. See https://www.fieldtriptoolbox.org/faq/coordsys for more
+% details.
 %
 % Note that the conversion will be an automatic and approximate conversion, not
 % taking into account differences in individual anatomies/differences in conventions
@@ -124,6 +129,7 @@ end
 %   s = superior
 %   i = inferior
 
+% the generic ones specify the axes but no origin
 generic = {
   'als'; 'ali'; 'ars'; 'ari';...
   'pls'; 'pli'; 'prs'; 'pri';...
@@ -138,7 +144,8 @@ generic = {
   'lsa'; 'lia'; 'rsa'; 'ria';...
   'lsp'; 'lip'; 'rsp'; 'rip'}';
 
-specific = {'ctf', 'bti', 'fourd', 'yokogawa', 'eeglab', 'neuromag', 'itab', 'acpc', 'spm', 'mni', 'fsaverage', 'tal', 'scanras', 'scanlps', 'dicom', 'nifti'};
+% the specific ones specify the axes and also the origin
+specific = {'ctf', 'bti', 'fourd', 'yokogawa', 'eeglab', 'neuromag', 'itab', 'acpc', 'spm', 'mni', 'fsaverage', 'tal', 'scanras', 'scanlps', 'dicom'};
 
 % generic orientation triplets (like RAS and ALS) are not specific with regard to the origin
 if ismember(object.coordsys, generic) && strcmp(target, 'acpc')
@@ -162,10 +169,10 @@ end
 
 % this is based on the ear canals, see ALIGN_CTF2ACPC
 acpc2ctf = [
-  0.0000  0.9987  0.0517  34.7467
+   0.0000  0.9987  0.0517  34.7467
   -1.0000  0.0000  0.0000   0.0000
-  0.0000 -0.0517  0.9987  52.2749
-  0.0000  0.0000  0.0000   1.0000
+   0.0000 -0.0517  0.9987  52.2749
+   0.0000  0.0000  0.0000   1.0000
   ];
 
 % this is based on the ear canals, see ALIGN_NEUROMAG2ACPC
@@ -178,10 +185,10 @@ acpc2neuromag = [
 
 % see http://freesurfer.net/fswiki/CoordinateSystems
 fsaverage2mni = [
-  0.9975   -0.0073    0.0176   -0.0429
-  0.0146    1.0009   -0.0024    1.5496
+   0.9975   -0.0073    0.0176   -0.0429
+   0.0146    1.0009   -0.0024    1.5496
   -0.0130   -0.0093    0.9971    1.1840
-  0.0000    0.0000    0.0000    1.0000
+   0.0000    0.0000    0.0000    1.0000
   ];
 
 % this is a 90 degree rotation around the z-axis
@@ -216,13 +223,13 @@ ctf2bti = eye(4);
 % the CTF and EEGLAB coordinate system are the same, see http://www.fieldtriptoolbox.org/faq/coordsys/
 ctf2eeglab = eye(4);
 
-% the Neuromag and Itab coordinate system are the same, see http://www.fieldtriptoolbox.org/faq/coordsys/
+% the NEUROMAG and ITAB coordinate system are the same, see http://www.fieldtriptoolbox.org/faq/coordsys/
 neuromag2itab = eye(4);
 
 % BTI and 4D are different names for exactly the same system, see http://www.fieldtriptoolbox.org/faq/coordsys/
 bti2fourd = eye(4);
 
-% the Yokogawa system expresses positions relative to the dewar, not relative to the head
+% the YOKOGAWA system expresses positions relative to the dewar, not relative to the head
 % see https://www.fieldtriptoolbox.org/faq/coordsys/#details-of-the-yokogawa-coordinate-system
 yokogawa2als = eye(4);
 
@@ -239,7 +246,7 @@ ctf2als   = eye(4);
 bti2als   = eye(4);
 fourd2als = eye(4);
 
-% the Neuromag, Itab, ACPC, MNI, SPM and FSAVERAGE coordinate systems are all RAS coordinate systems
+% the NEUROMAG, ITAB, ACPC, MNI, SPM and FSAVERAGE coordinate systems are all RAS coordinate systems
 % but the origin is poorly defined in RAS, hence converting from RAS to another is problematic
 neuromag2ras  = eye(4);
 itab2ras      = eye(4);
@@ -249,16 +256,14 @@ spm2ras       = eye(4);
 fsaverage2ras = eye(4);
 tal2ras       = eye(4);
 
-% the NIFTI, and SCANRAS coordinate system are the same
-% the DICOM and SCANALS coordinate system are the same, and rotated 180 degrees from SCANRAS
-nifti2scanras   = eye(4);
-nifti2ras       = eye(4);
+% the SCANRAS coordinate system is RAS with the origin at the center opf the gradient coil
 scanras2ras     = eye(4);
+
+% the DICOM and SCANALS coordinate system are the same, and rotated 180 degrees from SCANRAS
 dicom2scanlps   = eye(4);
 dicom2lps       = eye(4);
 scanlps2lps     = eye(4);
 scanlps2scanras = lps2ras; % this is a 180 degree rotation around the z-axis
-dicom2nifti     = lps2ras; % this is a 180 degree rotation around the z-axis
 
 % make the combined and the inverse transformations where possible
 coordsys = [specific generic];

--- a/utilities/ft_datatype_volume.m
+++ b/utilities/ft_datatype_volume.m
@@ -11,7 +11,7 @@ function [volume] = ft_datatype_volume(volume, varargin)
 % An example volume structure is
 %       anatomy: [181x217x181 double]  the numeric data, in this case anatomical information
 %           dim: [181 217 181]         the dimensionality of the 3D volume
-%     transform: [4x4 double]          affine transformation matrix for mapping the voxel coordinates to the head coordinate system
+%     transform: [4x4 double]          4x4 homogenous transformation matrix, specifying the transformation from voxel coordinates to head or world coordinates
 %          unit: 'mm'                  geometrical units of the coordinate system
 %      coordsys: 'ctf'                 description of the coordinate system
 %

--- a/utilities/ft_determine_coordsys.m
+++ b/utilities/ft_determine_coordsys.m
@@ -26,8 +26,13 @@ function [data] = ft_determine_coordsys(data, varargin)
 % see the figure from all angles. To change the anatomical labels of the
 % coordinate system, you should press the corresponding keyboard button.
 %
-% Recognized and supported coordinate systems are 'ctf', '4d', 'bti', 'eeglab',
-% 'neuromag', 'itab', 'acpc', 'spm', 'mni', 'tal', 'als', 'ras', 'paxinos'.
+% Recognized and supported coordinate systems are 'ctf', 'bti', '4d', 'yokogawa',
+% 'eeglab', 'neuromag', 'itab', 'acpc', 'spm', 'mni', 'fsaverage', 'tal', 'scanras',
+% 'scanlps', 'dicom'.
+% 
+% Furthermore, supported coordinate systems that do not specify the origin are 'ras',
+% 'als', 'lps', etc. See https://www.fieldtriptoolbox.org/faq/coordsys for more
+% details.
 %
 % See also FT_CONVERT_COORDSYS, FT_DETERMINE_UNITS, FT_CONVERT_UNITS, FT_PLOT_AXES, FT_PLOT_XXX
 


### PR DESCRIPTION
This is only a small improvement for reading, as the output MRI structure still will not have the `mri.coordsys` assigned. It only gets printed on screen for now, as I suspect the `sform_code/qform_code` to be incorrect in many of the files that we are processing.

For writing (see https://github.com/fieldtrip/fieldtrip/issues/1879) this also does not make any real difference to the files on disk, since the low-level FreeSurfer code does not support passing `sform_code/qform_code`. 

This PR also makes the documentation more consistent. 