### PR TITLE
FIX - fix mismatch between orientation of volume and coordsys for AFNI

### DIFF
--- a/fileio/ft_read_atlas.m
+++ b/fileio/ft_read_atlas.m
@@ -206,7 +206,7 @@ switch fileformat
     else
       coordsys = 'tal'; % FIXME could be different in other atlases
     end
-    
+
     if isfield(tmp.hdr, 'ATLAS_LABEL_TABLE') && ~isempty(tmp.hdr.ATLAS_LABEL_TABLE)
       if isfield(tmp.hdr.ATLAS_LABEL_TABLE(1), 'sb_label') && ~all(tmp.anatomy(:)==round(tmp.anatomy(:)))
         % probabilistic atlas


### PR DESCRIPTION
This was identified in a regression error for ft_volumelookup.

The issue was that the axes' orientation in an AFNI file are typically 'lps' or so, and the corresponding transform that is generated is always diagonal on the rotation part. This is inconsistent with the axes' orientation of the world coordinate system (tal/mni or so), which is typically 'ras'. This fix fixes it.