### PR TITLE
networkanalysis: use parfor instead of for

### DIFF
--- a/ft_networkanalysis.m
+++ b/ft_networkanalysis.m
@@ -84,6 +84,7 @@ end
 cfg = ft_checkconfig(cfg, 'required', {'method' 'parameter'});
 
 cfg.threshold = ft_getopt(cfg, 'threshold', []);
+cfg.parformaxworkers  = ft_getopt(cfg, 'parformaxworkers' , Inf);
 
 % ensure that the bct-toolbox is on the path
 ft_hastoolbox('BCT', 1);
@@ -189,12 +190,13 @@ switch cfg.method
     dimord = dimord;
 end
 
+% Prepare for parfor loop
 outsiz_4 = outsiz(4); % Make clear to parfor that the inner loop stop variable is a static value
 cfg_method = cfg.method; % Avoid sending full cfg struct to each parallel worker
 
 binarywarning = 'weights are not taken into account and graph is converted to binary values by thresholding';
 
-parfor k = 1:outsiz(3)
+parfor (k = 1:outsiz(3), cfg.parformaxworkers)
   for m = 1:outsiz_4
 
     % switch to the appropriate function from the BCT

--- a/ft_networkanalysis.m
+++ b/ft_networkanalysis.m
@@ -165,7 +165,6 @@ end
 
 fprintf('computing %s\n', cfg.method);
 % allocate memory
-needlabel = true;
 switch cfg.method
   case {'assortativity' 'charpath' 'density'  'transitivity'}
     % 1 value per connection matrix
@@ -177,7 +176,6 @@ switch cfg.method
     elseif strcmp(dimord(1:4), 'chan')
       dimord = dimord(11:end);
     end
-    needlabel = false;
   case {'betweenness' 'clustering_coef' 'degrees'}
     % 1 value per node
     outsiz = inputsize;
@@ -192,7 +190,7 @@ switch cfg.method
     % 1 value per node pair
     outsiz = inputsize;
     output = zeros(outsiz);
-    dimord = dimord;
+    % Full dimord used
 end
 
 % Prepare for parfor loop
@@ -307,7 +305,6 @@ end
 % create the output structure
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-stat              = [];
 stat = keepfields(data, {'label', 'freq', 'time', 'grad', 'elec', 'opto', 'dof', 'pos', 'tri', 'inside', 'brainordinate'});
 stat.(cfg.method) = output;
 stat.dimord       = dimord;


### PR DESCRIPTION
With some small adaptations, it is possible to use a parfor loop in
ft_networkanalysis. This potentially speeds up the calculation, when the
parallel computing toolbox is available.

Possibly, this could be further sped up by converting the nested loops into
a single parfor loop. However, this requires a good benchmark testcase to be
available, to test the difference.

Tested with https://github.com/AljenU/fieldtrip-parallel-support/tree/additional_tests, however no tests were found that take more than a few seconds on ft_networkanalysis, making it hard to actually compare performance.
Output has been tested by comparing the saved output of ft_bench_04_networkanalysis_01.