### PR TITLE
On-fly CSD computation in ft_connectivity_dwpli

### DIFF
--- a/ft_connectivityanalysis.m
+++ b/ft_connectivityanalysis.m
@@ -76,6 +76,11 @@ function [stat] = ft_connectivityanalysis(cfg, data)
 %                     indicating whether the canonical vectors are
 %                     determined from the real-valued part of a complex
 %                     matrix.
+%   cfg.onflycsd    = false (default) or true, used for
+%                     'wpli'/'wpli_debiased' to average across trial "on
+%                     fly" and thus save immense memory when trials are
+%                     many (e.g. resting state connectivity)
+%                    
 %
 % To facilitate data-handling and distributed computing you can use
 %   cfg.inputfile   =  ...
@@ -258,13 +263,23 @@ switch cfg.method
   
   case {'wpli'}
     data = ft_checkdata(data, 'datatype', {'freqmvar' 'freq'});
-    inparam = 'crsspctrm';
+    cfg.onflycsd    = ft_getopt(cfg, 'onflycsd', 0);
+    if (cfg.onflycsd) 
+        inparam = 'fourierspctrm';
+    else 
+        inparam = 'crsspctrm';
+    end
     outparam = 'wplispctrm';
     if hasjack, ft_error('to compute wpli, data should be in rpt format'); end
   
   case {'wpli_debiased'}
     data = ft_checkdata(data, 'datatype', {'freqmvar' 'freq'});
-    inparam = 'crsspctrm';
+    cfg.onflycsd    = ft_getopt(cfg, 'onflycsd', 0);    
+    if (cfg.onflycsd) 
+        inparam = 'fourierspctrm';
+    else 
+        inparam = 'crsspctrm';
+    end
     outparam = 'wpli_debiasedspctrm';
     if hasjack, ft_error('to compute wpli, data should be in rpt format'); end
   
@@ -670,9 +685,13 @@ switch cfg.method
     end
   case {'wpli' 'wpli_debiased'}
     % weighted pli or debiased weighted phase lag index.
-    optarg = {'feedback', cfg.feedback, 'dojack', dojack, 'debias', strcmp(cfg.method, 'wpli_debiased')};
-    [datout, varout, nrpt] = ft_connectivity_wpli(data.(inparam), optarg{:});
-    
+    if (~cfg.onflycsd)
+      optarg = {'feedback', cfg.feedback, 'dojack', dojack, 'debias', strcmp(cfg.method, 'wpli_debiased'), 'onflycsd', 0};
+      [datout, varout, nrpt] = ft_connectivity_wpli(data.(inparam), optarg{:});
+    else
+      optarg = {'feedback', cfg.feedback, 'dojack', dojack, 'debias', strcmp(cfg.method, 'wpli_debiased'), 'onflycsd', 1};
+      [datout, varout, nrpt] = ft_connectivity_wpli(data, optarg{:});
+    end
   case {'wppc' 'ppc'}
     % weighted pairwise phase consistency or pairwise phase consistency
     optarg = {'feedback', cfg.feedback, 'dojack', dojack, 'weighted', strcmp(cfg.method, 'wppc')};

--- a/test/test_ft_connectivityanalysis.m
+++ b/test/test_ft_connectivityanalysis.m
@@ -127,6 +127,10 @@ c10m           = ft_connectivityanalysis(cfgc, mfreq);
 cfgc.method    = 'gpdc';
 c11            = ft_connectivityanalysis(cfgc, freq);
 c11m           = ft_connectivityanalysis(cfgc, mfreq);
+cfgc.method    = 'wpli';
+c12            = ft_connectivityanalysis(cfgc, freq);
+c12b           = ft_connectivityanalysis(cfgc, ft_checkdata(freq, 'cmbstyle', 'full'));
+assert(isequaln(c12.wplispctrm, c12b.wplispctrm));
 
 cfgc             = [];
 cfgc.partchannel = 'signal003'; % this should destroy coherence between 1 and 2


### PR DESCRIPTION
Here is the first draft of the proposed RAM-saving shortcut for (d)wPLI computation.
I've basically introduced a flag allowing to specify the interest in this alternative. This way, the function accepts fourier spectrum as input. 
I have had thoughts about integrating a similar way of computation in different other measurements (e.g. PLI), as well as doing a more compliant changes. So I'm glad if you suggest a way to do so. 
The whole pipeline (starting with `ft_connectivityanalysis`) was tested with the data of "rpttap_chan_freq" dimension. I am happy to come up with a dataset and add a test function :)