### PR TITLE
Small bug fix for opm_fil subfunction

### DIFF
--- a/fileio/private/opm_fil.m
+++ b/fileio/private/opm_fil.m
@@ -116,7 +116,7 @@ if needhdr
     hdr.grad.label = positions.name;
     hdr.grad.coilpos = [positions.Px positions.Py positions.Pz];
     hdr.grad.coilori = [positions.Ox positions.Oy positions.Oz];
-    hdr.grad.type = 'megmag';
+    hdr.grad.type = 'meg';
     hdr.grad.tra  = diag(ones(1,length(positions.name)));
     if ~isempty(coordsys)
       hdr.grad.unit = coordsys.MEGCoordinateUnits;

--- a/fileio/private/opm_fil.m
+++ b/fileio/private/opm_fil.m
@@ -40,11 +40,17 @@ needdat = (nargin==5);
 [p, f, x] = fileparts(filename);
 assert(isfile(filename), sprintf('file "%s" not found', filename));
 
-channelsfile  = fullfile(p, 'channels.tsv');
-coordsysfile  = fullfile(p, 'coordsystem.json');
-datafile      = fullfile(p, 'meg.bin');
-headerfile    = fullfile(p, 'meg.json');
-positionsfile = fullfile(p, 'positions.tsv');
+% Remove the _meg part of the filename
+if strcmp(f(end-3:end),'_meg')
+    f = f(1:end-4);
+end
+
+% Get the BIDS compliant files
+channelsfile  = fullfile(p,[f '_channels.tsv']);
+coordsysfile  = fullfile(p,[f '_coordsystem.json']);
+datafile      = fullfile(p,[f '_meg.bin']);
+headerfile    = fullfile(p,[f '_meg.json']);
+positionsfile = fullfile(p,[f '_positions.tsv']);
 
 precision = 'double';
 switch precision
@@ -57,10 +63,13 @@ end
 
 if needhdr
   %% read the header
-  
-  fid = fopen(headerfile, 'rt');
-  header = jsondecode(fread(fid, [1 inf], 'char=>char'));
-  fclose(fid);
+  try
+      fid = fopen(headerfile, 'rt');
+      header = jsondecode(fread(fid, [1 inf], 'char=>char'));
+      fclose(fid);
+  catch
+      ft_warning('Cannot open header');
+  end
   
   channels  = readtable(channelsfile, 'Delimiter', 'tab', 'FileType', 'text');
   

--- a/fileio/private/opm_fil.m
+++ b/fileio/private/opm_fil.m
@@ -52,7 +52,8 @@ datafile      = fullfile(p,[f '_meg.bin']);
 headerfile    = fullfile(p,[f '_meg.json']);
 positionsfile = fullfile(p,[f '_positions.tsv']);
 
-precision = 'double';
+precision = 'single';
+
 switch precision
   case 'single'
     samplesize = 4;
@@ -93,12 +94,16 @@ if needhdr
   
   hdr.label       = channels.name;
   hdr.nChans      = size(channels, 1);
-  hdr.nSamples    = d.bytes/(size(channels, 1) * samplesize);
+  hdr.nSamples    = (d.bytes/(size(channels, 1) * samplesize))-1;
   hdr.nSamplesPre = 0; % continuous data
   hdr.nTrials     = 1; % continuous data
   hdr.Fs          = header.SamplingFrequency;
   hdr.chantype    = channels.type;
-  hdr.chanunit    = repmat({'unknown'}, size(hdr.label));
+  try
+      hdr.chanunit    = channels.unit;
+  catch
+      hdr.chanunit    = repmat({'unknown'}, size(hdr.label));
+  end
   
   % keep the original header details
   hdr.orig.header     = header;
@@ -111,7 +116,8 @@ if needhdr
     hdr.grad.label = positions.name;
     hdr.grad.coilpos = [positions.Px positions.Py positions.Pz];
     hdr.grad.coilori = [positions.Ox positions.Oy positions.Oz];
-    hdr.grad.type = 'meg';
+    hdr.grad.type = 'megmag';
+    hdr.grad.tra  = diag(ones(1,length(positions.name)));
     if ~isempty(coordsys)
       hdr.grad.unit = coordsys.MEGCoordinateUnits;
       hdr.grad.coordsys = coordsys.MEGCoordinateSystem;
@@ -123,7 +129,6 @@ if needhdr
   
 elseif needdat
   %% read the data, note that it is big endian
-  
   fid = fopen(datafile, 'rb');
   fseek(fid, begsample*samplesize*hdr.nChans, 'bof');
   dat = fread(fid,[hdr.nChans, (endsample-begsample+1)], precision, 0, 'b');


### PR DESCRIPTION
Part of #2130

This fixes an error when reading the header - json files are not stored as meg.json, but have a prefix that is the same as the .bin file (e.g. sub-001Y_ses-001_task-encoding_control_run-001_meg.json)