### PR TITLE
Make ft_componentanalysis more robust by determining scaling factor based on first non-all-NaN trial

### DIFF
--- a/ft_componentanalysis.m
+++ b/ft_componentanalysis.m
@@ -347,7 +347,12 @@ end
 if strcmp(cfg.doscale, 'yes')
   % determine the scaling of the data, scale it to approximately unity
   % this will improve the performance of some methods, esp. fastica
-  tmp                 = data.trial{1};
+  trlidx = 1;
+  tmp    = data.trial{trlidx};
+  while all(isnan(tmp(:))) % if all data in this trial is NaN
+      trlidx  = trlidx + 1; % try next trial
+      tmp     = data.trial{trlidx}; % overwrite tmp with next trial
+  end
   tmp(~isfinite(tmp)) = 0; % ensure that the scaling is a finite value
   scale = norm((tmp*tmp')./size(tmp,2)); clear tmp;
   scale = sqrt(scale);


### PR DESCRIPTION
Make ft_componentanalysis more robust by determining scaling factor based on first trial that is not all NaN (which might happen if ft_componentanalysis is run based on data together with an existing unmixing matrix & all data in the first trial has been rejected with ft_rejectartifact).