### PR TITLE
change the backward slash to forward slash

### DIFF
--- a/data2bids.m
+++ b/data2bids.m
@@ -2045,6 +2045,9 @@ if ~isempty(cfg.bidsroot)
   this = table();
   [p, f, x] = fileparts(cfg.outputfile);
   this.filename = {fullfile(datatype2dirname(cfg.datatype), [f x])};
+  path = fullfile(datatype2dirname(cfg.datatype), [f x]);
+  path(strfind(path,'\')) = '/';
+  this.filename = {path};
   fn = fieldnames(cfg.scans);
   for i=1:numel(fn)
     % write [] as 'n/a'

--- a/data2bids.m
+++ b/data2bids.m
@@ -63,7 +63,6 @@ function cfg = data2bids(cfg, varargin)
 %   cfg.echo                    = string
 %   cfg.proc                    = string
 %   cfg.desc                    = string
-%   cfg.space                   = string
 %
 % When specifying the output directory in cfg.bidsroot, you can also specify
 % additional information to be added as extra columns in the participants.tsv and
@@ -264,10 +263,9 @@ cfg.echo      = ft_getopt(cfg, 'echo');
 cfg.proc      = ft_getopt(cfg, 'proc');
 cfg.desc      = ft_getopt(cfg, 'desc');
 cfg.datatype  = ft_getopt(cfg, 'datatype');
-cfg.space     = ft_getopt(cfg, 'space');
 
 % do a sanity check on the fields that form the filename as key-value pair
-fn = {'sub', 'ses', 'task', 'acq', 'ce', 'rec', 'dir', 'run', 'mod', 'echo', 'proc', 'desc', 'space'};
+fn = {'sub', 'ses', 'task', 'acq', 'ce', 'rec', 'dir', 'run', 'mod', 'echo', 'proc', 'desc'};
 for i=1:numel(fn)
   if ischar(cfg.(fn{i})) && any(cfg.(fn{i})=='-')
     ft_error('the field cfg.%s cannot contain a "-"', fn{i});
@@ -1868,7 +1866,6 @@ for i=1:numel(modality)
       f = remove_entity(f, 'proc');     % remove _proc-something
       f = remove_entity(f, 'desc');     % remove _desc-something
       f = remove_datatype(f);           % remove _meg, _eeg, etc.
-      f = add_entity(f, 'space', cfg.space);
       filename = fullfile(p, [f '_coordsystem.json']);
     else
       % just replace the extension with json
@@ -1926,7 +1923,6 @@ for i=1:numel(modality)
       f = remove_entity(f, 'proc');     % remove _proc-something
       f = remove_entity(f, 'desc');     % remove _desc-something
       f = remove_datatype(f);           % remove _meg, _eeg, etc.
-      f = add_entity(f, 'space', cfg.space);
       filename = fullfile(p, sprintf('%s_%s.tsv', f, modality{i}));
     else
       [p, f] = fileparts(cfg.outputfile);

--- a/data2bids.m
+++ b/data2bids.m
@@ -63,6 +63,7 @@ function cfg = data2bids(cfg, varargin)
 %   cfg.echo                    = string
 %   cfg.proc                    = string
 %   cfg.desc                    = string
+%   cfg.space                   = string
 %
 % When specifying the output directory in cfg.bidsroot, you can also specify
 % additional information to be added as extra columns in the participants.tsv and
@@ -263,9 +264,10 @@ cfg.echo      = ft_getopt(cfg, 'echo');
 cfg.proc      = ft_getopt(cfg, 'proc');
 cfg.desc      = ft_getopt(cfg, 'desc');
 cfg.datatype  = ft_getopt(cfg, 'datatype');
+cfg.space     = ft_getopt(cfg, 'space');
 
 % do a sanity check on the fields that form the filename as key-value pair
-fn = {'sub', 'ses', 'task', 'acq', 'ce', 'rec', 'dir', 'run', 'mod', 'echo', 'proc', 'desc'};
+fn = {'sub', 'ses', 'task', 'acq', 'ce', 'rec', 'dir', 'run', 'mod', 'echo', 'proc', 'desc', 'space'};
 for i=1:numel(fn)
   if ischar(cfg.(fn{i})) && any(cfg.(fn{i})=='-')
     ft_error('the field cfg.%s cannot contain a "-"', fn{i});
@@ -1866,6 +1868,7 @@ for i=1:numel(modality)
       f = remove_entity(f, 'proc');     % remove _proc-something
       f = remove_entity(f, 'desc');     % remove _desc-something
       f = remove_datatype(f);           % remove _meg, _eeg, etc.
+      f = add_entity(f, 'space', cfg.space);
       filename = fullfile(p, [f '_coordsystem.json']);
     else
       % just replace the extension with json
@@ -1923,6 +1926,7 @@ for i=1:numel(modality)
       f = remove_entity(f, 'proc');     % remove _proc-something
       f = remove_entity(f, 'desc');     % remove _desc-something
       f = remove_datatype(f);           % remove _meg, _eeg, etc.
+      f = add_entity(f, 'space', cfg.space);
       filename = fullfile(p, sprintf('%s_%s.tsv', f, modality{i}));
     else
       [p, f] = fileparts(cfg.outputfile);

--- a/data2bids.m
+++ b/data2bids.m
@@ -263,8 +263,8 @@ cfg.mod       = ft_getopt(cfg, 'mod');
 cfg.echo      = ft_getopt(cfg, 'echo');
 cfg.proc      = ft_getopt(cfg, 'proc');
 cfg.desc      = ft_getopt(cfg, 'desc');
-cfg.datatype  = ft_getopt(cfg, 'datatype');
 cfg.space     = ft_getopt(cfg, 'space');
+cfg.datatype  = ft_getopt(cfg, 'datatype');
 
 % do a sanity check on the fields that form the filename as key-value pair
 fn = {'sub', 'ses', 'task', 'acq', 'ce', 'rec', 'dir', 'run', 'mod', 'echo', 'proc', 'desc', 'space'};
@@ -1868,7 +1868,9 @@ for i=1:numel(modality)
       f = remove_entity(f, 'proc');     % remove _proc-something
       f = remove_entity(f, 'desc');     % remove _desc-something
       f = remove_datatype(f);           % remove _meg, _eeg, etc.
-      f = add_entity(f, 'space', cfg.space);
+      if ismember(modality{i}, {'mri', 'meg', 'motion', 'coordsystem'})
+        f = add_entity(f, 'space', cfg.space); % this should be present in case it is not empty
+      end
       filename = fullfile(p, [f '_coordsystem.json']);
     else
       % just replace the extension with json
@@ -1926,7 +1928,9 @@ for i=1:numel(modality)
       f = remove_entity(f, 'proc');     % remove _proc-something
       f = remove_entity(f, 'desc');     % remove _desc-something
       f = remove_datatype(f);           % remove _meg, _eeg, etc.
-      f = add_entity(f, 'space', cfg.space);
+      if ismember(modality{i}, {'electrodes', 'optodes'})
+        f = add_entity(f, 'space', cfg.space); % this should be present in case it is not empty
+      end
       filename = fullfile(p, sprintf('%s_%s.tsv', f, modality{i}));
     else
       [p, f] = fileparts(cfg.outputfile);


### PR DESCRIPTION
Dear Fieldtrip developers
Dear Robert

I noticed that the data2bids function always write backslashes. Working on windows 10 pro, with Matlab R2020b, it completely makes sense to use backslash, as this is what the operating system uses. However, the BIDS specification seems to require forward slashes when internally referring to its own files.

We made an improvement in how we would resolve this of the scans.tsv, but there are more places in which backslash should be converted to a forward slash, that I unfortunately am not sure where one could achieve this in the data2bids.m code. I documented below some of those possible cases (that do not pertain to our current dataset) for your information below.

Thank you very much for your help
Best wishes
Jonathan - on behalf of the ICN Lab Charité Berlin

https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/02-magnetoencephalography.html#coordinate-system-json-_coordsystemjson

![image](https://user-images.githubusercontent.com/72917013/151818573-90c2e182-58f7-4d20-a6aa-ce37a3e2c156.png)

https://bids-specification.readthedocs.io/en/stable/99-appendices/03-hed.html

![image](https://user-images.githubusercontent.com/72917013/151818727-b4eda4c0-b6be-4ffb-a3d3-1cf278c1bd6a.png)

https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/01-magnetic-resonance-imaging-data.html#using-intendedfor-metadata

![image](https://user-images.githubusercontent.com/72917013/151818957-5726433f-4ccd-46f7-bccd-1d60df6cb4c3.png)

Example of an error in the scans.tsv because of the backslashes:

![image](https://user-images.githubusercontent.com/72917013/151820057-10c004de-92a5-4c9e-ac5a-80a434a93223.png)
