### PR TITLE
fix the channel selection for EDF files

### DIFF
--- a/fileio/private/read_edf.m
+++ b/fileio/private/read_edf.m
@@ -342,7 +342,7 @@ elseif needdat || needevt
     useChanindx = true;
   elseif ~isempty(chanindx) &&  isfield(EDF, 'chansel')
     % a subset of channels should been selected from the predefined list
-    chanindx = EDF.chansel(chanindx);
+    chanindx = EDF.chansel;
     useChanindx = true;
   elseif  isempty(chanindx) &&  isfield(EDF, 'chansel')
     % all channels from the predefined list should be selected


### PR DESCRIPTION
in the channel selection part of read_EDF, the desired channels are first saved from `chanindx` to `EDF.chansel` and then later the code tries to select the to-be-loaded channels through `EDF.chansel(chanindx)`, which under certain condition throws an error (since `chansel` may be shorter than what is indexed in `chanindx`). 
The proposed change fixed this for my usecase. 