### PR TITLE
Fix try/catch syntax for older MATLAB versions

### DIFF
--- a/fileio/private/read_yorkinstruments_hdf5_meta.m
+++ b/fileio/private/read_yorkinstruments_hdf5_meta.m
@@ -57,8 +57,10 @@ info.ChNames= h5read(datafile,[strcat('/acquisitions/',num2str(acq_run)) '/chann
 [info.NChannels, null]=size(info.ChNames);
 Data = h5read(datafile,[strcat('/acquisitions/',num2str(acq_run)) '/data/']);
 [null, info.NSamples]=size(Data);
-try [null, info.NTrials] = size(h5read(datafile,[strcat('/acquisitions/',num2str(acq_run)) '/epochs/trigger_codes']));
-catch info.NTrials=1;
+try
+  [null, info.NTrials] = size(h5read(datafile,[strcat('/acquisitions/',num2str(acq_run)) '/epochs/trigger_codes']));
+catch
+  info.NTrials=1;
 end
 
 info.ChUnit = strings(info.NChannels,1);
@@ -71,7 +73,8 @@ for i = 1:info.NChannels
   end
   
   info.ChType(i)=h5readatt(datafile, char(strcat('/config/channels/',info.ChNames(i) )) ,'chan_type');
-  try info.ChType(i)=h5readatt(datafile, char(strcat('/config/channels/',info.ChNames(i) )) ,'mode');
+  try
+    info.ChType(i)=h5readatt(datafile, char(strcat('/config/channels/',info.ChNames(i) )) ,'mode');
   catch
     continue
   end


### PR DESCRIPTION
With MATLAB < R2017a, the line:
https://github.com/fieldtrip/fieldtrip/blob/4792c437305b1013d7204ce64e5121af09d2f67f/fileio/private/read_yorkinstruments_hdf5_meta.m#L61
fails to parse with the MATLAB Compiler:
```
MATLAB code
'fieldtrip/fileio/private/read_yorkinstruments_hdf5_meta.m'
contains the following syntax error(s):
L 61 (C 11): SYNER: Parse error at '.': usage might be invalid MATLAB syntax.
```