### PR TITLE
setting numerical event values to string events in the order provided as input

### DIFF
--- a/trialfun/ft_trialfun_general.m
+++ b/trialfun/ft_trialfun_general.m
@@ -194,6 +194,8 @@ else
     elseif ischar(event(i).value) && numel(event(i).value)>1 && (event(i).value(1)=='S'|| event(i).value(1)=='R')
       % on brainvision these are called 'S  1' for stimuli or 'R  1' for responses
       trlval = str2double(event(i).value(2:end));
+    elseif ischar(event(i).value) && numel(event(i).value)>1 && ~isempty(cfg.trialdef.eventvalue)
+        trlval = strmatch(event(i).value, cfg.trialdef.eventvalue);
     else
       trlval = nan;
     end


### PR DESCRIPTION
Using this data file

https://openneuro.org/crn/datasets/ds003061/files/sub-001:eeg:sub-001_task-P300_run-2_eeg.set

```matlab
cfg              = [];
cfg.dataset      = filename;
cfg.trialdef.eventtype  = 'stimulus';
cfg.trialdef.eventvalue = { 'standard' 'oddball_with_reponse' };
cfg.trialdef.prestim        = 1; % in seconds
cfg.trialdef.poststim       = 2; % in seconds
cfg = ft_definetrial(cfg);

% Baseline-correction options
cfg.demean          = 'yes';
cfg.baselinewindow  = [-0.3 0];
data = ft_preprocessing(cfg);
``` 

When I run preprocessing, I lose the data.trialinfo field because the events are not numerical - so I do not know which trials are which. Also, I want to extract trials together (standard and oddball_with_reponse) because I want to preprocess them together. With the attached modification, I can get the trialinfo field and the number (1 and 2) correspond to the other of the event values provided as input ('standard' 'oddball_with_reponse').

```
data = 

  struct with fields:

           hdr: [1×1 struct]
         label: {79×1 cell}
          time: {1×636 cell}
         trial: {1×636 cell}
       fsample: 256
    sampleinfo: [636×2 double]
     trialinfo: [636×1 double]
          elec: [1×1 struct]
           cfg: [1×1 struct]
```
