### PR TITLE
FIX #2168 - add check for correct meshes, fix CSF conductivity

### DIFF
--- a/forward/ft_headmodel_bemcp.m
+++ b/forward/ft_headmodel_bemcp.m
@@ -19,7 +19,7 @@ function headmodel = ft_headmodel_bemcp(mesh, varargin)
 %
 % See also FT_PREPARE_VOL_SENS, FT_COMPUTE_LEADFIELD
 
-% Copyright (C) 2010, Robert Oostenveld
+% Copyright (C) 2010, Robert Oostenveld, Donders Centre for Cognitive Neuroimaging, Nijmegen, NL
 %
 % This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
 % for the documentation and details.

--- a/forward/ft_headmodel_bemcp.m
+++ b/forward/ft_headmodel_bemcp.m
@@ -12,9 +12,14 @@ function headmodel = ft_headmodel_bemcp(mesh, varargin)
 % Use as
 %   headmodel = ft_headmodel_bemcp(mesh, ...)
 %
+% Optional input arguments should be specified in key-value pairs and can
+% include
+%   conductivity     = vector, conductivity of each compartment
+%   checkmesh        = 'yes' or 'no'
+%
 % See also FT_PREPARE_VOL_SENS, FT_COMPUTE_LEADFIELD
 
-% Copyright (C) 2012, Donders Centre for Cognitive Neuroimaging, Nijmegen, NL
+% Copyright (C) 2010, Robert Oostenveld
 %
 % This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
 % for the documentation and details.
@@ -38,6 +43,10 @@ ft_hastoolbox('bemcp', 1);
 
 % get the optional input arguments
 conductivity    = ft_getopt(varargin, 'conductivity');
+checkmesh       = ft_getopt(varargin, 'checkmesh', 'yes');
+
+% convert to Boolean value
+checkmesh = istrue(checkmesh);
 
 if isfield(mesh, 'bnd')
   mesh = mesh.bnd;
@@ -46,57 +55,96 @@ end
 % replace pnt with pos
 mesh = fixpos(mesh);
 
+% determine the number of compartments
+numboundaries = length(mesh);
+
+% bemcp expects surface normals to point outwards;
+% this checks and corrects if needed
+for i=1:numboundaries
+  switch surface_orientation(mesh(i))
+    case 'outward'
+      % this is ok
+    case 'inward'
+      ft_warning('flipping mesh %d', i);
+      mesh(i).tri = fliplr(mesh(i).tri);
+    case 'otherwise'
+      ft_error('incorrect mesh %d', i)
+  end
+end
+
 % ensure that the vertices and triangles are double precision, otherwise the bemcp mex files will crash
-for i=1:length(mesh)
+for i=1:numboundaries
   mesh(i).pos = double(mesh(i).pos);
   mesh(i).tri = double(mesh(i).tri);
 end
 
 % start with an empty volume conductor
 headmodel = [];
-headmodel.bnd = mesh;
 
 % determine the number of compartments
-numboundaries = length(headmodel.bnd);
+numboundaries = length(mesh);
 
 if numboundaries~=3
   ft_error('this only works for three surfaces');
 end
 
 % determine the desired nesting of the compartments
-order = surface_nesting(headmodel.bnd, 'insidefirst');
+order = surface_nesting(mesh, 'insidefirst');
 
 % rearrange boundaries and conductivities
-if numel(headmodel.bnd)>1 && ~isequal(order(:)', 1:numel(headmodel.bnd))
+if numboundaries>1 && ~isequal(order(:)', 1:numboundaries)
   fprintf('reordering the boundaries to: ');
   fprintf('%d ', order);
   fprintf('\n');
   % update the order of the compartments
-  headmodel.bnd    = headmodel.bnd(order);
+  mesh = mesh(order);
 end
 
 if isempty(conductivity)
-  ft_warning('No conductivity is declared, assuming standard values')
+  ft_warning('no conductivity specified, using default values')
   % brain/skull/skin
-  conductivity = [1 1/80 1] * 0.33;
+  conductivity = [0.33 0.0042 0.33];
   headmodel.cond = conductivity;
 else
   if numel(conductivity)~=numboundaries
-    ft_error('a conductivity value should be specified for each compartment');
+    ft_error('each compartment should have a conductivity value');
   end
   headmodel.cond = conductivity(order);
 end
 
-headmodel.skin_surface   = numboundaries;
-headmodel.source = 1;  
+% do some sanity checks on the meshes
+if checkmesh
+  for i=1:numboundaries
+    ntri = size(mesh(i).tri,1);
+    npos = size(mesh(i).pos,1);
+    assert(2*(npos-2)==ntri, 'the number of triangles does not match the number of vertices')
+  end
 
-% do some sanity checks
+  % check for each of the vertices that it falls inside the next surface
+  for i=1:(numboundaries-1)
+    for j=1:size(mesh(i).pos,1)
+      inside = bounding_mesh(mesh(i).pos(j,:), mesh(i+1).pos, mesh(i+1).tri);
+      assert(inside, 'vertex %d of surface %d is outside surface %d', j, i, i+1);
+    end
+  end
+
+  ft_info('the meshes are closed and properly nested')
+end % if checkmesh
+
+headmodel.bnd          = mesh;
+headmodel.skin_surface = numboundaries;
+headmodel.source       = 1;
+
 if headmodel.skin_surface~=3
   ft_error('the third surface should be the skin');
 end
-% if headmodel.source~=1
-%   ft_error('the first surface should be the inside of the skull');
-% end
+
+if headmodel.source~=1
+  ft_error('the first surface should the source compartment');
+end
+
+% just to be sure
+clear mesh
 
 % Build Triangle 4th point
 headmodel = triangle4pt(headmodel);

--- a/forward/ft_headmodel_concentricspheres.m
+++ b/forward/ft_headmodel_concentricspheres.m
@@ -56,7 +56,7 @@ if any(strcmp(varargin(1:2:end), 'unit')) || any(strcmp(varargin(1:2:end), 'unit
 end
 
 if isnumeric(mesh) && size(mesh,2)==3
-  % assume that it is a Nx3 array with vertices
+  % assume that it is a Nx3 array with vertices such as a head surface
   % convert it to a structure, this is needed to determine the units further down
   mesh = struct('pos', mesh);
 elseif isstruct(mesh) && isfield(mesh, 'bnd')
@@ -84,11 +84,11 @@ if isempty(conductivity)
   defaultconductivity = true;
   switch length(mesh)
     case 1
-      conductivity = 1;                        % brain
+      conductivity = 1;                             % uniform
     case 3
-      conductivity = [0.3300   0.0042 0.3300]; % brain, skull, scalp
+      conductivity = [0.3300        0.0042 0.3300]; % brain, skull, scalp
     case 4
-      conductivity = [0.3300 1 0.0042 0.3300]; % brain, csf, skull, scalp
+      conductivity = [0.3300 1.7900 0.0042 0.3300]; % brain, csf, skull, scalp
     otherwise
       ft_error('conductivity values should be specified for each tissue type');
   end
@@ -118,7 +118,7 @@ npos = size(pos, 1);
 
 % fit a single sphere to all combined headshape points, this is used for the center of the spheres
 [single_o, single_r] = fitsphere(pos);
-fprintf('initial sphere: number of unique surface points = %d\n', npos);
+fprintf('initial sphere: total number of unique surface points = %d\n', npos);
 fprintf('initial sphere: center = [%.1f %.1f %.1f]\n', single_o(1), single_o(2), single_o(3));
 fprintf('initial sphere: radius = %.1f\n', single_r);
 
@@ -139,12 +139,12 @@ if any(diff(indx)<1)
   ft_warning('reordering spheres from smallest to largest')
 end
 % order the spheres from the smallest to the largest ('insidefirst' order)
-headmodel.r    = headmodel.r(indx);
+headmodel.r = headmodel.r(indx);
 if ~defaultconductivity
-  % assume that the specified conductivities are in the same order as the meshes
+  % assume that the user-specified conductivities are in the same order as the meshes
   headmodel.cond = headmodel.cond(indx);
 else
-  % the conductivities are already ordered 'insidefirst'
+  % the default conductivities are already ordered 'insidefirst'
 end
 
 for i=1:numel(mesh)

--- a/forward/ft_headmodel_dipoli.m
+++ b/forward/ft_headmodel_dipoli.m
@@ -25,8 +25,29 @@ function headmodel = ft_headmodel_dipoli(mesh, varargin)
 %   conductivity     = vector, conductivity of each compartment
 %   tempdir          = string, allows you to specify the path for the tempory files (default is automatic)
 %   tempname         = string, allows you to specify the full tempory name including path (default is automatic)
+%   checkmesh        = 'yes' or 'no'
 %
 % See also FT_PREPARE_VOL_SENS, FT_COMPUTE_LEADFIELD
+
+% Copyright (C) 2012, Donders Centre for Cognitive Neuroimaging, Nijmegen, NL
+%
+% This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
+% for the documentation and details.
+%
+%    FieldTrip is free software: you can redistribute it and/or modify
+%    it under the terms of the GNU General Public License as published by
+%    the Free Software Foundation, either version 3 of the License, or
+%    (at your option) any later version.
+%
+%    FieldTrip is distributed in the hope that it will be useful,
+%    but WITHOUT ANY WARRANTY; without even the implied warranty of
+%    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%    GNU General Public License for more details.
+%
+%    You should have received a copy of the GNU General Public License
+%    along with FieldTrip. If not, see <http://www.gnu.org/licenses/>.
+%
+% $Id$
 
 ft_hastoolbox('dipoli', 1);
 
@@ -35,6 +56,10 @@ isolatedsource  = ft_getopt(varargin, 'isolatedsource');
 conductivity    = ft_getopt(varargin, 'conductivity');
 tdir            = ft_getopt(varargin, 'tempdir');
 tname           = ft_getopt(varargin, 'tempname');
+checkmesh       = ft_getopt(varargin, 'checkmesh', 'yes');
+
+% convert to Boolean value
+checkmesh = istrue(checkmesh);
 
 if isfield(mesh, 'bnd')
   mesh = mesh.bnd;
@@ -45,33 +70,23 @@ mesh = fixpos(mesh);
 
 % start with an empty volume conductor
 headmodel = [];
-headmodel.bnd = mesh;
 
 % determine the number of compartments
-numboundaries = numel(headmodel.bnd);
+numboundaries = numel(mesh);
 
-% % The following checks can in principle be performed, but are too
-% % time-consuming. Instead the code here relies on the calling function to
-% % feed in the correct geometry.
-% %
-% % if ~all(surface_closed(headmodel.bnd))
-% %   ft_error('...');
-% % end
-% % if any(surface_intersection(headmodel.bnd))
-% %   ft_error('...');
-% % end
-% % if any(surface_selfintersection(headmodel.bnd))
-% %   ft_error('...');
-% % end
-%
-% % The following checks should always be done.
-% headmodel.bnd = surface_orientation(headmodel.bnd, 'outwards'); % might have to be inwards
-%
-% order = surface_nesting(headmodel.bnd, 'outsidefirst'); % might have to be insidefirst
-% headmodel.bnd = headmodel.bnd(order);
-%
-% FIXME also the cond should be in the right order
-%
+% Dipoli expects surface normals to point inwards;
+% this checks and corrects if needed
+for i=1:numboundaries
+  switch surface_orientation(mesh(i))
+    case 'outward'
+      ft_warning('flipping mesh %d', i);
+      mesh(i).tri = fliplr(mesh(i).tri);
+    case 'inward'
+      % this is ok
+    case 'otherwise'
+      ft_error('incorrect mesh %d', i)
+  end
+end
 
 if isempty(isolatedsource)
   if numboundaries>1
@@ -92,41 +107,65 @@ else
 end
 
 % determine the desired nesting of the compartments
-order = surface_nesting(headmodel.bnd, 'outsidefirst');
+order = surface_nesting(mesh, 'outsidefirst');
 
-% rearrange boundaries and conductivities
-if numel(headmodel.bnd)>1
+% reorder the boundaries
+if numel(mesh)>1
   fprintf('reordering the boundaries to: ');
   fprintf('%d ', order);
   fprintf('\n');
   % update the order of the compartments
-  headmodel.bnd = headmodel.bnd(order);
+  mesh = mesh(order);
 end
 
 if isempty(conductivity)
-  ft_warning('No conductivity is declared, Assuming standard values\n')
+  ft_warning('no conductivity specified, using default values')
   if numboundaries == 1
+    % uniform
     conductivity = 1;
   elseif numboundaries == 3
     % skin/skull/brain
-    conductivity = [1 1/80 1] * 0.33;
+    conductivity = [0.3300 0.0042        0.3300];
   elseif numboundaries == 4
-    % FIXME: check for better default values here
-    % skin / outer skull / inner skull / brain
-    conductivity = [1 1/80 1 1] * 0.33;
+    % skin/skull/csf/brain
+    conductivity = [0.3300 0.0042 1.7900 0.3300];
   else
-    ft_error('Conductivity values are required!')
+    ft_error('conductivity values must be specified')
   end
   headmodel.cond = conductivity;
 else
   if numel(conductivity)~=numboundaries
-    ft_error('a conductivity value should be specified for each compartment');
+    ft_error('each compartment should have a conductivity value');
   end
+  % reorder the user-specified conductivities
   headmodel.cond = conductivity(order);
 end
 
+% do some sanity checks on the meshes
+if checkmesh
+  for i=1:numboundaries
+    ntri = size(mesh(i).tri,1);
+    npos = size(mesh(i).pos,1);
+    assert(2*(npos-2)==ntri, 'the number of triangles does not match the number of vertices')
+  end
+
+  % check for each of the vertices that it falls inside the previous surface
+  for i=2:numboundaries
+    for j=1:size(mesh(i).pos,1)
+      inside = bounding_mesh(mesh(i).pos(j,:), mesh(i-1).pos, mesh(i-1).tri);
+      assert(inside, 'vertex %d of surface %d is outside surface %d', j, i, i-1);
+    end
+  end
+
+  ft_info('the meshes are closed and properly nested')
+end % if checkmesh
+
+headmodel.bnd          = mesh;
 headmodel.skin_surface = 1;
 headmodel.source       = numboundaries; % this is now the last one
+
+% just to be sure
+clear mesh
 
 if isolatedsource
   fprintf('using compartment %d for the isolated source approach\n', headmodel.source);
@@ -163,15 +202,6 @@ if isempty(tname)
   end
 else
   prefix = tname;
-end
-
-% checks if normals are inwards oriented, otherwise flips them
-for i=1:numel(headmodel.bnd)
-  isinward = checknormals(headmodel.bnd(i));
-  if ~isinward
-    fprintf('flipping the normals inward prior to head matrix calculation\n')
-    headmodel.bnd(i).tri = fliplr(headmodel.bnd(i).tri);
-  end
 end
 
 % write the triangulations to file
@@ -237,30 +267,3 @@ delete(exefile);
 
 % remember that it is a dipoli model
 headmodel.type = 'dipoli';
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% SUBFUNCTION
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-function ok = checknormals(bnd)
-% checks if the normals are inward oriented
-pos = bnd.pos;
-tri = bnd.tri;
-% translate to the center
-center = median(pos,1);
-pos(:,1) = pos(:,1) - center(1);
-pos(:,2) = pos(:,2) - center(2);
-pos(:,3) = pos(:,3) - center(3);
-
-w = sum(solid_angle(pos, tri));
-
-% FIXME: this method is rigorous only for star shaped surfaces with the origin inside
-if w<0 && (abs(w)-4*pi)<1000*eps
-  % normals are outwards oriented
-  ok = 0;
-elseif w>0 && (abs(w)-4*pi)<1000*eps
-  % normals are inwards oriented
-  ok = 1;
-else
-  ft_warning('your headmodel boundary is not star-shaped when seen from the center')
-  ok = 1;
-end

--- a/forward/private/surface_orientation.m
+++ b/forward/private/surface_orientation.m
@@ -1,0 +1,24 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% SUBFUNCTION
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+function s = surface_orientation(bnd)
+points = bnd.pos;
+faces = bnd.tri;
+
+% translate to the center
+org = mean(points,1);
+points(:,1) = points(:,1) - org(1);
+points(:,2) = points(:,2) - org(2);
+points(:,3) = points(:,3) - org(3);
+
+% this method is rigorous only for star shaped surfaces
+w = sum(solid_angle(points, faces));
+
+if w<0 && (abs(w)-4*pi)<1000*eps
+  s = 'outward';
+elseif w>0 && (abs(w)-4*pi)<1000*eps
+  s = 'inward';
+else
+  s = 'unknown';
+end
+


### PR DESCRIPTION
- this checks for matching numbers of vertices and triangles
- this checks that each vertex of each boundary is contained inside the next boundary
- I noticed that for four-compartment models the default CSF conductivity was set to 1.0, whereas 1.79 is specified in https://www.fieldtriptoolbox.org/faq/what_is_the_conductivity_of_the_brain_csf_skull_and_skin_tissue/