### PR TITLE
Attempt at fixing figure name in ft_sourceplot

### DIFF
--- a/ft_sourceplot.m
+++ b/ft_sourceplot.m
@@ -1499,12 +1499,16 @@ else
 end
 
 % set the figure window title
-if ~isempty(dataname)
-  set(gcf, 'Name', sprintf('%d: %s: %s', double(gcf), mfilename, join_str(', ', dataname)));
+if ~isempty(cfg.figurename)
+  set(gcf, 'Name', cfg.figurename);
 else
-  set(gcf, 'Name', sprintf('%d: %s', double(gcf), mfilename));
+    if ~isempty(dataname)
+      set(gcf, 'Name', sprintf('%d: %s: %s', double(gcf), mfilename, join_str(', ', dataname)));
+    else
+      set(gcf, 'Name', sprintf('%d: %s', double(gcf), mfilename));
+    end
+    set(gcf, 'NumberTitle', 'off');
 end
-set(gcf, 'NumberTitle', 'off');
 
 % do the general cleanup and bookkeeping at the end of the function
 ft_postamble debug


### PR DESCRIPTION
As mentioned in #2166 `cfg.figurename` in `ft_sourceplot` gets ignored as it gets set regardless of the presence of this field. 
This fixes it - but might be a bit sloppy as `cfg.figurename` does get passed to `open_figure` in the code above my fix - was not sure if it should rather get fixed there? 

CC @robertoostenveld 