### PR TITLE
allow montage to be applied to data with nans, without the nans spreading

### DIFF
--- a/forward/ft_apply_montage.m
+++ b/forward/ft_apply_montage.m
@@ -40,7 +40,6 @@ function [input] = ft_apply_montage(input, montage, varargin)
 %   'balancename'   = string, name of the montage (default = '')
 %   'feedback'      = string, see FT_PROGRESS (default = 'text')
 %   'warning'       = boolean, whether to show warnings (default = true)
-%   'showcallinfo'  = string, 'yes' or 'no' (default = 'no')
 %
 % If the first input is a montage, then the second input montage will be
 % applied to the first. In effect, the output montage will first do
@@ -48,7 +47,7 @@ function [input] = ft_apply_montage(input, montage, varargin)
 %
 % See also FT_READ_SENS, FT_DATATYPE_SENS
 
-% Copyright (C) 2008-2016, Robert Oostenveld
+% Copyright (C) 2008-2023, Robert Oostenveld
 %
 % This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
 % for the documentation and details.
@@ -68,7 +67,7 @@ function [input] = ft_apply_montage(input, montage, varargin)
 %
 % $Id$
 
-if iscell(input) && iscell(input)
+if iscell(input)
   % this represents combined EEG, ECoG and/or MEG
   for i=1:numel(input)
     input{i} = ft_apply_montage(input{i}, montage, varargin{:});
@@ -86,17 +85,16 @@ inverse       = ft_getopt(varargin, 'inverse',     'no');
 feedback      = ft_getopt(varargin, 'feedback',    'text');
 showwarning   = ft_getopt(varargin, 'warning',     true);
 bname         = ft_getopt(varargin, 'balancename', '');
-showcallinfo  = ft_getopt(varargin, 'showcallinfo', 'no');
-
-% ensure that the input montage is correct, see https://github.com/fieldtrip/fieldtrip/issues/1718
-assert(length(unique(montage.labelold))==length(montage.labelold), 'the montage is invalid');
-assert(length(unique(montage.labelnew))==length(montage.labelnew), 'the montage is invalid');
 
 if istrue(showwarning)
   warningfun = @warning;
 else
   warningfun = @nowarning;
 end
+
+% ensure that the input montage is correct, see https://github.com/fieldtrip/fieldtrip/issues/1718
+assert(length(unique(montage.labelold))==length(montage.labelold), 'the montage is invalid');
+assert(length(unique(montage.labelnew))==length(montage.labelnew), 'the montage is invalid');
 
 % these are optional, at the end we will clean up the output in case they did not exist
 if ~istrue(inverse)
@@ -204,15 +202,14 @@ if ~isfield(input, 'tra') && isfield(input, 'label')
 end
 
 if istrue(inverse)
-  % swap the role of the original and new channels
+  % swap the role of the old and new channels
   tmp.labelnew    = montage.labelold;
   tmp.labelold    = montage.labelnew;
   tmp.chantypenew = montage.chantypeold;
   tmp.chantypeold = montage.chantypenew;
   tmp.chanunitnew = montage.chanunitold;
   tmp.chanunitold = montage.chanunitnew;
-  % apply the inverse montage, this can be used to undo a previously
-  % applied montage
+  % apply the inverse montage, this can be used to undo a previously applied montage
   tmp.tra = full(montage.tra);
   if rank(tmp.tra) < length(tmp.tra)
     warningfun('the linear projection for the montage is not full-rank, the resulting data will have reduced dimensionality');
@@ -223,7 +220,7 @@ if istrue(inverse)
   montage = tmp;
 end
 
-% select and keep the columns that are non-empty, i.e. remove the empty columns
+% keep only the columns that are not empty
 selcol = ~all(montage.tra==0, 1);
 if istrue(keepunused)
   for i=find(selcol==false)
@@ -237,7 +234,7 @@ montage.chantypeold = montage.chantypeold(selcol);
 montage.chanunitold = montage.chanunitold(selcol);
 clear selcol
 
-% select and remove the columns corresponding to channels that are not present in the original data
+% keep only the channels that are present in the input data
 remove = setdiff(montage.labelold, intersect(montage.labelold, inputlabel));
 selcol = match_str(montage.labelold, remove);
 % we cannot just remove the colums, all rows that depend on it should also be removed
@@ -257,8 +254,7 @@ montage.chanunitnew = montage.chanunitnew(~selrow);
 montage.tra         = montage.tra(~selrow, ~selcol);
 clear remove selcol selrow
 
-% add columns for channels that are present in the input data but not specified in
-% the montage, stick to the original order in the data
+% add columns for channels present in the input data but that are not specified in the montage, stick to the original order in the data
 [dum, ix]   = setdiff(inputlabel, montage.labelold);
 addlabel    = inputlabel(sort(ix));
 addchantype = inputchantype(sort(ix));
@@ -266,23 +262,24 @@ addchanunit = inputchanunit(sort(ix));
 m = size(montage.tra,1);
 n = size(montage.tra,2);
 k = length(addlabel);
-% check for NaNs in unused channels; these will be mixed in with the rest
-% of the channels and result in NaNs in the output even when multiplied
-% with zeros or identity
-if k > 0 && isfield(input, 'trial') % check for raw data now only
-  cfg = [];
-  cfg.channel = addlabel;
-  cfg.showcallinfo = showcallinfo;
-  data_unused = ft_selectdata(cfg, input);
-  % use an anonymous function to test for the presence of NaNs in the input data
-  hasnan = @(x) any(isnan(x(:)));
-  if any(cellfun(hasnan, data_unused.trial))
-    ft_error('FieldTrip:NaNsinInputData', ['Your input data contains NaNs in channels that are unused '...
-      'in the supplied montage. This would result in undesired NaNs in the '...
-      'output data. Please remove these channels from the input data (using '...
-      'ft_selectdata) before attempting to apply the montage.']);
-  end
-end
+
+% % check for NaNs in unused channels; these will be mixed in with the rest
+% % of the channels and result in NaNs in the output even when multiplied
+% % with zeros or identity
+% if k > 0 && isfield(input, 'trial') % check for raw data now only
+%   cfg = [];
+%   cfg.channel = addlabel;
+%   cfg.showcallinfo = showcallinfo;
+%   data_unused = ft_selectdata(cfg, input);
+%   % use an anonymous function to test for the presence of NaNs in the input data
+%   hasnan = @(x) any(isnan(x(:)));
+%   if any(cellfun(hasnan, data_unused.trial))
+%     ft_error('FieldTrip:NaNsinInputData', ['Your input data contains NaNs in channels that are unused '...
+%       'in the supplied montage. This would result in undesired NaNs in the '...
+%       'output data. Please remove these channels from the input data (using '...
+%       'ft_selectdata) before attempting to apply the montage.']);
+%   end
+% end
 
 if istrue(keepunused)
   % add the channels that are not rereferenced to the input and output of the montage
@@ -327,10 +324,8 @@ montage.chanunitold    = montage.chanunitold(selmontage);
 % ensure that the montage is double precision
 montage.tra = double(montage.tra);
 
-% making the tra matrix sparse will speed up subsequent multiplications, but should
-% not result in a sparse matrix
-% note that this only makes sense for matrices with a lot of zero elements, for dense
-% matrices keeping it full will be much quicker
+% making the tra matrix sparse will speed up subsequent multiplications, but should not result in sparse output data
+% this only makes sense for matrices with a lot of zero elements; for dense matrices it is faster to keep it full
 if size(montage.tra,1)>1 && nnz(montage.tra)/numel(montage.tra) < 0.3
   montage.tra = sparse(montage.tra);
 else
@@ -366,7 +361,7 @@ elseif ft_datatype(input, 'freq') && isfield(input, 'fourierspctrm')
   inputtype = 'freq';
 elseif ft_datatype(input, 'freq') && isfield(input, 'crsspctrm')
   inputtype = 'freq_crsspctrm';
-  
+
   % attempt to convert to a chan-chan representation
   input     = ft_checkdata(input, 'cmbstyle', 'full');
 else
@@ -391,7 +386,7 @@ switch inputtype
     sens = input;
     clear input
 
-    % apply the montage to the inputor array
+    % apply the montage to the input
     if isa(sens.tra, 'single')
       % sparse matrices and single precision do not match
       sens.tra = full(montage.tra) * sens.tra;
@@ -400,7 +395,7 @@ switch inputtype
     end
 
     % The montage operates on the coil weights in sens.tra, but the output channels can be different.
-    % If possible, we want to keep the original channel positions and orientations.
+    % If possible, we want to keep the old channel positions and orientations.
     [sel1, sel2] = match_str(montage.labelnew, inputlabel);
     keepchans = isequal(sel1(:)', 1:numel(montage.labelnew));
 
@@ -419,7 +414,7 @@ switch inputtype
           sens.chantypeold = inputchantype;
           sens.chanunitold = inputchanunit;
         end
-        % compute the channel positions as a weighted sum of the original ones
+        % compute the new channel positions as a weighted sum of the old ones
         sens.chanpos = posweight * sens.chanpos;
       end
     end
@@ -431,7 +426,7 @@ switch inputtype
         if ~isfield(sens, 'chanoriold')
           sens.chanoriold = sens.chanori;
         end
-        % compute the channel orientations as a weighted sum of the original ones
+        % compute the new channel orientations as a weighted sum of the old ones
         sens.chanori = posweight * sens.chanori;
       end
     end
@@ -456,15 +451,13 @@ switch inputtype
 
     elseif ~istrue(inverse) && ~isempty(bname)
       if isfield(sens, 'balance')
-        % check whether a balancing montage with name bname already exist,
-        % and if so, how many
+        % check whether a balancing montage with name bname already exist, and if so, how many
         mnt = fieldnames(sens.balance);
         sel = strmatch(bname, mnt);
         if numel(sel)==0
           % bname can stay the same
         elseif numel(sel)==1
-          % the original should be renamed to 'bname1' and the new one should
-          % be 'bname2'
+          % the original should be renamed to 'bname1' and the new one should be 'bname2'
           sens.balance.([bname, '1']) = sens.balance.(bname);
           sens.balance                = rmfield(sens.balance, bname);
           if isfield(sens.balance, 'current') && strcmp(sens.balance.current, bname)
@@ -497,22 +490,44 @@ switch inputtype
     clear sens
 
   case 'raw'
-    % apply the montage to the raw data that was preprocessed using FieldTrip
+    % apply the montage to the raw input data
     data = input;
     clear input
+
+    % there are two challenges to deal with
+    % 1) the input data can be single, and sparse(1) * single(0) fails
+    % 2) the input data can contain nans, and 0*nan returns a nan
+    % see http://bugzilla.fieldtriptoolbox.org/show_bug.cgi?id=3035 and https://github.com/fieldtrip/fieldtrip/issues/2169
 
     Ntrials = numel(data.trial);
     ft_progress('init', feedback, 'processing trials');
     for i=1:Ntrials
       ft_progress(i/Ntrials, 'processing trial %d from %d\n', i, Ntrials);
-      if isa(data.trial{i}, 'single')
-        % sparse matrices and single
-        % precision do not match
-        data.trial{i} = full(montage.tra) * data.trial{i};
-      else
+
+      if     ~isa(data.trial{i}, 'single') && ~any(isnan(data.trial{i}(:)))
         data.trial{i} = montage.tra * data.trial{i};
+      elseif ~isa(data.trial{i}, 'single') &&  any(isnan(data.trial{i}(:)))
+        % do not multiply 0 in the montage with nan in the data
+        tmp = zeros(size(montage.tra,1), size(data.trial{i}, 2));
+        for j=1:size(montage.tra,1)
+          sel = montage.tra(j,:)~=0;
+          tmp(j,:) = montage.tra(j,sel) * data.trial{i}(sel,:);
+        end
+        data.trial{i} = tmp;
+      elseif  isa(data.trial{i}, 'single') && ~any(isnan(data.trial{i}(:)))
+        % sparse matrices and single precision do not match
+        data.trial{i} = full(montage.tra) * data.trial{i};
+      elseif  isa(data.trial{i}, 'single') &&  any(isnan(data.trial{i}(:)))
+        % sparse matrices and single precision do not match
+        % do not multiply 0 in the montage with nan in the data, see http://bugzilla.fieldtriptoolbox.org/show_bug.cgi?id=3035
+        tmp = zeros(size(montage.tra,1), size(data.trial{i}, 2));
+        for j=1:size(montage.tra,1)
+          sel = montage.tra(j,:)~=0;
+          tmp(j,:) = full(montage.tra(j,sel)) * data.trial{i}(sel,:);
+        end
+        data.trial{i} = tmp;
       end
-    end
+    end % for Ntrials
     ft_progress('close');
 
     data.label    = montage.labelnew;
@@ -614,7 +629,7 @@ switch inputtype
   case 'freq_crsspctrm'
     % input freq data has a chan-chan crsspctrm, montage needs te be
     % applied to both ends
-    
+
     freq = input;
     clear input
     if contains(getdimord(freq, 'crsspctrm'), 'rpt')
@@ -640,7 +655,7 @@ switch inputtype
       end
       freq.crsspctrm = output;
     end
-    
+
     freq.label    = montage.labelnew;
     freq.chantype = montage.chantypenew;
     freq.chanunit = montage.chanunitnew;

--- a/test/test_bug3035.m
+++ b/test/test_bug3035.m
@@ -38,40 +38,26 @@ end
 
 cfg = [];
 cfg.component = 1;
+data_reject1 = ft_rejectcomponent(cfg, comp, data);
 
-ok = false;
-try
-  data_reject1 = ft_rejectcomponent(cfg, comp, data);
-catch err
-  if strcmp(err.identifier, 'FieldTrip:NaNsinInputData')
-    ok = true;
-  end
-end
-
-if ~ok
-  error('ft_rejectcomponent did not throw the expected error');
-end
-
-% check
-if exist('data_reject1', 'var')
-  tmp = cat(1, data_reject1.trial{:});
-  if any(isnan(tmp(:)))
-    errfun('cleaned data contains nans');
-  end
+% the nans should not spread beyond the eye channels
+tmp = data_reject1.trial{1}(1:42,:);
+if any(isnan(tmp(:)))
+  errfun('cleaned data contains nans')
 end
 
 %% rejectcomponent with 3rd input argument after zeroing nans
 
 % NOTE: the original bug did not occur here
 
-dat2 = data;
-for k = 1:numel(dat2.trial)
-  dat2.trial{k}(isnan(dat2.trial{k})) = 0;
+data1b = data;
+for k = 1:numel(data1b.trial)
+  data1b.trial{k}(isnan(data1b.trial{k})) = 0;
 end
 
 cfg = [];
 cfg.component = 1;
-data_reject1b = ft_rejectcomponent(cfg, comp, dat2);
+data_reject1b = ft_rejectcomponent(cfg, comp, data1b);
 
 % check
 tmp = cat(1, data_reject1b.trial{:});

--- a/test/test_issue2169.m
+++ b/test/test_issue2169.m
@@ -1,0 +1,114 @@
+function test_issue2169
+
+% WALLTIME 00:10:00
+% MEM 2gb
+% DEPENDENCY ft_apply_montage
+
+%%
+
+data0 = {};
+data0.label = {
+  '1'
+  '2'
+  '3'
+  '4'
+  '5'
+  '6'
+  '7'
+  '8'
+  '9'
+  };
+data0.trial{1} = [
+  1 1 1 1 1 1 1 1 1 1
+  2 2 2 2 2 2 2 2 2 2
+  3 3 3 3 3 3 3 3 3 3
+  4 4 4 4 4 4 4 4 4 4
+  5 5 5 5 5 5 5 5 5 5
+  6 6 6 6 6 6 6 6 6 6
+  7 7 7 7 7 7 7 7 7 7
+  8 8 8 8 8 8 8 8 8 8
+  9 9 9 9 9 9 9 9 9 9 
+  ];
+data0.time{1} = 1:10;
+
+data1 = data0;
+data1.trial{1}(1,10) = nan;
+
+data2 = data0;
+data2.trial{1}(2,10) = nan;
+
+data3 = data0;
+data3.trial{1}(3,10) = nan;
+
+%%
+
+cfg = [];
+cfg.montage.labelold = {'1', '2', '3'};
+cfg.montage.labelnew = {'1', '2', '1-2'};
+cfg.montage.tra = [
+  1  0 0
+  0  1 0
+  1 -1 0
+  ];
+reref0 = ft_preprocessing(cfg, data0);
+reref1 = ft_preprocessing(cfg, data1);
+reref2 = ft_preprocessing(cfg, data2);
+reref3 = ft_preprocessing(cfg, data3);
+
+% check that the nans don't spread
+
+assert(~isnan(reref0.trial{1}(1,10)))
+assert(~isnan(reref0.trial{1}(2,10)))
+assert(~isnan(reref0.trial{1}(3,10)))
+
+assert( isnan(reref1.trial{1}(1,10)))
+assert(~isnan(reref1.trial{1}(2,10)))
+assert( isnan(reref1.trial{1}(3,10)))
+
+assert(~isnan(reref2.trial{1}(1,10)))
+assert( isnan(reref2.trial{1}(2,10)))
+assert( isnan(reref2.trial{1}(3,10)))
+
+assert(~isnan(reref3.trial{1}(1,10)))
+assert(~isnan(reref3.trial{1}(2,10)))
+assert(~isnan(reref3.trial{1}(3,10)))
+
+%%
+% repeat the same thing as above, but now for single precision data
+
+data0.trial{1} = single(data0.trial{1});
+data1.trial{1} = single(data1.trial{1});
+data2.trial{1} = single(data2.trial{1});
+data3.trial{1} = single(data3.trial{1});
+
+cfg = [];
+cfg.montage.labelold = {'1', '2', '3'};
+cfg.montage.labelnew = {'1', '2', '1-2'};
+cfg.montage.tra = [
+  1  0 0
+  0  1 0
+  1 -1 0
+  ];
+reref0 = ft_preprocessing(cfg, data0);
+reref1 = ft_preprocessing(cfg, data1);
+reref2 = ft_preprocessing(cfg, data2);
+reref3 = ft_preprocessing(cfg, data3);
+
+% check that the nans don't spread
+
+assert(~isnan(reref0.trial{1}(1,10)))
+assert(~isnan(reref0.trial{1}(2,10)))
+assert(~isnan(reref0.trial{1}(3,10)))
+
+assert( isnan(reref1.trial{1}(1,10)))
+assert(~isnan(reref1.trial{1}(2,10)))
+assert( isnan(reref1.trial{1}(3,10)))
+
+assert(~isnan(reref2.trial{1}(1,10)))
+assert( isnan(reref2.trial{1}(2,10)))
+assert( isnan(reref2.trial{1}(3,10)))
+
+assert(~isnan(reref3.trial{1}(1,10)))
+assert(~isnan(reref3.trial{1}(2,10)))
+assert(~isnan(reref3.trial{1}(3,10)))
+


### PR DESCRIPTION
This fixes #2169

- new test script added
- existing test script updated

This deals with raw data only, as the old solution for http://bugzilla.fieldtriptoolbox.org/show_bug.cgi?id=3035 was also only specific for raw data. Any other input to `ft_apply_montage` will still suffer from the nans spreading. 