### PR TITLE
ENH - some generic speedups and depth-of-recursion limitation

### DIFF
--- a/ft_sourceinterpolate.m
+++ b/ft_sourceinterpolate.m
@@ -128,8 +128,8 @@ cfg.interpmethod = ft_getopt(cfg, 'interpmethod', []);   % cfg.interpmethod depe
 anatomical = fixpos(anatomical);
 functional = fixpos(functional);
 
-% ensure the functional data to be in double precision
-functional = ft_struct2double(functional);
+% ensure the functional data to be in double precision, the maxdepth parameter ensure double precision up to the content of functional.avg.mom{:}, avoiding too much recursion
+functional = ft_struct2double(functional, 3);
 
 if (strcmp(cfg.interpmethod, 'nearest') || strcmp(cfg.interpmethod, 'mode')) && (ft_datatype(functional, 'volume+label') || ft_datatype(functional, 'source+label') || ft_datatype(functional, 'mesh+label'))
   % the first input argument describes a parcellation or segmentation with tissue labels

--- a/utilities/ft_struct2double.m
+++ b/utilities/ft_struct2double.m
@@ -63,15 +63,21 @@ switch class(a)
       % warning, this is a recursive call to traverse nested structures
       for i=1:length(fna)
         fn = fna{i};
-        ra = getfield(a(j), fn);
+        ra = a(j).(fn);
         ra = convert(ra, depth+1, maxdepth);
-        a(j) = setfield(a(j), fn, ra);
+        a(j).(fn) = ra;
       end
     end
     
   case 'cell'
     % process all elements of the cell-array recursively
     % warning, this is a recursive call to traverse nested structures
+    
+    % the recursion is only needed if the maxdepth allows it
+    if depth+1>maxdepth
+      return
+    end
+    
     for i=1:length(a(:))
       a{i} = convert(a{i}, depth+1, maxdepth);
     end


### PR DESCRIPTION
As reported by Mikkel @mcvinding ft_sourceinterpolate may spend a lot of time in ft_struct2double, even if it is not strictly needed. This PR limits the recursion depth into ft_struct2double, so that no unnecessary time is spent in an attempt to convert data of non-interest. Also some structural improvements to ft_struct2double lead to faster execution times.