### PR TITLE
Update read_EDF to fix slow EDF reading in.

### DIFF
--- a/fileio/private/read_edf.m
+++ b/fileio/private/read_edf.m
@@ -433,7 +433,7 @@ end
 % SUBFUNCTION for reading the 16 bit values
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 function buf = readLowLevel(filename, offset, numwords)
-is_below_2GB = offset < 2*1024^2;
+is_below_2GB = offset < 2*1024^3;
 read_16bit_success = true;
 if is_below_2GB
   % use the external mex file, only works for <2GB


### PR DESCRIPTION
The low level function was slow for any reading of EDF files beyond 2 MB when the fast .mex files of reading 16bit could handle up to 2 GB. 
The error was that it was treated as limiting to 2 MB when it should be 2 GB!
1024^2 is clearly a Mega and 1024^3 is a GB
This improves the slow reading in speed of EDFs to a high degree.
This saves a lot of people working with EDF a lot of waiting time (order of magnitude less).