### PR TITLE
Remove strfind from ft_read_atlas

### DIFF
--- a/fileio/ft_read_atlas.m
+++ b/fileio/ft_read_atlas.m
@@ -90,7 +90,7 @@ elseif strcmp(x, '.nii') && exist(fullfile(p, [f '.txt']), 'file')
     format = 'aal';
   end
   fclose(fid);
-elseif strcmp(x, '.mgz') && contains(strfind(f, 'aparc')) || contains(f, 'aseg')
+elseif strcmp(x, '.mgz') && contains(f, 'aparc') || contains(f, 'aseg')
   % individual volume based segmentation from freesurfer
   format = 'freesurfer_volume';
 elseif ft_filetype(filename, 'caret_label')


### PR DESCRIPTION
Bugfix for issue [#2018](https://github.com/fieldtrip/fieldtrip/issues/2018)

Error using contains vanished once strfind is removed.

<img width="764" alt="image" src="https://user-images.githubusercontent.com/625355/165154936-fe718dc1-5ea5-4a93-9ff8-c72e14d6c980.png">
