### PR TITLE
Fix reading neuroomega mat

### DIFF
--- a/fileio/ft_read_data.m
+++ b/fileio/ft_read_data.m
@@ -1301,6 +1301,7 @@ switch dataformat
     for i=1:hdr.nChans
       v=double(hdr.orig.orig.(hdr.label{i}));
       v=v*hdr.orig.orig.(char(strcat(hdr.label{i},'_BitResolution')));
+      v=v/hdr.orig.orig.(char(strcat(hdr.label{i},'_Gain')));
       dat(i,:)=v(begsample:endsample); %channels sometimes have small differences in samples
     end
     

--- a/fileio/ft_read_header.m
+++ b/fileio/ft_read_header.m
@@ -2079,8 +2079,8 @@ switch headerformat
       chantype={'micro'};
     end
     
-    chantype_dict={'micro','macro',     'analog', 'micro_lfp','macro_lfp','micro_hp','add_analog','emg', 'eeg';...
-      'CRAW', 'CMacro_RAW','CANALOG', 'CLFP',     'CMacro_LFP',   'CSPK' ,'CADD_ANALOG','CEMG', 'CEEG'};
+    chantype_dict={'micro','macro',     'analog', 'micro_lfp','macro_lfp','micro_hp','add_analog','emg', 'eeg', 'ecog';...
+      'CRAW', 'CMacro_RAW','CANALOG', 'CLFP',     'CMacro_LFP',   'CSPK' ,'CADD_ANALOG','CEMG', 'CEEG', 'CECOG'};
     neuroomega_param={'_KHz','_KHz_Orig','_Gain','_BitResolution','_TimeBegin','_TimeEnd'};
     
     %identifying channels to be loaded

--- a/test/test_pull2110.m
+++ b/test/test_pull2110.m
@@ -1,0 +1,10 @@
+function test_pull2110
+
+% WALLTIME 00:10:00
+% MEM 1gb
+% DEPENDENCY ft_read_data, ft_read_header
+
+filename = dccnpath('/home/common/matlab/fieldtrip/data/test/pull2110/F220916-0001.mat');
+
+hdr = ft_read_header(filename, 'headerformat', 'neuroomega_mat', 'chantype', 'ecog');
+data = ft_read_data(filename, 'header', hdr, 'dataformat', 'neuroomega_mat', 'headerformat', 'neuroomega_mat');

--- a/test/test_pull2111.m
+++ b/test/test_pull2111.m
@@ -1,4 +1,4 @@
-function test_pull2110
+function test_pull2111
 
 % WALLTIME 00:10:00
 % MEM 1gb

--- a/test/test_pull2111.m
+++ b/test/test_pull2111.m
@@ -4,7 +4,7 @@ function test_pull2111
 % MEM 1gb
 % DEPENDENCY ft_read_data, ft_read_header
 
-filename = dccnpath('/home/common/matlab/fieldtrip/data/test/pull2110/F220916-0001.mat');
+filename = dccnpath('/home/common/matlab/fieldtrip/data/test/pull2110/data_test_pull2111.mat');
 
 hdr = ft_read_header(filename, 'headerformat', 'neuroomega_mat', 'chantype', 'ecog');
 data = ft_read_data(filename, 'header', hdr, 'dataformat', 'neuroomega_mat', 'headerformat', 'neuroomega_mat');


### PR DESCRIPTION
This pull request is related to #2110 and is aimed at fixing correct conversion of rawdata to the unit 'µV'.
Additionally, support is implemented for reading ECoG data which is acquired from the manufacturers ECoG headbox.

**Edit**:
I would be happy to provide the sample data used for the test. This is empty data that contains no sensitive data.

**Changes/Additions:**
- Add chantype 'ecog' to support reading ECoG channels that start with 'CECOG'
- Add test with example data
- Data conversion to µV takes into account the '_Gain' of the amplifier