### PR TITLE
freqanalysis: use parfor instead of for

### DIFF
--- a/ft_freqanalysis.m
+++ b/ft_freqanalysis.m
@@ -584,6 +584,7 @@ for itrial = 1:ntrials
 
   fbopt.i = itrial;
   fbopt.n = ntrials;
+  fbopt.useftprogress = true;
   
   dat = data.trial{itrial}; % chansel has already been performed
   time = data.time{itrial};

--- a/ft_freqanalysis.m
+++ b/ft_freqanalysis.m
@@ -261,6 +261,7 @@ cfg.inputlock   = ft_getopt(cfg, 'inputlock',  []);  % this can be used as mutex
 cfg.outputlock  = ft_getopt(cfg, 'outputlock', []);  % this can be used as mutex when doing distributed computation
 cfg.trials      = ft_getopt(cfg, 'trials',     'all', 1);
 cfg.channel     = ft_getopt(cfg, 'channel',    'all');
+cfg.parformaxworkers = ft_getopt(cfg, 'parformaxworkers', Inf);
 
 % select channels and trials of interest, by default this will select all channels and trials
 tmpcfg = keepfields(cfg, {'trials', 'channel', 'tolerance', 'showcallinfo', 'trackcallinfo', 'trackconfig', 'trackusage', 'trackdatainfo', 'trackmeminfo', 'tracktimeinfo'});
@@ -610,7 +611,7 @@ data_time = data.time;
 
 if keeprpt==1
 
-  parfor itrial = 1:ntrials
+  parfor (itrial = 1:ntrials, cfg.parformaxworkers)
   
     fbopt = struct();
     fbopt.i = itrial;
@@ -688,7 +689,7 @@ elseif keeprpt==2
   fft_update_size = [1, fourierspctrm_size(2:end)];
   csd_update_size = [1, crsspctrm_size(2:end)];
 
-  parfor itrial = 1:ntrials
+  parfor (itrial = 1:ntrials, cfg.parformaxworkers)
   
     fbopt = struct();
     fbopt.i = itrial;

--- a/ft_freqanalysis.m
+++ b/ft_freqanalysis.m
@@ -706,9 +706,7 @@ for itrial = 1:ntrials
       % do calcdof  dof = zeros(numper,numfoi,numtoi);
       if strcmp(cfg.calcdof, 'yes')
         if hastime
-          acttimboiind = ~all(isnan(spectrum(1,:,foiind(ifoi),:)), 2); % check over all channels, some channels might contain a NaN
-          acttimboiind = reshape(acttimboiind, [1 ntoi]);
-          dof(ifoi,acttimboiind) = ntaper(ifoi) + dof(ifoi,acttimboiind);
+          dof(ifoi,acttboi) = ntaper(ifoi) + dof(ifoi,acttboi);
         else % hastime = false
           dof(ifoi) = ntaper(ifoi) + dof(ifoi);
         end

--- a/specest/ft_specest_hilbert.m
+++ b/specest/ft_specest_hilbert.m
@@ -75,6 +75,7 @@ if isempty(fbopt)
   fbopt.i = 1;
   fbopt.n = 1;
 end
+useftprogress = ft_getopt(fbopt, 'useftprogress', false);
 
 % set the default filter type
 if isempty(bpfilttype)
@@ -190,9 +191,8 @@ nfreqoi = size(filtfreq,1);
 spectrum = complex(nan(nchan, nfreqoi, ntimeboi), nan(nchan, nfreqoi, ntimeboi));
 for ifreqoi = 1:nfreqoi
   str = sprintf('frequency %d (%.2f Hz)', ifreqoi,freqoi(ifreqoi));
-  [st, cws] = dbstack;
-  if length(st)>1 && strcmp(st(2).name, 'ft_freqanalysis') && verbose
-    % specest_convol has been called by ft_freqanalysis, meaning that ft_progress has been initialised
+  if useftprogress && verbose
+    % ft_progress has been initialised
     ft_progress(fbopt.i./fbopt.n, ['trial %d, ',str,'\n'], fbopt.i);
   elseif verbose
     fprintf([str, '\n']);

--- a/specest/ft_specest_irasa.m
+++ b/specest/ft_specest_irasa.m
@@ -167,10 +167,10 @@ if isempty(fbopt)
   fbopt.i = 1;
   fbopt.n = 1;
 end
+useftprogress = ft_getopt(fbopt, 'useftprogress', false);
 str = sprintf('nfft: %d samples, datalength: %d samples, %d tapers',endnsample,ndatsample,ntaper(1));
-st  = dbstack;
-if length(st)>1 && strcmp(st(2).name, 'ft_freqanalysis')
-  % specest_mtmfft has been called by ft_freqanalysis, meaning that ft_progress has been initialised
+if useftprogress
+  % ft_progress has been initialised
   ft_progress(fbopt.i./fbopt.n, ['processing trial %d/%d ',str,'\n'], fbopt.i, fbopt.n);
 elseif verbose
   fprintf([str, '\n']);

--- a/specest/ft_specest_mtmconvol.m
+++ b/specest/ft_specest_mtmconvol.m
@@ -70,6 +70,7 @@ if isempty(fbopt)
   fbopt.i = 1;
   fbopt.n = 1;
 end
+useftprogress = ft_getopt(fbopt, 'useftprogress', false);
 
 % throw errors for required input
 if ismember(taper, {'dpss', 'sine', 'sine_old'}) && isempty(tapsmofrq)
@@ -290,9 +291,8 @@ switch dimord
     spectrum = cell(max(ntaper), nfreqoi);
     for ifreqoi = 1:nfreqoi
       str = sprintf('frequency %d (%.2f Hz), %d tapers', ifreqoi,freqoi(ifreqoi),ntaper(ifreqoi));
-      [st, cws] = dbstack;
-      if length(st)>1 && strcmp(st(2).name, 'ft_freqanalysis') && verbose
-        % specest_mtmconvol has been called by ft_freqanalysis, meaning that ft_progress has been initialised
+      if useftprogress && verbose
+        % ft_progress has been initialised
         ft_progress(fbopt.i./fbopt.n, ['trial %d, ',str,'\n'], fbopt.i);
       elseif verbose
         fprintf([str, '\n']);
@@ -333,9 +333,8 @@ switch dimord
     spectrum = complex(zeros([nchan ntimeboi sum(ntaper)]));
     for ifreqoi = 1:nfreqoi
       str = sprintf('frequency %d (%.2f Hz), %d tapers', ifreqoi,freqoi(ifreqoi),ntaper(ifreqoi));
-      [st, cws] = dbstack;
-      if length(st)>1 && strcmp(st(2).name, 'ft_freqanalysis') && verbose
-        % specest_mtmconvol has been called by ft_freqanalysis, meaning that ft_progress has been initialised
+      if useftprogress && verbose
+        % ft_progress has been initialised
         ft_progress(fbopt.i./fbopt.n, ['trial %d, ',str,'\n'], fbopt.i);
       elseif verbose
         fprintf([str, '\n']);

--- a/specest/ft_specest_mtmfft.m
+++ b/specest/ft_specest_mtmfft.m
@@ -65,6 +65,7 @@ if isempty(fbopt)
   fbopt.i = 1;
   fbopt.n = 1;
 end
+useftprogress = ft_getopt(fbopt, 'useftprogress', false);
 
 % throw errors for required input
 if isempty(tapsmofrq) && (strcmp(taper, 'dpss') || strcmp(taper, 'sine'))
@@ -259,9 +260,8 @@ end
 % compute fft
 if ~((strcmp(taper,'dpss') || strcmp(taper,'sine')) && numel(tapsmofrq)>1) % ariable number of slepian tapers not requested
   str = sprintf('nfft: %d samples, datalength: %d samples, %d tapers',endnsample,ndatsample,ntaper(1));
-  [st, cws] = dbstack;
-  if length(st)>1 && strcmp(st(2).name, 'ft_freqanalysis')
-    % specest_mtmfft has been called by ft_freqanalysis, meaning that ft_progress has been initialised
+  if useftprogress
+    % ft_progress has been initialised
     ft_progress(fbopt.i./fbopt.n, ['processing trial %d/%d ',str,'\n'], fbopt.i, fbopt.n);
   elseif verbose
     fprintf([str, '\n']);
@@ -291,9 +291,8 @@ else % variable number of slepian tapers requested
       spectrum = complex(NaN([max(ntaper) nchan nfreqoi]));
       for ifreqoi = 1:nfreqoi
         str = sprintf('nfft: %d samples, datalength: %d samples, frequency %d (%.2f Hz), %d tapers',endnsample,ndatsample,ifreqoi,freqoi(ifreqoi),ntaper(ifreqoi));
-        [st, cws] = dbstack;
-        if length(st)>1 && strcmp(st(2).name, 'ft_freqanalysis') && verbose
-          % specest_mtmconvol has been called by ft_freqanalysis, meaning that ft_progress has been initialised
+        if useftprogress && verbose
+          % ft_progress has been initialised
           ft_progress(fbopt.i./fbopt.n, ['processing trial %d, ',str,'\n'], fbopt.i);
         elseif verbose
           fprintf([str, '\n']);
@@ -324,9 +323,8 @@ else % variable number of slepian tapers requested
       spectrum = complex(zeros([nchan sum(ntaper)]));
       for ifreqoi = 1:nfreqoi
         str = sprintf('nfft: %d samples, datalength: %d samples, frequency %d (%.2f Hz), %d tapers',endnsample,ndatsample,ifreqoi,freqoi(ifreqoi),ntaper(ifreqoi));
-        [st, cws] = dbstack;
-        if length(st)>1 && strcmp(st(2).name, 'ft_freqanalysis') && verbose
-          % specest_mtmconvol has been called by ft_freqanalysis, meaning that ft_progress has been initialised
+        if useftprogress && verbose
+          % ft_progress has been initialised
           ft_progress(fbopt.i./fbopt.n, ['processing trial %d, ',str,'\n'], fbopt.i);
         elseif verbose
           fprintf([str, '\n']);

--- a/specest/ft_specest_neuvar.m
+++ b/specest/ft_specest_neuvar.m
@@ -54,6 +54,7 @@ if isempty(fbopt)
   fbopt.i = 1;
   fbopt.n = 1;
 end
+useftprogress = ft_getopt(fbopt, 'useftprogress', false);
 
 % this does not work on integer data
 dat = cast(dat, 'double');
@@ -93,9 +94,8 @@ dat = ft_preproc_derivative(dat, order);
 
 % Calculate overall power using variance
 str = sprintf('neuronal variance: %d samples, datalength: %d samples',endnsample,ndatsample);
-[st, cws] = dbstack;
-if length(st)>1 && strcmp(st(2).name, 'ft_freqanalysis')
-  % specest_mtmfft has been called by ft_freqanalysis, meaning that ft_progress has been initialised
+if useftprogress
+  % ft_progress has been initialised
   ft_progress(fbopt.i./fbopt.n, ['processing trial %d/%d ',str,'\n'], fbopt.i, fbopt.n);
 elseif verbose
   fprintf([str, '\n']);

--- a/specest/ft_specest_tfr.m
+++ b/specest/ft_specest_tfr.m
@@ -58,6 +58,7 @@ if isempty(fbopt)
   fbopt.i = 1;
   fbopt.n = 1;
 end
+useftprogress = ft_getopt(fbopt, 'useftprogress', false);
 
 % Set n's
 [nchan,ndatsample] = size(dat);
@@ -207,9 +208,8 @@ end
 spectrum = complex(nan(nchan,nfreqoi,ntimeboi),nan(nchan,nfreqoi,ntimeboi));
 for ifreqoi = 1:nfreqoi
   str = sprintf('frequency %d (%.2f Hz)', ifreqoi,freqoi(ifreqoi));
-  [st, cws] = dbstack;
-  if length(st)>1 && strcmp(st(2).name, 'ft_freqanalysis') && verbose
-    % specest_convol has been called by ft_freqanalysis, meaning that ft_progress has been initialised
+  if useftprogress && verbose
+    % ft_progress has been initialised
     ft_progress(fbopt.i./fbopt.n, ['trial %d, ',str,'\n'], fbopt.i);
   elseif verbose
     fprintf([str, '\n']);

--- a/specest/ft_specest_wavelet.m
+++ b/specest/ft_specest_wavelet.m
@@ -61,6 +61,7 @@ if isempty(fbopt)
   fbopt.i = 1;
   fbopt.n = 1;
 end
+useftprogress = ft_getopt(fbopt, 'useftprogress', false);
 
 % Set n's
 [nchan,ndatsample] = size(dat);
@@ -209,9 +210,8 @@ datspectrum = fft(ft_preproc_padding(dat, padtype, 0, postpad), [], 2);
 for ifreqoi = 1:nfreqoi
   str = sprintf('frequency %d (%.2f Hz)', ifreqoi,freqoi(ifreqoi));
   
-  [st, cws] = dbstack;
-  if length(st)>1 && strcmp(st(2).name, 'ft_freqanalysis') && verbose
-    % specest_convol has been called by ft_freqanalysis, meaning that ft_progress has been initialised
+  if useftprogress && verbose
+    % ft_progress has been initialised
     ft_progress(fbopt.i./fbopt.n, ['trial %d, ',str,'\n'], fbopt.i);
   elseif verbose
     fprintf([str, '\n']);


### PR DESCRIPTION
For this function, using parfor does appear to be useful. The timing information gathered on some testfunctions does show improvement (https://github.com/fieldtrip/fieldtrip/issues/1853#issuecomment-1220758118), and this is also confirmed by the profiling reports.

This function also shows that sometimes, quite some work is needed to enable changing a for loop to a parfor loop.

Note that for now only the keeprpt cases 1 and 2 have a parfor loop, the case 4 is still a regular for loop. This because the case 4 indexes into the output in a way that is not compatible with parfor. Refactoring that case to use parfor could also be done, but it would use a lot more temporary memory.