### PR TITLE
Fixed crash when reading epoched .fif file where the event codes are …

### DIFF
--- a/fileio/ft_read_event.m
+++ b/fileio/ft_read_event.m
@@ -1617,7 +1617,8 @@ switch eventformat
       begsample = cumsum([1 repmat(hdr.nSamples, hdr.nTrials-1, 1)']);
       events_id = split(split(hdr.orig.epochs.event_id, ';'), ':');
       events_label = cell2mat(events_id(:, 1));
-      events_code = str2num(cell2mat(events_id(:, 2)));
+      maxLength = max(cellfun(@length,events_id(:, 2)));
+      events_code = str2num(cell2mat(cellfun(@pad,events_id(:, 2),num2cell(repmat(maxLength,size(events_id(:, 2)))),'UniformOutput',false)));
       for i=1:hdr.nTrials
         event(end+1).type      = 'trial';
         event(end  ).sample    = begsample(i);


### PR DESCRIPTION
…character strings and they have differing lengths.