### PR TITLE
ENH: rejectvisual_summary: recall toggled channels/trials in a click

### DIFF
--- a/private/rejectvisual_summary.m
+++ b/private/rejectvisual_summary.m
@@ -412,6 +412,7 @@ info = guidata(h);
 excludetrltxt = sprintf('%d, ', find(~info.trlsel));
 excludetrltxt = excludetrltxt(1:end-2);
 set(findobj('tag','edit_toggle_trials'), 'string', excludetrltxt)
+set(info.plottrltxt, 'string', excludetrltxt)
 
 % process input from the "toggle channels" textbox
 function toggle_channels(h, eventdata)

--- a/private/rejectvisual_summary.m
+++ b/private/rejectvisual_summary.m
@@ -139,18 +139,18 @@ end
 
 % editboxes for manually specifying which channels/trials to toggle on or off
 uicontrol(h, 'Units', 'normalized', 'position', [0.630 0.470 0.14 0.05], 'Style', 'text', 'HorizontalAlignment', 'left', 'backgroundcolor', get(h, 'color'), 'string', 'Toggle trial:');
-uicontrol(h, 'Units', 'normalized', 'position', [0.630 0.430 0.14 0.05], 'Style', 'edit', 'HorizontalAlignment', 'left', 'backgroundcolor', [1 1 1], 'callback', @toggle_trials);
+uicontrol(h, 'Units', 'normalized', 'position', [0.630 0.430 0.14 0.05], 'Style', 'edit', 'HorizontalAlignment', 'left', 'backgroundcolor', [1 1 1], 'callback', @toggle_trials, 'tag', 'edit_toggle_trials');
 uicontrol(h, 'Units', 'normalized', 'position', [0.630 0.340 0.14 0.05], 'Style', 'text', 'HorizontalAlignment', 'left', 'backgroundcolor', get(h, 'color'), 'string', 'Toggle channel:');
-uicontrol(h, 'Units', 'normalized', 'position', [0.630 0.300 0.14 0.05], 'Style', 'edit', 'HorizontalAlignment', 'left', 'backgroundcolor', [1 1 1], 'callback', @toggle_channels);
+uicontrol(h, 'Units', 'normalized', 'position', [0.630 0.300 0.14 0.05], 'Style', 'edit', 'HorizontalAlignment', 'left', 'backgroundcolor', [1 1 1], 'callback', @toggle_channels, 'tag', 'edit_toggle_channels');
 
 % editbox for trial plotting
 uicontrol(h, 'Units', 'normalized', 'position', [0.630 0.210 0.14 0.05], 'Style', 'text', 'HorizontalAlignment', 'left', 'backgroundcolor', get(h, 'color'), 'string', 'Plot trial:');
 info.plottrltxt = uicontrol(h, 'Units', 'normalized', 'position', [0.630 0.170 0.14 0.05], 'Style', 'edit', 'HorizontalAlignment', 'left', 'backgroundcolor', [1 1 1], 'callback', @display_trial);
 
 info.excludetrllbl  = uicontrol(h, 'Units', 'normalized', 'position', [0.795 0.470 0.210 0.05], 'Style', 'text', 'HorizontalAlignment', 'left', 'backgroundcolor', get(h, 'color'), 'string', sprintf('Rejected trials: %i/%i', sum(info.trlsel==0), info.ntrl));
-info.excludetrltxt  = uicontrol(h, 'Units', 'normalized', 'position', [0.795 0.330 0.210 0.15], 'Style', 'text', 'HorizontalAlignment', 'left', 'backgroundcolor', get(h, 'color'));
+info.excludetrltxt  = uicontrol(h, 'Units', 'normalized', 'position', [0.795 0.330 0.210 0.15], 'Style', 'text', 'HorizontalAlignment', 'left', 'backgroundcolor', get(h, 'color'), 'Enable', 'Inactive');
 info.excludechanlbl = uicontrol(h, 'Units', 'normalized', 'position', [0.795 0.340 0.210 0.05], 'Style', 'text', 'HorizontalAlignment', 'left', 'backgroundcolor', get(h, 'color'), 'string', sprintf('Rejected channels: %i/%i', sum(info.chansel==0), info.nchan));
-info.excludechantxt = uicontrol(h, 'Units', 'normalized', 'position', [0.795 0.200 0.210 0.15], 'Style', 'text', 'HorizontalAlignment', 'left', 'backgroundcolor', get(h, 'color'));
+info.excludechantxt = uicontrol(h, 'Units', 'normalized', 'position', [0.795 0.200 0.210 0.15], 'Style', 'text', 'HorizontalAlignment', 'left', 'backgroundcolor', get(h, 'color'), 'Enable', 'Inactive');
 
 % "show rejected" button
 % ui_tog = uicontrol(h, 'Units', 'normalized', 'position', [0.55 0.200 0.25 0.05], 'Style', 'checkbox', 'backgroundcolor', get(h, 'color'), 'string', 'Show rejected?', 'callback', @toggle_rejected);
@@ -357,7 +357,7 @@ set(info.excludetrllbl, 'string', sprintf('Trials to exclude: %i/%i', sum(info.t
 if ~all(info.trlsel)
   excludetrltxt = sprintf('%d, ', find(~info.trlsel));
   excludetrltxt = excludetrltxt(1:end-2);
-  set(info.excludetrltxt, 'String', excludetrltxt, 'FontAngle', 'normal');
+  set(info.excludetrltxt, 'String', excludetrltxt, 'FontAngle', 'normal', 'ButtonDownFcn', @toggle_trials_edit);
 else
   set(info.excludetrltxt, 'String', 'No trials to exclude', 'FontAngle', 'italic');
 end
@@ -369,7 +369,7 @@ if ~all(info.chansel)
     excludechantxt = sprintf('%d, ', find(~info.chansel));
   end
   excludechantxt = excludechantxt(1:end-2);
-  set(info.excludechantxt, 'String', excludechantxt, 'FontAngle', 'normal');
+  set(info.excludechantxt, 'String', excludechantxt, 'FontAngle', 'normal', 'ButtonDownFcn', @toggle_channels_edit);
 else
   set(info.excludechantxt, 'String', 'No channels to exclude', 'FontAngle', 'italic');
 end
@@ -406,6 +406,12 @@ end
 compute_metric(h)
 guidata(h, info);
 uiresume;
+
+function toggle_trials_edit(h,eventdata)
+info = guidata(h);
+excludetrltxt = sprintf('%d, ', find(~info.trlsel));
+excludetrltxt = excludetrltxt(1:end-2);
+set(findobj('tag','edit_toggle_trials'), 'string', excludetrltxt)
 
 % process input from the "toggle channels" textbox
 function toggle_channels(h, eventdata)
@@ -452,6 +458,12 @@ end
 compute_metric(h)
 guidata(h, info);
 uiresume;
+
+function toggle_channels_edit(h,eventdata)
+info = guidata(h);
+excludechantxt = sprintf('%d, ', find(~info.chansel));
+excludechantxt = excludechantxt(1:end-2);
+set(findobj('tag','edit_toggle_channels'), 'string', excludechantxt)
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % SUBFUNCTION


### PR DESCRIPTION
UI adaptation in order not to have to retype the list of channels/trials to toggle if I want to reset or change selection based on previous ones.

A click on the list of previously selected channels/trials will push that list to the toggle editbox.