### PR TITLE
ENH keep list of badchannels out of ft_rejectvisual

### DIFF
--- a/ft_rejectvisual.m
+++ b/ft_rejectvisual.m
@@ -368,6 +368,8 @@ cfg.channel = data.label(chansel);
 tmpcfg = [];
 if strcmp(cfg.keepchannel, 'no')
   tmpcfg.channel = cfg.channel;
+elseif strcmp(cfg.keepchannel, 'yes')
+  cfg.badchannel = data.label(~chansel);
 end
 if strcmp(cfg.keeptrial, 'no')
   tmpcfg.trials = cfg.trials;


### PR DESCRIPTION
Coming out of ft_rejectivisual, need to keep track of selected bad channels even if keepchannel = 'yes'
This is a suggested way.