### PR TITLE
add support to ft_redefinetrial to stitch pseudo-continuous segmented data back together

### DIFF
--- a/ft_redefinetrial.m
+++ b/ft_redefinetrial.m
@@ -7,10 +7,10 @@ function [data] = ft_redefinetrial(cfg, data)
 %
 % Use as
 %   data = ft_redefinetrial(cfg, data)
-% where the input data should correspond to the output of FT_PREPROCESSING and
-% the configuration should be specified as explained below. Note that some
-% options are mutually exclusive, and require two calls to this function to
-% avoid confusion about the order in which they are applied.
+% where the input data should correspond to the output of FT_PREPROCESSING and the
+% configuration should be specified as explained below. Note that some options are
+% mutually exclusive. If you want to use both,  you neew two calls to this function
+% to avoid confusion about the order in which they are applied.
 %
 % For selecting a subset of trials you can specify
 %   cfg.trials    = 'all' or a selection given as a 1xN vector (default = 'all')
@@ -42,6 +42,14 @@ function [data] = ft_redefinetrial(cfg, data)
 %   cfg.length    = single number (in unit of time, typically seconds) of the required snippets
 %   cfg.overlap   = single number (between 0 and 1 (exclusive)) specifying the fraction of overlap between snippets (0 = no overlap)
 %
+% Alternatively you can merge or stitch pseudo-continuous segmented data back into a
+% continuous representation. This requires that the data has a valid sampleinfo field
+% and that there are no jumps in the signal in subsequent trials (e.g. due to
+% filtering or demeaning). If there are missing segments (e.g. due to artifact
+% rejection), the output data will have one trial for each section where the data is
+% continuous.
+%   cfg.continuous = 'yes' 
+%
 % To facilitate data-handling and distributed computing you can use
 %   cfg.inputfile   =  ...
 %   cfg.outputfile  =  ...
@@ -52,7 +60,7 @@ function [data] = ft_redefinetrial(cfg, data)
 %
 % See also FT_DEFINETRIAL, FT_RECODEEVENT, FT_PREPROCESSING
 
-% Copyright (C) 2006-2008, Robert Oostenveld
+% Copyright (C) 2006-2021, Robert Oostenveld
 %
 % This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
 % for the documentation and details.
@@ -105,16 +113,17 @@ data = ft_checkdata(data, 'datatype', {'raw+comp', 'raw'}, 'feedback', 'yes');
 cfg = ft_checkconfig(cfg, 'forbidden',  {'trial'}); % prevent accidental typos, see issue 1729
 
 % set the defaults
-cfg.offset       = ft_getopt(cfg, 'offset',    []);
-cfg.toilim       = ft_getopt(cfg, 'toilim',    []);
-cfg.begsample    = ft_getopt(cfg, 'begsample', []);
-cfg.endsample    = ft_getopt(cfg, 'endsample', []);
-cfg.minlength    = ft_getopt(cfg, 'minlength', []);
-cfg.trials       = ft_getopt(cfg, 'trials',    'all', 1);
-cfg.feedback     = ft_getopt(cfg, 'feedback',  'yes');
-cfg.trl          = ft_getopt(cfg, 'trl',       []);
-cfg.length       = ft_getopt(cfg, 'length',    []);
-cfg.overlap      = ft_getopt(cfg, 'overlap',   0);
+cfg.offset       = ft_getopt(cfg, 'offset',     []);
+cfg.toilim       = ft_getopt(cfg, 'toilim',     []);
+cfg.begsample    = ft_getopt(cfg, 'begsample',  []);
+cfg.endsample    = ft_getopt(cfg, 'endsample',  []);
+cfg.minlength    = ft_getopt(cfg, 'minlength',  []);
+cfg.trials       = ft_getopt(cfg, 'trials',     'all', 1);
+cfg.feedback     = ft_getopt(cfg, 'feedback',   'yes');
+cfg.trl          = ft_getopt(cfg, 'trl',        []);
+cfg.length       = ft_getopt(cfg, 'length',     []);
+cfg.overlap      = ft_getopt(cfg, 'overlap',    0);
+cfg.continuous   = ft_getopt(cfg, 'continuous', 'no');
 
 % select trials of interest
 if ~strcmp(cfg.trials, 'all')
@@ -144,7 +153,7 @@ end
 Ntrial = numel(data.trial);
 
 % check the input arguments, only one method for processing is allowed
-numoptions = ~isempty(cfg.toilim) + ~isempty(cfg.offset) + (~isempty(cfg.begsample) || ~isempty(cfg.endsample)) + ~isempty(cfg.trl) + ~isempty(cfg.length);
+numoptions = ~isempty(cfg.toilim) + ~isempty(cfg.offset) + (~isempty(cfg.begsample) || ~isempty(cfg.endsample)) + ~isempty(cfg.trl) + ~isempty(cfg.length) + istrue(cfg.continuous);
 if numoptions>1
   ft_error('you should specify only one of the options for redefining the data segments');
 end
@@ -233,7 +242,6 @@ elseif ~isempty(cfg.trl)
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   % select new trials from the existing data
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-  
   if ischar(cfg.trl)
     % load the trial information from file
     newtrl = loadvar(cfg.trl, 'trl');
@@ -304,7 +312,6 @@ elseif ~isempty(cfg.length)
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   % cut the existing trials into segments of the specified length
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-  
   data = ft_checkdata(data, 'hassampleinfo', 'yes');
   
   % create dummy trl-matrix and recursively call ft_redefinetrial
@@ -347,6 +354,30 @@ elseif ~isempty(cfg.length)
   data   = ft_redefinetrial(tmpcfg, data);
   % restore the provenance information
   [cfg, data] = rollback_provenance(cfg, data);
+  
+elseif istrue(cfg.continuous)
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    % identify conscitive segments that can be glued back together
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    data = ft_checkdata(data, 'hassampleinfo', 'yes');
+    
+    boolvec = artifact2boolvec(data.sampleinfo);
+    newtrl = boolvec2trl(boolvec);
+    
+    % In general: An offset of 0 means that the first sample of the trial corresponds
+    % to the trigger. A positive offset indicates that the first sample is later than
+    % the trigger.
+    
+    % here we want to use the start of the recording as t=0
+    newtrl(:,3) = newtrl(:,1) - 1;
+    
+    tmpcfg = keepfields(cfg, {'showcallinfo', 'feedback'});
+    tmpcfg.trl = newtrl;
+
+    data   = removefields(data, {'trialinfo'}); % the trialinfo does not apply any more
+    data   = ft_redefinetrial(tmpcfg, data);
+    % restore the provenance information
+    [cfg, data] = rollback_provenance(cfg, data);
   
 end % processing the realignment or data selection
 

--- a/test/test_ft_redefinetrial.m
+++ b/test/test_ft_redefinetrial.m
@@ -4,7 +4,7 @@ function test_ft_redefinetrial
 % WALLTIME 00:10:00
 % DEPENDENCY
 
-
+%% use 10 trials from the ctf151 data structure
 load(dccnpath('/home/common/matlab/fieldtrip/data/test/latest/raw/meg/preproc_ctf151'));
 
 data.trialinfo = (1:10)';
@@ -71,5 +71,37 @@ cfg        = [];
 cfg.toilim = repmat([0.2 0.8], numel(data.trial), 1);
 data9      = ft_redefinetrial(cfg, data);
 assert(all(data9.sampleinfo(:,1)==[61:300:2761]') && all(data9.sampleinfo(:,2)==[241:300:2941]'));
+
+%% construct a continuous data structure
+
+data_orig = [];
+data_orig.label = {'1'};
+data_orig.time{1} = ((1:10000)-1)./1000; % 10 seconds
+data_orig.trial{1} = randn(1, 10000);
+data_orig.sampleinfo = [1 100000];
+data_orig.trialinfo = [1];
+
+cfg = [];
+cfg.length = 1;
+data_segmented = ft_redefinetrial(cfg, data_orig);
+assert(length(data_segmented.trial)==10);
+
+cfg = [];
+cfg.continuous = 'yes';
+data_continuous = ft_redefinetrial(cfg, data_segmented);
+assert(length(data_continuous.trial)==1);
+
+cfg = [];
+cfg.trials = setdiff(1:10, 5); % remove one trial
+data_segmented = ft_selectdata(cfg, data_segmented);
+
+cfg = [];
+cfg.continuous = 'yes';
+data_continuous = ft_redefinetrial(cfg, data_segmented);
+assert(length(data_continuous.trial)==2);
+
+
+
+
 
 


### PR DESCRIPTION
The use case for this is to do `ft_preprocessing` on continuous data, segment it into non-overlapping segments with `ft_redefinetrial`, use `ft_rejectvisual`, and then put it all back together again. 

In case of keeptrials=no in rejectvisual, this will result in multiple (long) segment, one for each continuous part that was reconstructed.

In case of keeptrials-nan  in rejectvisual, this will result in a single continuous segment where parts of the data are replaced by nan.