### PR TITLE
fixed regression error observed after change to ft_checkconfig/renamedval

### DIFF
--- a/ft_sourceinterpolate.m
+++ b/ft_sourceinterpolate.m
@@ -171,23 +171,8 @@ else
   functional = ft_checkdata(functional, 'datatype', 'volume', 'insidestyle', 'logical', 'feedback', 'yes', 'hasunit', 'yes');
 end
 
-if ~isa(cfg.parameter, 'cell')
-  cfg.parameter = {cfg.parameter};
-end
-
-% try to select all relevant parameters present in the data
-if any(strcmp(cfg.parameter, 'all'))
-  cfg.parameter = parameterselection('all', functional);
-  for k = numel(cfg.parameter):-1:1
-    % check whether the field is numeric
-    tmp = getsubfield(functional, cfg.parameter{k});
-    if iscell(tmp)
-      cfg.parameter(k) = [];
-    elseif strcmp(cfg.parameter{k}, 'pos')
-      cfg.parameter(k) = [];
-    end
-  end
-end
+% select the parameters from the data
+cfg.parameter = parameterselection(cfg.parameter, functional);
 
 % ensure that the functional data has the same unit as the anatomical data
 functional = ft_convert_units(functional, anatomical.unit);

--- a/test/test_bug1563.m
+++ b/test/test_bug1563.m
@@ -53,9 +53,19 @@ template = dccnpath('/home/common/matlab/fieldtrip/external/spm8/templates/T1.ni
 source.coordsys = 'mni'; % this can also be determined with ft_determine_coordsys
 
 template_mri = ft_read_mri(template);
+
+%%
+
 cfg              = [];
 cfg.voxelcoord   = 'no';
 cfg.parameter    = {'avg.pow'};
+cfg.interpmethod = 'spline';
+% cfg.coordsys   = 'mni'; % not supported any more, should be specified in the input data
+source_int  = ft_sourceinterpolate(cfg, source, template_mri);
+
+cfg              = [];
+cfg.voxelcoord   = 'no';
+cfg.parameter    = 'avg.pow'; % this was a regression error in commit 4569991a6b38824e39effc114ad4cf2419351702
 cfg.interpmethod = 'spline';
 % cfg.coordsys   = 'mni'; % not supported any more, should be specified in the input data
 source_int  = ft_sourceinterpolate(cfg, source, template_mri);


### PR DESCRIPTION
in commit 4569991a6b38824e39effc114ad4cf2419351702 there was a change to `renamedval` in ft_checkconfig, which caused `avg.pow` not to be replaced by `pow` any more, but only if cfg.parameter was specified as a cell array. The reason it worked before was probably accidental, since the string comparison between a cell-array and string returned true.

In this commit the way that parameterselection is called by ft_sourecinterpolate has been updated, consistent with how it is used elsewhere. This ensures that the code now works both for `'avg.pow'` and `{'avg.pow'}`