### PR TITLE
dip to sourcemodel in dipsimulation

### DIFF
--- a/ft_dipolesimulation.m
+++ b/ft_dipolesimulation.m
@@ -11,6 +11,7 @@ function [data] = ft_dipolesimulation(cfg)
 % The dipoles position and orientation have to be specified with
 %   cfg.dip.pos     = [Rx Ry Rz] (size Nx3)
 %   cfg.dip.mom     = [Qx Qy Qz] (size 3xN)
+%   cfg.dip.unit    = string, can be 'mm', 'cm', 'm' (default is automatic)
 %
 % The number of trials and the time axes of the trials can be specified by
 %   cfg.fsample    = simulated sample frequency (default = 1000)
@@ -106,6 +107,7 @@ cfg = ft_checkconfig(cfg, 'renamed',    {'gradfile', 'grad'});
 cfg = ft_checkconfig(cfg, 'renamed',    {'optofile', 'opto'});
 cfg = ft_checkconfig(cfg, 'renamed',    {'hdmfile', 'headmodel'});
 cfg = ft_checkconfig(cfg, 'renamed',    {'vol',     'headmodel'});
+cfg = ft_checkconfig(cfg, 'renamed',    {'dip',    'sourcemodel'});
 
 % for consistency with FT_TIMELOCKSIMULUATION and FT_FREQSIMULATION
 cfg = ft_checkconfig(cfg, 'createsubcfg', 'dip');
@@ -113,18 +115,18 @@ cfg = ft_checkconfig(cfg, 'renamed', {'ntrials', 'numtrl'});
 cfg = ft_checkconfig(cfg, 'renamed', {'triallength', 'trllen'});
 
 % set the defaults
-cfg.dip         = ft_getopt(cfg, 'dip', []);
-cfg.dip.pos     = ft_getopt(cfg.dip, 'pos', [-5 0 15]);
-cfg.dip.mom     = ft_getopt(cfg.dip, 'mom', [1 0 0]');
-cfg.dip.time    = ft_getopt(cfg.dip, 'time', {});
-cfg.dip.signal  = ft_getopt(cfg.dip, 'signal', {});
-cfg.fsample     = ft_getopt(cfg, 'fsample', 250);
-cfg.relnoise    = ft_getopt(cfg, 'relnoise', 0);
-cfg.absnoise    = ft_getopt(cfg, 'absnoise', 0);
-cfg.feedback    = ft_getopt(cfg, 'feedback', 'text');
-cfg.channel     = ft_getopt(cfg, 'channel',  'all');
-cfg.dipoleunit  = ft_getopt(cfg, 'dipoleunit', 'nA*m');
-cfg.chanunit    = ft_getopt(cfg, 'chanunit', {});
+cfg.sourcemodel         = ft_getopt(cfg, 'sourcemodel', []);
+cfg.sourcemodel.pos     = ft_getopt(cfg.sourcemodel, 'pos', [-5 0 15]);
+cfg.sourcemodel.mom     = ft_getopt(cfg.sourcemodel, 'mom', [1 0 0]');
+cfg.sourcemodel.time    = ft_getopt(cfg.sourcemodel, 'time', {});
+cfg.sourcemodel.signal  = ft_getopt(cfg.sourcemodel, 'signal', {});
+cfg.fsample             = ft_getopt(cfg, 'fsample', 250);
+cfg.relnoise            = ft_getopt(cfg, 'relnoise', 0);
+cfg.absnoise            = ft_getopt(cfg, 'absnoise', 0);
+cfg.feedback            = ft_getopt(cfg, 'feedback', 'text');
+cfg.channel             = ft_getopt(cfg, 'channel',  'all');
+cfg.dipoleunit          = ft_getopt(cfg, 'dipoleunit', 'nA*m');
+cfg.chanunit            = ft_getopt(cfg, 'chanunit', {});
 
 % collect and preprocess the electrodes/gradiometer and head model
 % this will also update cfg.channel to match the electrodes/gradiometers
@@ -138,25 +140,25 @@ leadfieldopt = ft_setopt(leadfieldopt, 'normalize',      ft_getopt(cfg, 'normali
 leadfieldopt = ft_setopt(leadfieldopt, 'normalizeparam', ft_getopt(cfg, 'normalizeparam'));
 leadfieldopt = ft_setopt(leadfieldopt, 'weight',         ft_getopt(cfg, 'weight'));
 
-cfg.dip = fixdipole(cfg.dip);
-Ndipoles = size(cfg.dip.pos,1);
+cfg.sourcemodel = fixdipole(cfg.sourcemodel);
+Ndipoles = size(cfg.sourcemodel.pos,1);
 
 % in case no time or signal was given, set some additional defaults
-if ~isempty(cfg.dip.time) && ~isempty(cfg.dip.signal)
-  assert(length(cfg.dip.signal)==length(cfg.dip.time)); % these must match
-  cfg.numtrl    = length(cfg.dip.time);
-  cfg.fsample   = 1/mean(diff(cfg.dip.time{1}));  % determine from time-axis
-  cfg.trllen    = length(cfg.dip.time{1})/cfg.fsample;
-  cfg.baseline  = -cfg.dip.time{1}(1);
-elseif ~isempty(cfg.dip.time)
-  cfg.numtrl    = length(cfg.dip.time);
-  cfg.fsample   = 1/mean(diff(cfg.dip.time{1}));  % determine from time-axis
-  cfg.trllen    = length(cfg.dip.time{1})/cfg.fsample;
-  cfg.baseline  = -cfg.dip.time{1}(1);
-elseif ~isempty(cfg.dip.signal)
-  cfg.numtrl    = length(cfg.dip.signal);
+if ~isempty(cfg.sourcemodel.time) && ~isempty(cfg.sourcemodel.signal)
+  assert(length(cfg.sourcemodel.signal)==length(cfg.sourcemodel.time)); % these must match
+  cfg.numtrl    = length(cfg.sourcemodel.time);
+  cfg.fsample   = 1/mean(diff(cfg.sourcemodel.time{1}));  % determine from time-axis
+  cfg.trllen    = length(cfg.sourcemodel.time{1})/cfg.fsample;
+  cfg.baseline  = -cfg.sourcemodel.time{1}(1);
+elseif ~isempty(cfg.sourcemodel.time)
+  cfg.numtrl    = length(cfg.sourcemodel.time);
+  cfg.fsample   = 1/mean(diff(cfg.sourcemodel.time{1}));  % determine from time-axis
+  cfg.trllen    = length(cfg.sourcemodel.time{1})/cfg.fsample;
+  cfg.baseline  = -cfg.sourcemodel.time{1}(1);
+elseif ~isempty(cfg.sourcemodel.signal)
+  cfg.numtrl    = length(cfg.sourcemodel.signal);
   cfg.fsample   = ft_getopt(cfg, 'fsample', 1000);
-  cfg.trllen    = length(cfg.dip.signal{1})/cfg.fsample;
+  cfg.trllen    = length(cfg.sourcemodel.signal{1})/cfg.fsample;
   cfg.baseline  = ft_getopt(cfg, 'baseline', 0);
 else
   cfg.numtrl    = ft_getopt(cfg, 'numtrl', 10);
@@ -166,25 +168,25 @@ else
 end
 
 % no signal was given, set some additional defaults
-if isempty(cfg.dip.signal)
-  cfg.dip.frequency   = ft_getopt(cfg.dip, 'frequency', ones(Ndipoles,1)*10);
-  cfg.dip.phase       = ft_getopt(cfg.dip, 'phase', zeros(Ndipoles,1));
-  cfg.dip.amplitude   = ft_getopt(cfg.dip, 'amplitude', ones(Ndipoles,1));
+if isempty(cfg.sourcemodel.signal)
+  cfg.sourcemodel.frequency   = ft_getopt(cfg, 'frequency', ones(Ndipoles,1)*10);
+  cfg.sourcemodel.phase       = ft_getopt(cfg, 'phase', zeros(Ndipoles,1));
+  cfg.sourcemodel.amplitude   = ft_getopt(cfg, 'amplitude', ones(Ndipoles,1));
 end
 
-if isfield(cfg.dip, 'frequency')
+if isfield(cfg.sourcemodel, 'frequency')
   % this should be a column vector
-  cfg.dip.frequency = cfg.dip.frequency(:);
+  cfg.sourcemodel.frequency = cfg.sourcemodel.frequency(:);
 end
 
-if isfield(cfg.dip, 'phase')
+if isfield(cfg.sourcemodel, 'phase')
   % this should be a column vector
-  cfg.dip.phase = cfg.dip.phase(:);
+  cfg.sourcemodel.phase = cfg.sourcemodel.phase(:);
 end
 
-if ~isempty(cfg.dip.time)
+if ~isempty(cfg.sourcemodel.time)
   % use the user-supplied time vectors
-  diptime = cfg.dip.time;
+  diptime = cfg.sourcemodel.time;
 else
   % construct a time axis for every trial
   nsample = round(cfg.trllen*cfg.fsample);
@@ -194,21 +196,21 @@ else
   end
 end
 
-if ~isempty(cfg.dip.signal)
+if ~isempty(cfg.sourcemodel.signal)
   % use the user-supplied signal for the dipoles
-  dipsignal = cfg.dip.signal;
+  dipsignal = cfg.sourcemodel.signal;
 else
   dipsignal = cell(1, cfg.numtrl);
   for iTr = 1:cfg.numtrl
     % compute a cosine signal with the desired frequency, phase and amplitude for each dipole
     for i=1:Ndipoles
-      dipsignal{iTr}(i,:) = cos(cfg.dip.frequency(i)*diptime{iTr}*2*pi + cfg.dip.phase(i)) * cfg.dip.amplitude(i);
+      dipsignal{iTr}(i,:) = cos(cfg.sourcemodel.frequency(i)*diptime{iTr}*2*pi + cfg.sourcemodel.phase(i)) * cfg.sourcemodel.amplitude(i);
     end
   end
 end
 
-dippos = cfg.dip.pos;
-dipmom = cfg.dip.mom;
+dippos = cfg.sourcemodel.pos;
+dipmom = cfg.sourcemodel.mom;
 
 if ~iscell(dipmom)
   dipmom = {dipmom};


### PR DESCRIPTION
`ft_dipolesimulation.m` still uses `cfg.dip` instead of `cfg.sourcemodel`. The advantage of using `cfg.sourcemodel` is that all sanity checks already implemented for compatibility across inputs will roll out also for `ft_dipolesimulation`.
Suggested changes are related to that:

* change `cfg.dip` to `cfg.sourcemodel`
* `ft_checkconfig` to rename dip to sourcemodel
* add info about units in help

Additional remarks:

*  ft_dipolefitting.m also uses cfg.dip, in combination with cfg.sourcemodel. Standardise ft_dipolefitting.m as well?  Then leaving cfg.dipfit untouched
* ft_prepare_sourcemodel now has cfg.unit at top level. It should be placed under cfg.sourcemodel.unit: special request by @robertoostenveld