### PR TITLE
adapt the channels_tsv order

### DIFF
--- a/data2bids.m
+++ b/data2bids.m
@@ -1364,6 +1364,13 @@ if need_channels_tsv
   channels_tsv = hdr2table(hdr);
   channels_tsv = merge_table(channels_tsv, cfg.channels, 'name');
   
+  channels_tsv = movevars(channels_tsv,{'type'},'After',{'name'});
+  channels_tsv = movevars(channels_tsv,{'units'},'After',{'type'});   
+  if ismember({'low_cutoff'},channels_tsv.Properties.VariableNames) %this required is for modality ieeg
+     channels_tsv = movevars(channels_tsv,{'low_cutoff'},'After',{'units'});
+     channels_tsv = movevars(channels_tsv,{'high_cutoff'},'After',{'low_cutoff'});
+  end
+  
   % the default for cfg.channels consists of one row where all values are nan, this needs to be removed
   keep = false(size(channels_tsv.name));
   for i=1:numel(channels_tsv.name)


### PR DESCRIPTION
Dear Fieldtrip developers
Dear Robert

For the channels.tsv there is a specific order in which the columns need to be written down, apparently.
For EEG and MEG, this is
name type units
For IEEG this is
name type units low_cutoff high_cutoff

Here is an error of the BIDS Validator, and the issue I wrote earlier today for the Validator was declined:
![image](https://user-images.githubusercontent.com/72917013/151861219-bff1381f-d64f-471e-89cd-c573cc111752.png)

https://github.com/bids-standard/bids-validator/issues/1410

In the improvement I made, I was not able to specifically call in your code the modality,
(if modality = ieeg, then ... elif modality = meg, then ...), I just assume that the column names need to be reordered as such by default, and my piece of code takes care of that.

I really appreciate your efforts,

Best wishes
Jonathan - ICN Lab Charité Berlin

specify the order of the columns for the tsv file https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/04-intracranial-electroencephalography.html#channels-description-_channelstsv