### PR TITLE
Fix: cfg.funcolorlim-dependent scaling of cloud radius

### DIFF
--- a/plotting/ft_plot_cloud.m
+++ b/plotting/ft_plot_cloud.m
@@ -317,8 +317,7 @@ end
 cmid   = size(cmapsc,1)/2;                          % colorbar middle
 colscf = 2*( (val-clim(1)) / (clim(2)-clim(1)) )-1; % color between -1 and 1, bottom vs. top colorbar
 colscf(colscf>1)=1; colscf(colscf<-1)=-1;           % clip values outside the [-1 1] range
-radscf = val-(min(abs(val)) * sign(max(val)));      % radius between 0 and 1, small vs. large pos/neg effect
-radscf = abs( radscf / max(abs(radscf)) );
+radscf = abs(colscf);                               % radius between 0 and 1, small vs. large pos/neg effect
 
 if strcmp(scalerad, 'yes')
   rmax = rmin+(radius-rmin)*radscf; % maximum radius of the clouds

--- a/plotting/ft_plot_cloud.m
+++ b/plotting/ft_plot_cloud.m
@@ -317,7 +317,10 @@ end
 cmid   = size(cmapsc,1)/2;                          % colorbar middle
 colscf = 2*( (val-clim(1)) / (clim(2)-clim(1)) )-1; % color between -1 and 1, bottom vs. top colorbar
 colscf(colscf>1)=1; colscf(colscf<-1)=-1;           % clip values outside the [-1 1] range
-radscf = abs(colscf);                               % radius between 0 and 1, small vs. large pos/neg effect
+
+radscf = (val-min(abs(val)) * sign(max(val)));      % 'vdown' representation
+radscf = radscf / abs(clim(2)-clim(1));             % radius between 0 and 1, small vs. large pos/neg effect
+radscf(radscf>1)=1; radscf(radscf<0)=0;             % clip values outside the [0 1] range
 
 if strcmp(scalerad, 'yes')
   rmax = rmin+(radius-rmin)*radscf; % maximum radius of the clouds


### PR DESCRIPTION
This PR fixes a bug in ft_plot_cloud involving the scaling of the cloud sizes. Before this fix, the radii of the clouds were determined by the range of the data, irrespective of the specifications of the cfg.funcolorlim variable. 