### PR TITLE
Fix dashboard

### DIFF
--- a/bin/synchronize-private.sh
+++ b/bin/synchronize-private.sh
@@ -1477,6 +1477,7 @@ sync ${ARRAY[*]}
 ARRAY=()
 ARRAY+=(test/private/isalmostequal.m)
 ARRAY+=(private/isalmostequal.m)
+ARRAY+=(preproc/private/isalmostequal.m)
 sync ${ARRAY[*]}
 
 ################################################################################

--- a/external/signal/filtfilt.m
+++ b/external/signal/filtfilt.m
@@ -74,6 +74,7 @@ lb = length(b);
 la = length(a);
 n = max(lb, la);
 lrefl = 3 * (n - 1);
+if lrefl >= lx, lrefl = lx-1; end
 if la < n, a(n) = 0; end
 if lb < n, b(n) = 0; end
 

--- a/external/signal/fir1.m
+++ b/external/signal/fir1.m
@@ -1,0 +1,189 @@
+% Copyright (C) 2000 Paul Kienzle <pkienzle@users.sf.net>
+%
+% This program is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program; see the file COPYING. If not, see
+% <https://www.gnu.org/licenses/>.
+
+% -*- texinfo -*-
+% @deftypefn  {Function File} {@var{b} =} fir1 (@var{n}, @var{w})
+% @deftypefnx {Function File} {@var{b} =} fir1 (@var{n}, @var{w}, @var{type})
+% @deftypefnx {Function File} {@var{b} =} fir1 (@var{n}, @var{w}, @var{type}, @var{window})
+% @deftypefnx {Function File} {@var{b} =} fir1 (@var{n}, @var{w}, @var{type}, @var{window}, @var{noscale})
+%
+% Produce an order @var{n} FIR filter with the given frequency cutoff @var{w},
+% returning the @var{n}+1 filter coefficients in @var{b}.  If @var{w} is a
+% scalar, it specifies the frequency cutoff for a lowpass or highpass filter.
+% If @var{w} is a two-element vector, the two values specify the edges of a
+% bandpass or bandstop filter.  If @var{w} is an N-element vector, each
+% value specifies a band edge of a multiband pass/stop filter.
+%
+% The filter @var{type} can be specified with one of the following strings:
+% "low", "high", "stop", "pass", "bandpass", "DC-0", or "DC-1".  The default
+% is "low" is @var{w} is a scalar, "pass" if @var{w} is a pair, or "DC-0" if
+% @var{w} is a vector with more than 2 elements.
+%
+% An optional shaping @var{window} can be given as a vector with length
+% @var{n}+1.  If not specified, a Hamming window of length @var{n}+1 is used.
+%
+% With the option "noscale", the filter coefficients are not normalized. The
+% default is to normalize the filter such that the magnitude response of the
+% center of the first passband is 1.
+%
+% To apply the filter, use the return vector @var{b} with the @code{filter}
+% function, for example @code{y = filter (b, 1, x)}.
+%
+% Examples:
+% @example
+% freqz (fir1 (40, 0.3));
+% freqz (fir1 (15, [0.2, 0.5], "stop"));  # note the zero-crossing at 0.1
+% freqz (fir1 (15, [0.2, 0.5], "stop", "noscale"));
+% @end example
+% @seealso{filter, fir2}
+% @end deftypefn
+
+% FIXME: Consider using exact expression (in terms of sinc) for the
+%        impulse response rather than relying on fir2.
+% FIXME: Find reference to the requirement that order be even for
+%        filters that end high.  Figure out what to do with the
+%        window in these cases
+
+function b = fir1(n, w, varargin)
+
+  if nargin < 2 || nargin > 5
+    error('wrong number of inputs');
+  end
+
+  % Assign default window, filter type and scale.
+  % If single band edge, the first band defaults to a pass band to
+  % create a lowpass filter.  If multiple band edges, the first band
+  % defaults to a stop band so that the two band case defaults to a
+  % band pass filter.  Ick.
+  window  = [];
+  scale   = 1;
+  ftype   = (length(w)==1);
+
+  % sort arglist, normalize any string
+  for i=1:length(varargin)
+    arg = varargin{i};
+    if ischar(arg), arg=lower(arg);end
+    if isempty(arg) continue; end  
+    switch arg
+      case {'low','stop','dc-1'},             ftype  = 1;
+      case {'high','pass','bandpass','dc-0'}, ftype  = 0;
+      case {'scale'},                         scale  = 1;
+      case {'noscale'},                       scale  = 0;
+      otherwise                               window = arg;
+    end
+  end
+
+  % build response function according to fir2 requirements
+  bands = length(w)+1;
+  f = zeros(1,2*bands);
+  f(1) = 0; f(2*bands)=1;
+  f(2:2:2*bands-1) = w;
+  f(3:2:2*bands-1) = w;
+  m = zeros(1,2*bands);
+  m(1:2:2*bands) = rem([1:bands]-(1-ftype),2);
+  m(2:2:2*bands) = m(1:2:2*bands);
+
+  % Increment the order if the final band is a pass band.  Something
+  % about having a nyquist frequency of zero causing problems.
+  if rem(n,2)==1 && m(2*bands)==1,
+    warning("n must be even for highpass and bandstop filters. Incrementing.");
+    n = n+1;
+    if isvector(window) && isreal(window) && ~ischar(window)
+      % Extend the window using interpolation
+      M = length(window);
+      if M == 1,
+        window = [window; window];
+      elseif M < 4
+        window = interp1(linspace(0,1,M),window,linspace(0,1,M+1),'linear');
+      else
+        window = interp1(linspace(0,1,M),window,linspace(0,1,M+1),'spline');
+      end
+    end
+  end
+
+  % compute the filter
+  b = fir2(n, f, m, [], 2, window);
+
+  % normalize filter magnitude
+  if scale == 1
+    % find the middle of the first band edge
+    % find the frequency of the normalizing gain
+    if m(1) == 1
+      % if the first band is a passband, use DC gain
+      w_o = 0;
+    elseif f(4) == 1
+      % for a highpass filter,
+      % use the gain at half the sample frequency
+      w_o = 1;
+    else
+      % otherwise, use the gain at the center
+      % frequency of the first passband
+      w_o = f(3) + (f(4)-f(3))/2;
+    end
+
+    % compute |h(w_o)|^-1
+    renorm = 1/abs(polyval(b, exp(-1i*pi*w_o)));
+
+    % normalize the filter
+    b = renorm*b;
+  end
+
+end
+
+%!demo
+%! freqz(fir1(40,0.3));
+%!demo
+%! freqz(fir1(15,[0.2, 0.5], 'stop'));  # note the zero-crossing at 0.1
+%!demo
+%! freqz(fir1(15,[0.2, 0.5], 'stop', 'noscale'));
+
+%!assert(fir1(2, .5, 'low', @hanning, 'scale'), [0 1 0]);
+%!assert(fir1(2, .5, 'low', "hanning", 'scale'), [0 1 0]);
+%!assert(fir1(2, .5, 'low', hanning(3), 'scale'), [0 1 0]);
+
+%!assert(fir1(10,.5,'noscale'), fir1(10,.5,'low','hamming','noscale'));
+%!assert(fir1(10,.5,'high'), fir1(10,.5,'high','hamming','scale'));
+%!assert(fir1(10,.5,'boxcar'), fir1(10,.5,'low','boxcar','scale'));
+%!assert(fir1(10,.5,'hanning','scale'), fir1(10,.5,'scale','hanning','low'));
+%!assert(fir1(10,.5,'haNNing','NOscale'), fir1(10,.5,'noscale','Hanning','LOW'));
+%!assert(fir1(10,.5,'boxcar',[]), fir1(10,.5,'boxcar'));
+
+%% Test expected magnitudes of passbands, stopbands, and cutoff frequencies
+
+%!test
+%! b = fir1 (30, 0.3);
+%! h = abs (freqz (b, 1, [0, 0.3, 1], 2));
+%! assert (h(1), 1, 1e-3)
+%! assert (all (h(2:3) <= [1/sqrt(2), 3e-3]))
+
+%!test
+%! b = fir1 (30, 0.7, "high");
+%! h = abs (freqz (b, 1, [0, 0.7, 1], 2));
+%! assert (h(3), 1, 1e-3)
+%! assert (all (h(1:2) <= [3e-3, 1/sqrt(2)]))
+
+%!test
+%! b = fir1 (30, [0.3, 0.7]);
+%! h = abs (freqz (b, 1, [0, 0.3, 0.5, 0.7, 1], 2));
+%! assert (h(3), 1, 1e-3)
+%! assert (all (h([1:2, 4:5]) <= [3e-3, 1/sqrt(2), 1/sqrt(2), 3e-3]))
+
+%!test
+%! b = fir1 (50, [0.3, 0.7], "stop");
+%! h = abs (freqz (b, 1, [0, 0.3, 0.5, 0.7, 1], 2));
+%! assert (h(1), 1, 1e-3)
+%! assert (h(5), 1, 1e-3)
+%! assert (all (h(2:4) <= [1/sqrt(2), 3e-3, 1/sqrt(2)]))

--- a/external/signal/fir2.m
+++ b/external/signal/fir2.m
@@ -1,0 +1,245 @@
+% Copyright (C) 2000 Paul Kienzle <pkienzle@users.sf.net>
+%
+% This program is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program; see the file COPYING. If not, see
+% <https://www.gnu.org/licenses/>.
+
+% -*- texinfo -*-
+% @deftypefn  {Function File} {@var{b} =} fir2 (@var{n}, @var{f}, @var{m})
+% @deftypefnx {Function File} {@var{b} =} fir2 (@var{n}, @var{f}, @var{m}, @var{grid_n})
+% @deftypefnx {Function File} {@var{b} =} fir2 (@var{n}, @var{f}, @var{m}, @var{grid_n}, @var{ramp_n})
+% @deftypefnx {Function File} {@var{b} =} fir2 (@var{n}, @var{f}, @var{m}, @var{grid_n}, @var{ramp_n}, @var{window})
+%
+% Produce an order @var{n} FIR filter with arbitrary frequency response
+% @var{m} over frequency bands @var{f}, returning the @var{n}+1 filter
+% coefficients in @var{b}.  The vector @var{f} specifies the frequency band
+% edges of the filter response and @var{m} specifies the magnitude response
+% at each frequency.
+%
+% The vector @var{f} must be nondecreasing over the range [0,1], and the
+% first and last elements must be 0 and 1, respectively.  A discontinuous
+% jump in the frequency response can be specified by duplicating a band edge
+% in @var{f} with different values in @var{m}.
+%
+% The resolution over which the frequency response is evaluated can be
+% controlled with the @var{grid_n} argument.  The default is 512 or the
+% next larger power of 2 greater than the filter length.
+%
+% The band transition width for discontinuities can be controlled with the
+% @var{ramp_n} argument.  The default is @var{grid_n}/25.  Larger values
+% will result in wider band transitions but better stopband rejection.
+%
+% An optional shaping @var{window} can be given as a vector with length
+% @var{n}+1.  If not specified, a Hamming window of length @var{n}+1 is used.
+%
+% To apply the filter, use the return vector @var{b} with the @code{filter}
+% function, for example @code{y = filter (b, 1, x)}.
+%
+% Example:
+% @example
+% f = [0, 0.3, 0.3, 0.6, 0.6, 1]; m = [0, 0, 1, 1/2, 0, 0];
+% [h, w] = freqz (fir2 (100, f, m));
+% plot (f, m, ';target response;', w/pi, abs (h), ';filter response;');
+% @end example
+% @seealso{filter, fir1}
+% @end deftypefn
+
+function b = fir2(n, f, m, grid_n, ramp_n, window)
+
+  if nargin < 3 || nargin > 6
+    error('wrong number of inputs');
+  end
+
+  % verify frequency and magnitude vectors are reasonable
+  t = length(f);
+  if t<2 || f(1)~=0 || f(t)~=1 || any(diff(f)<0)
+    error ('fir2: frequency must be nondecreasing starting from 0 and ending at 1');
+  elseif t ~= length(m)
+    error ('fir2: frequency and magnitude vectors must be the same length');
+  % find the grid spacing and ramp width
+  elseif (nargin>4 && length(grid_n)>1) || ...
+         (nargin>5 && (length(grid_n)>1 || length(ramp_n)>1))
+    error ('fir2: grid_n and ramp_n must be integers');
+  end
+  if nargin < 4, grid_n=[]; end
+  if nargin < 5, ramp_n=[]; end
+
+  % find the window parameter, or default to hamming
+  w=[];
+  if length(grid_n)>1, w=grid_n; grid_n=[]; end
+  if length(ramp_n)>1, w=ramp_n; ramp_n=[]; end
+  if nargin < 6, window=w; end
+  if isempty(window), window=hamming(n+1); end
+  if ~isreal(window) || ischar(window), window=feval(window, n+1); end
+    if length(window) ~= n+1, error ('fir2: window must be of length n+1'); end
+
+  % Default grid size is 512... unless n+1 >= 1024
+  if isempty (grid_n)
+    if n+1 < 1024
+      grid_n = 512;
+    else
+      grid_n = n+1;
+    end
+  end
+
+  % ML behavior appears to always round the grid size up to a power of 2
+  grid_n = 2 ^ nextpow2 (grid_n);
+
+  % Error out if the grid size is not big enough for the window
+  if 2*grid_n < n+1
+    error ('fir2: grid size must be greater than half the filter order');
+  end
+
+  if isempty (ramp_n), ramp_n = fix (grid_n / 25); end
+
+  % Apply ramps to discontinuities
+  if (ramp_n > 0)
+    % remember original frequency points prior to applying ramps
+    basef = f(:); basem = m(:);
+
+    % separate identical frequencies, but keep the midpoint
+    idx = find (diff(f) == 0);
+    f(idx) = f(idx) - ramp_n/grid_n/2;
+    f(idx+1) = f(idx+1) + ramp_n/grid_n/2;
+    f = [f(:);basef(idx)]';
+
+    % make sure the grid points stay monotonic in [0,1]
+    f(f<0) = 0;
+    f(f>1) = 1;
+    f = unique([f(:);reshape(basef(idx),[],1)]');
+
+    % preserve window shape even though f may have changed
+    % JM change: MATLAB (2021b) errors if the basef points are not unique,
+    % which might be often the case, add some numeric noise to basef
+    for k = 1:numel(basef)-1
+      if basef(k)==basef(k+1)
+        basef(k) = basef(k)-eps;
+        basef(k+1) = basef(k+1)+eps;
+      end
+    end
+
+    m = interp1(basef, basem, f); %original
+
+    % axis([-.1 1.1 -.1 1.1])
+    % plot(f,m,'-xb;ramped;',basef,basem,'-or;original;'); pause;
+  end
+
+  % interpolate between grid points
+  grid = interp1(f,m,linspace(0,1,grid_n+1)');
+  % hold on; plot(linspace(0,1,grid_n+1),grid,'-+g;grid;'); hold off; pause;
+
+  % Transform frequency response into time response and
+  % center the response about n/2, truncating the excess
+  if (rem(n,2) == 0)
+    b = ifft([grid ; grid(grid_n:-1:2)]);
+    mid = (n+1)/2;
+    b = real ([ b([end-floor(mid)+1:end]) ; b(1:ceil(mid)) ]);
+  else
+    % Add zeros to interpolate by 2, then pick the odd values below.
+    b = ifft([grid ; zeros(grid_n*2,1) ;grid(grid_n:-1:2)]);
+    b = 2 * real([ b([end-n+1:2:end]) ; b(2:2:(n+1))]);
+  end
+
+  % Multiplication in the time domain is convolution in frequency,
+  % so multiply by our window now to smooth the frequency response.
+  % Also, for matlab compatibility, we return return values in 1 row
+  b = b(:)' .* window(:)';
+
+end
+
+%% Test that the grid size is rounded up to the next power of 2
+%% FIXME: test fails randomly on i386
+%!xtest
+%! f = [0 0.6 0.6 1]; m = [1 1 0 0];
+%! b9  = fir2 (30, f, m, 9);
+%! b16 = fir2 (30, f, m, 16);
+%! b17 = fir2 (30, f, m, 17);
+%! b32 = fir2 (30, f, m, 32);
+%! assert ( isequal (b9,  b16))
+%! assert ( isequal (b17, b32))
+%! assert (~isequal (b16, b17))
+
+%% Test expected magnitudes of passbands, stopbands, and cutoff frequencies
+%!test
+%! f = [0, 0.7, 0.7, 1]; m = [0, 0, 1, 1];
+%! b = fir2 (50, f, m);
+%! h = abs (freqz (b, 1, [0, 0.7, 1], 2));
+%! assert (h(1) <= 3e-3)
+%! assert (h(2) <= 1/sqrt (2))
+%! assert (h(3), 1, 2e-3)
+
+%!test
+%! f = [0, 0.25, 0.25, 0.75, 0.75, 1]; m = [0, 0, 1, 1, 0, 0];
+%! b = fir2 (50, f, m);
+%! h = abs (freqz (b, 1, [0, 0.25, 0.5, 0.75, 1], 2));
+%! assert (h(1) <= 3e-3)
+%! assert (h(2) <= 1/sqrt (2))
+%! assert (h(3), 1, 2e-3)
+%! assert (h(4) <= 1/sqrt (2))
+%! assert (h(5) <= 3e-3)
+
+%!test
+%! f = [0, 0.45, 0.45, 0.55, 0.55, 1]; m = [1, 1, 0, 0, 1, 1];
+%! b = fir2 (50, f, m);
+%! h = abs (freqz (b, 1, [0, 0.45, 0.5, 0.55, 1], 2));
+%! assert (h(1), 1, 2e-3)
+%! assert (h(2) <= 1/sqrt (2))
+%! assert (h(3) <= 1e-1)
+%! assert (h(4) <= 1/sqrt (2))
+%! assert (h(5), 1, 2e-3)
+
+%!demo
+%! f=[0, 0.3, 0.3, 0.6, 0.6, 1]; m=[0, 0, 1, 1/2, 0, 0];
+%! [h, w] = freqz(fir2(100,f,m));
+%! subplot(121);
+%! plot(f,m,';target response;',w/pi,abs(h),';filter response;');
+%! subplot(122);
+%! plot(f,20*log10(m+1e-5),';target response (dB);',...
+%!      w/pi,20*log10(abs(h)),';filter response (dB);');
+
+%!demo
+%! f=[0, 0.3, 0.3, 0.6, 0.6, 1]; m=[0, 0, 1, 1/2, 0, 0];
+%! plot(f,20*log10(m+1e-5),';target response;');
+%! hold on;
+%! [h, w] = freqz(fir2(50,f,m,512,0));
+%! plot(w/pi,20*log10(abs(h)),';filter response (ramp=0);');
+%! [h, w] = freqz(fir2(50,f,m,512,25.6));
+%! plot(w/pi,20*log10(abs(h)),';filter response (ramp=pi/20 rad);');
+%! [h, w] = freqz(fir2(50,f,m,512,51.2));
+%! plot(w/pi,20*log10(abs(h)),';filter response (ramp=pi/10 rad);');
+%! hold off;
+
+%!demo
+%! % Classical Jakes spectrum
+%! % X represents the normalized frequency from 0
+%! % to the maximum Doppler frequency
+%! asymptote = 2/3;
+%! X = linspace(0,asymptote-0.0001,200);
+%! Y = (1 - (X./asymptote).^2).^(-1/4);
+%!
+%! % The target frequency response is 0 after the asymptote
+%! X = [X, asymptote, 1];
+%! Y = [Y, 0, 0];
+%!
+%! plot(X,Y,'b;Target spectrum;');
+%! hold on;
+%! [H,F]=freqz(fir2(20, X, Y));
+%! plot(F/pi,abs(H),'c;Synthesized spectrum (n=20);');
+%! [H,F]=freqz(fir2(50, X, Y));
+%! plot(F/pi,abs(H),'r;Synthesized spectrum (n=50);');
+%! [H,F]=freqz(fir2(200, X, Y));
+%! plot(F/pi,abs(H),'g;Synthesized spectrum (n=200);');
+%! hold off;
+%! title('Theoretical/Synthesized CLASS spectrum');
+%! xlabel('Normalized frequency (Fs=2)');
+%! ylabel('Magnitude');

--- a/external/signal/firls.m
+++ b/external/signal/firls.m
@@ -46,7 +46,7 @@
 function coef = firls(N, frequencies, pass, weight, str)
 
 if (nargin < 3 || nargin > 6)
-  print_usage;
+  error('there is somethig wrong with the input arguments');
 elseif (nargin == 3)
   weight = ones (1, length(pass)/2);
   str = [];
@@ -58,59 +58,62 @@ elseif (nargin == 4)
     str = [];
   end
 end
-if length (frequencies) ~= length (pass)
-  error("F and A must have equal lengths.");
-elseif 2 * length (weight) ~= length (pass)
-  error("W must contain one weight per band.");
-elseif ischar (str)
-  error("This feature is implemented yet");
-else
-  
-  N = 2*ceil(N/2);
-  
-  M = N/2;
-  w = kron (weight(:), [-1; 1]);
-  omega = frequencies * pi;
-  i1 = 1:2:length (omega);
-  i2 = 2:2:length (omega);
-  
-  % Generate the matrix Q
-  % As illustrated in the above-cited reference, the matrix can be
-  % expressed as the sum of a Hankel and Toeplitz matrix. A factor of
-  % 1/2 has been dropped and the final filter coefficients multiplied
-  % by 2 to compensate.
-  cos_ints = [omega; sin((1:N)' * omega)];
-  q = [1, 1./(1:N)]' .* (cos_ints * w);
-  Q = toeplitz (q(1:M+1)) + hankel (q(1:M+1), q(M+1:end));
-  
-  % The vector b is derived from solving the integral:
-  %
-  %           _ w
-  %          /   2
-  %  b  =   /       W(w) D(w) cos(kw) dw
-  %   k    /    w
-  %       -      1
-  %
-  % Since we assume that W(w) is constant over each band (if not, the
-  % computation of Q above would be considerably more complex), but
-  % D(w) is allowed to be a linear function, in general the function
-  % W(w) D(w) is linear. The computations below are derived from the
-  % fact that:
-  %     _
-  %    /                          a              ax + b
-  %   /   (ax + b) cos(nx) dx =  --- cos (nx) +  ------ sin(nx)
-  %  /                             2                n
-  % -                             n
-  %
-  cos_ints2 = [omega(i1).^2 - omega(i2).^2; ...
-    cos((1:M)' * omega(i2)) - cos((1:M)' * omega(i1))] ./ ...
-    ([2, 1:M]' * (omega(i2) - omega(i1)));
-  d = [-weight .* pass(i1); weight .* pass(i2)];
-  b = [1, 1./(1:M)]' .* ((kron (cos_ints2, [1, 1]) + cos_ints(1:M+1,:)) * d(:));
-  
-  % Having computed the components Q and b of the  matrix equation,
-  % solve for the filter coefficients.
-  a = Q \ b;
-  coef = [ a(end:-1:2); 2 * a(1); a(2:end) ];
-  
+if length(frequencies) ~= length(pass)
+  error('F and A must have equal lengths.');
+elseif 2 * length(weight) ~= length(pass)
+  error('W must contain one weight per band.');
+elseif ischar(str)
+  error('This feature is implemented yet');
 end
+
+% ensure both pass and frequency to be a row vector
+if ~isrow(frequencies), frequencies = frequencies(:)'; end
+if ~isrow(pass), pass = pass(:)'; end
+
+N = 2*ceil(N/2);
+
+M = N/2;
+w = kron(weight(:), [-1; 1]);
+omega = frequencies * pi;
+i1 = 1:2:length(omega);
+i2 = 2:2:length(omega);
+
+% Generate the matrix Q
+% As illustrated in the above-cited reference, the matrix can be
+% expressed as the sum of a Hankel and Toeplitz matrix. A factor of
+% 1/2 has been dropped and the final filter coefficients multiplied
+% by 2 to compensate.
+cos_ints = [omega; sin((1:N)' * omega)];
+q = [1, 1./(1:N)]' .* (cos_ints * w);
+Q = toeplitz(q(1:M+1)) + hankel(q(1:M+1), q(M+1:end));
+
+% The vector b is derived from solving the integral:
+%
+%           _ w
+%          /   2
+%  b  =   /       W(w) D(w) cos(kw) dw
+%   k    /    w
+%       -      1
+%
+% Since we assume that W(w) is constant over each band (if not, the
+% computation of Q above would be considerably more complex), but
+% D(w) is allowed to be a linear function, in general the function
+% W(w) D(w) is linear. The computations below are derived from the
+% fact that:
+%     _
+%    /                          a              ax + b
+%   /   (ax + b) cos(nx) dx =  --- cos (nx) +  ------ sin(nx)
+%  /                             2                n
+% -                             n
+%
+cos_ints2 = [omega(i1).^2 - omega(i2).^2; ...
+  cos((1:M)' * omega(i2)) - cos((1:M)' * omega(i1))] ./ ...
+  ([2, 1:M]' * (omega(i2) - omega(i1)));
+d = [-weight .* pass(i1); weight .* pass(i2)];
+b = [1, 1./(1:M)]' .* ( (kron(cos_ints2, [1, 1]) + cos_ints(1:M+1,:)) * d(:));
+
+% Having computed the components Q and b of the  matrix equation,
+% solve for the filter coefficients.
+a = Q \ b;
+coef = [ a(end:-1:2); 2 * a(1); a(2:end) ];
+coef = coef(:)';

--- a/external/signal/upfirdn.m
+++ b/external/signal/upfirdn.m
@@ -39,5 +39,5 @@ if(floor(p) ~= p || floor(q) ~= q || p < 1 || q < 1)
 end
 	
 yout = upsample(xin,p);
-yout = conv(yout, h); % original was filter(h, 1, yout);
+yout = convn(yout, h); % original was filter(h, 1, yout);
 yout = downsample(yout,q);

--- a/preproc/private/isalmostequal.m
+++ b/preproc/private/isalmostequal.m
@@ -1,0 +1,215 @@
+function [ok, message] = isalmostequal(a, b, varargin)
+
+% ISALMOSTEQUAL compares two input variables and returns true/false
+% and a message containing the details on the observed difference.
+%
+% Use as
+%   [ok, message] = isalmostequal(a, b)
+%   [ok, message] = isalmostequal(a, b, ...)
+%
+% This works for all possible input variables a and b, like
+% numerical arrays, string arrays, cell arrays, structures
+% and nested data types.
+%
+% Optional input arguments come in key-value pairs, supported are
+%   'depth'      number, for nested structures
+%   'abstol'     number, absolute tolerance for numerical comparison
+%   'reltol'     number, relative tolerance for numerical comparison
+%   'diffabs'    boolean, check difference between absolute values for numericals (useful for e.g. mixing matrices which have arbitrary signs)
+%
+% See also ISEQUAL, ISEQUALNAN
+
+% Copyright (C) 2004-2012, Robert Oostenveld & Markus Siegel
+%
+% $Id$
+
+if nargin==3
+  % for backward compatibility
+  depth = varargin{1};
+else
+  depth = ft_getopt(varargin, 'depth');
+  if isempty(depth)
+    % set the default
+    depth = inf;
+  end
+end
+
+message = {};
+location = '';
+
+[message] = do_work(a, b, depth, location, message, varargin{:});
+message = message(:);
+ok = isempty(message);
+
+if ~nargout
+  disp(message);
+end
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+function [message] = do_work(a, b, depth, location, message, varargin)
+
+knowntypes = {
+  'double'          % Double precision floating point numeric array
+  'logical'         % Logical array
+  'char'            % Character array
+  'cell'            % Cell array
+  'table'           % Table
+  'struct'          % Structure array
+  'numeric'         % Integer or floating-point array
+  'single'          % Single precision floating-point numeric array
+  'int8'            % 8-bit signed integer array
+  'uint8'           % 8-bit unsigned integer array
+  'int16'           % 16-bit signed integer array
+  'uint16'          % 16-bit unsigned integer array
+  'int32'           % 32-bit signed integer array
+  'uint32'          % 32-bit unsigned integer array
+  };
+
+if isempty(location)
+  location = 'array';
+end
+
+for type=knowntypes(:)'
+  if isa(a, type{:}) && ~isa(b, type{:})
+    message{end+1} = sprintf('different data type in %s', location);
+    return
+  end
+end
+
+if isa(a, 'numeric') || isa(a, 'char') || isa(a, 'logical')
+  % perform numerical comparison
+  if length(size(a))~=length(size(b))
+    message{end+1} = sprintf('different number of dimensions in %s', location);
+    return;
+  end
+  if any(size(a)~=size(b))
+    message{end+1} = sprintf('different size in %s', location);
+    return;
+  end
+  if ~all(isnan(a(:)) == isnan(b(:)))
+    message{end+1} = sprintf('different occurence of NaNs in %s', location);
+    return;
+  end
+  % replace the NaNs, since we cannot compare them numerically
+  a = a(~isnan(a(:)));
+  b = b(~isnan(b(:)));
+  % continue with numerical comparison
+  if ischar(a) && any(a~=b)
+    message{end+1} = sprintf('different string in %s: %s ~= %s', location, a, b);
+  else
+    % use the desired tolerance
+    reltol     = ft_getopt(varargin, 'reltol');       % any value, relative to the mean
+    abstol     = ft_getopt(varargin, 'abstol');       % any value
+    relnormtol = ft_getopt(varargin, 'relnormtol');   % the matrix norm, relative to the mean norm
+    absnormtol = ft_getopt(varargin, 'absnormtol');   % the matrix norm
+    diffabs    = ft_getopt(varargin, 'diffabs');
+    
+    if ~isempty(diffabs) && diffabs
+      a = abs(a);
+      b = abs(b);
+    end
+    
+    if ~isempty(abstol) && any(abs(a-b)>abstol)
+      message{end+1} = sprintf('different values in %s', location);
+    elseif ~isempty(reltol) && any((abs(a-b)./(0.5*abs(a+b)))>reltol)
+      message{end+1} = sprintf('different values in %s', location);
+    elseif isempty(abstol) && isempty(reltol) && any(a~=b)
+      message{end+1} = sprintf('different values in %s', location);
+    elseif ~isempty(relnormtol) && (norm(a-b)/(0.5*(norm(a)+norm(b)))>relnormtol)
+      message{end+1} = sprintf('different values in %s', location);
+    elseif ~isempty(absnormtol) && norm(a-b)>absnormtol
+      message{end+1} = sprintf('different values in %s', location);
+    end
+  end
+  
+elseif isa(a, 'struct') && all(size(a)==1)
+  % perform recursive comparison of all fields of the structure
+  fna = fieldnames(a);
+  fnb = fieldnames(b);
+  if ~all(ismember(fna, fnb))
+    tmp = fna(~ismember(fna, fnb));
+    for i=1:length(tmp)
+      message{end+1} = sprintf('field missing in the 2nd argument in %s: {%s}', location, tmp{i});
+    end
+  end
+  if ~all(ismember(fnb, fna))
+    tmp = fnb(~ismember(fnb, fna));
+    for i=1:length(tmp)
+      message{end+1} = sprintf('field missing in the 1st argument in %s: {%s}', location, tmp{i});
+    end
+  end
+  fna = intersect(fna, fnb);
+  if depth>0
+    % warning, this is a recursive call to transverse nested structures
+    for i=1:length(fna)
+      fn = fna{i};
+      ra = getfield(a, fn);
+      rb = getfield(b, fn);
+      [message] = do_work(ra, rb, depth-1, [location '.' fn], message, varargin{:});
+    end
+  end
+  
+elseif isa(a, 'struct') && ~all(size(a)==1)
+  % perform recursive comparison of all array elements
+  if any(size(a)~=size(b))
+    message{end+1} = sprintf('different size of struct-array in %s', location);
+    return;
+  end
+  siz = size(a);
+  dim = ndims(a);
+  a = a(:);
+  b = b(:);
+  for i=1:length(a)
+    ra = a(i);
+    rb = b(i);
+    tmp = sprintf('%s(%s)', location, my_ind2sub(siz, i));
+    [message] = do_work(ra, rb, depth-1, tmp, message, varargin{:});
+  end
+  
+elseif isa(a, 'cell')
+  % perform recursive comparison of all array elements
+  if any(size(a)~=size(b))
+    message{end+1} = sprintf('different size of cell-array in %s', location);
+    return;
+  end
+  siz = size(a);
+  dim = ndims(a);
+  a = a(:);
+  b = b(:);
+  for i=1:length(a)
+    ra = a{i};
+    rb = b{i};
+    tmp = sprintf('%s{%s}', location, my_ind2sub(siz, i));
+    [message] = do_work(ra, rb, depth-1, tmp, message, varargin{:});
+  end
+
+elseif isa(a, 'table')
+  if any(size(a)~=size(b))
+    message{end+1} = sprintf('different size of table');
+    return;
+  end
+  if ~isequal(a.Properties, b.Properties)
+    message{end+1} = sprintf('different properties of table');
+    return;
+  end
+  ra = table2cell(a);
+  rb = table2cell(b);
+  tmp = '';
+  [message] = do_work(ra, rb, depth-1, tmp, message, varargin{:});
+end
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% return a string with the formatted subscript
+function [str] = my_ind2sub(siz,ndx)
+n = length(siz);
+k = [1 cumprod(siz(1:end-1))];
+ndx = ndx - 1;
+for i = n:-1:1
+  tmp(i) = floor(ndx/k(i))+1;
+  ndx = rem(ndx,k(i));
+end
+str = '';
+for i=1:n
+  str = [str ',' num2str(tmp(i))];
+end
+str = str(2:end);

--- a/test/test_bug1129.m
+++ b/test/test_bug1129.m
@@ -78,8 +78,7 @@ for N=[199 432 1000] % test 'firls' option
 end
 
 %% high-level ft_preprocessing
-cd(dccnpath('/home/common/matlab/fieldtrip/data/test'))
-load bug1129.mat
+load(fullfile(dccnpath('/home/common/matlab/fieldtrip/data/test'), 'bug1129.mat'));
 
 cfg = [];
 cfg.bpfreq = [8 12];

--- a/test/test_bug1129.m
+++ b/test/test_bug1129.m
@@ -78,7 +78,7 @@ for N=[199 432 1000] % test 'firls' option
 end
 
 %% high-level ft_preprocessing
-load(fullfile(dccnpath('/home/common/matlab/fieldtrip/data/test'), 'bug1129.mat'));
+load(dccnpath('/home/common/matlab/fieldtrip/data/test/bug1129.mat'));
 
 cfg = [];
 cfg.bpfreq = [8 12];


### PR DESCRIPTION
This PR aims at fixing the failing dashboard, which was due to some overloaded functions being added to fieldtrip/external/signal. Due to slight incompatibilities between the matlab and octave-derived functions, a lot of test functions started failing. 

- upfirdn did not work yet for matrices, now it does.

- Also, there was some confusion when ft_default.toolbox.signal was set to 'compat', and some to-be-overloaded functions (fir1/fir2) were taken from matlab's signal toolbox. Therefore those functions have been added.

- the fir_filterdcpadded function was a bit too strict on equality testing for symmetric/antisymmetric. I added some leniency because the overloaded functions have some numerical roundoff differences.
 
I think that now most (if not all) should be fixed again. I ran the majority (i.e. the shortest ones) of the previously failing test functions locally, and they run through again.