### PR TITLE
Update ft_megplanar.m

### DIFF
--- a/ft_megplanar.m
+++ b/ft_megplanar.m
@@ -8,7 +8,7 @@ function [data] = ft_megplanar(cfg, data)
 % Use as
 %    [interp] = ft_megplanar(cfg, data)
 % where the input data corresponds to the output from FT_PREPROCESSING,
-% FT_TIMELOCKANALYSIS or FT_FREQANALYSIS (with output='fourierspcrm').
+% FT_TIMELOCKANALYSIS or FT_FREQANALYSIS (with output='fourier').
 %
 % The configuration should contain
 %   cfg.planarmethod   = string, can be 'sincos', 'orig', 'fitplane', 'sourceproject' (default = 'sincos')


### PR DESCRIPTION
`fourierspctrm` is the name of the respective field in the output of ft_freqanalysis; but the option in the input is called `output='fourier'`