### PR TITLE
reading and writing JSON/binary JSON based JMesh files

### DIFF
--- a/fileio/ft_filetype.m
+++ b/fileio/ft_filetype.m
@@ -1580,13 +1580,21 @@ elseif filetype_check_extension(filename, '.meghdf5')
   manufacturer = 'York Instruments';
   content = 'MEG header and data';
 elseif filetype_check_extension(filename, '.jnii')
-  type = 'openjdata_jnii';
-  manufacturer = 'OpenJData'; % See http://openjdata.org
+  type = 'neurojson_jnii';
+  manufacturer = 'NeuroJSON'; % See https://neurojson.org
   content = 'MRI';
 elseif filetype_check_extension(filename, '.bnii')
-  type = 'openjdata_bnii';
-  manufacturer = 'OpenJData'; % See http://openjdata.org
+  type = 'neurojson_bnii';
+  manufacturer = 'NeuroJSON'; % See https://neurojson.org
   content = 'MRI';
+elseif any(filetype_check_extension(filename, {'.jmsh' '.jmesh'}))
+  type = 'neurojson_jmesh';
+  manufacturer = 'NeuroJSON'; % See https://neurojson.org
+  content = 'Mesh';
+elseif any(filetype_check_extension(filename, {'.bmsh' '.bmesh'}))
+  type = 'neurojson_bmesh';
+  manufacturer = 'NeuroJSON'; % See https://neurojson.org
+  content = 'Mesh';
 elseif filetype_check_extension(filename, '.tsv') && filetype_check_header(filename, sprintf('event\tvalue\ttimestamp'))
   type = 'eegsynth_tsv';
   manufacturer = 'EEGsynth recordtrigger';

--- a/fileio/ft_read_headshape.m
+++ b/fileio/ft_read_headshape.m
@@ -1344,21 +1344,21 @@ switch fileformat
 
   case {'neurojson_jmesh' 'neurojson_bmesh'}
     if(fileformat == 'neurojson_bmesh')
-        shape.orig = loadbj(filename);
+        jmesh = loadbj(filename);
     else
-        shape.orig = loadjson(filename);
+        jmesh = loadjson(filename);
     end
 
-    % shape.orig metadata
-    if(isfield(shape.orig, encodevarname('_DataInfo_')))
-        shape.info = shape.orig.(encodevarname('_DataInfo_'));
+    % jmesh metadata
+    if(isfield(jmesh, encodevarname('_DataInfo_')))
+        shape.info = jmesh.(encodevarname('_DataInfo_'));
     end
 
     % node data
-    if(isfield(shape.orig, 'MeshVertex3'))
-        shape.pos  = shape.orig.MeshVertex3;
-    elseif(isfield(shape.orig, 'MeshNode'))
-        shape.pos  = shape.orig.MeshNode;
+    if(isfield(jmesh, 'MeshVertex3'))
+        shape.pos  = jmesh.MeshVertex3;
+    elseif(isfield(jmesh, 'MeshNode'))
+        shape.pos  = jmesh.MeshNode;
     end
 
     % extract node label if present
@@ -1372,10 +1372,10 @@ switch fileformat
     end
 
     % surface data
-    if(isfield(shape.orig, 'MeshTri3'))
-        shape.tri  = shape.orig.MeshTri3;
-    elseif(isfield(shape.orig, 'MeshSurf'))
-        shape.tri  = shape.orig.MeshSurf;
+    if(isfield(jmesh, 'MeshTri3'))
+        shape.tri  = jmesh.MeshTri3;
+    elseif(isfield(jmesh, 'MeshSurf'))
+        shape.tri  = jmesh.MeshSurf;
     end
 
     % extract face label if present
@@ -1389,10 +1389,10 @@ switch fileformat
     end
 
     % tet element data
-    if(isfield(shape.orig, 'MeshTet4'))
-        shape.tet  = shape.orig.MeshTet4;
-    elseif(isfield(shape.orig, 'MeshElem'))
-        shape.tet  = shape.orig.MeshElem;
+    if(isfield(jmesh, 'MeshTet4'))
+        shape.tet  = jmesh.MeshTet4;
+    elseif(isfield(jmesh, 'MeshElem'))
+        shape.tet  = jmesh.MeshElem;
     end
 
     % extract hex label if present
@@ -1406,8 +1406,8 @@ switch fileformat
     end
 
     % hex element data
-    if(isfield(shape.orig, 'MeshHex8'))
-        shape.hex  = shape.orig.MeshHex8;
+    if(isfield(jmesh, 'MeshHex8'))
+        shape.hex  = jmesh.MeshHex8;
     end
 
     % extract hex label if present

--- a/fileio/ft_read_headshape.m
+++ b/fileio/ft_read_headshape.m
@@ -1344,24 +1344,24 @@ switch fileformat
 
   case {'neurojson_jmesh' 'neurojson_bmesh'}
     if(fileformat == 'neurojson_bmesh')
-        mesh = loadbj(filename);
+        shape.orig = loadbj(filename);
     else
-        mesh = loadjson(filename);
+        shape.orig = loadjson(filename);
     end
 
-    % mesh metadata
-    if(isfield(mesh, encodevarname('_DataInfo_')))
-        shape.info = mesh.(encodevarname('_DataInfo_'));
+    % shape.orig metadata
+    if(isfield(shape.orig, encodevarname('_DataInfo_')))
+        shape.info = shape.orig.(encodevarname('_DataInfo_'));
     end
 
     % node data
-    if(isfield(mesh, 'MeshVertex3'))
-        shape.pos  = mesh.MeshVertex3;
-    elseif(isfield(mesh, 'MeshNode'))
-        shape.pos  = mesh.MeshNode;
+    if(isfield(shape.orig, 'MeshVertex3'))
+        shape.pos  = shape.orig.MeshVertex3;
+    elseif(isfield(shape.orig, 'MeshNode'))
+        shape.pos  = shape.orig.MeshNode;
     end
 
-    % extract mesh node label if present
+    % extract node label if present
     if(isfield(shape, 'pos') && isstruct(shape.pos))
         if(isfield(shape.pos, 'Properties') && isfield(shape.pos.Properties, 'Tag'))
             shape.poslabel = shape.pos.Properties.Tag;
@@ -1371,11 +1371,11 @@ switch fileformat
         end
     end
 
-    % surface mesh data
-    if(isfield(mesh, 'MeshTri3'))
-        shape.tri  = mesh.MeshTri3;
-    elseif(isfield(mesh, 'MeshSurf'))
-        shape.tri  = mesh.MeshSurf;
+    % surface data
+    if(isfield(shape.orig, 'MeshTri3'))
+        shape.tri  = shape.orig.MeshTri3;
+    elseif(isfield(shape.orig, 'MeshSurf'))
+        shape.tri  = shape.orig.MeshSurf;
     end
 
     % extract face label if present
@@ -1388,20 +1388,35 @@ switch fileformat
         end
     end
 
-    % tet mesh data
-    if(isfield(mesh, 'MeshTet4'))
-        shape.tet  = mesh.MeshTet4;
-    elseif(isfield(mesh, 'MeshElem'))
-        shape.tet  = mesh.MeshElem;
+    % tet element data
+    if(isfield(shape.orig, 'MeshTet4'))
+        shape.tet  = shape.orig.MeshTet4;
+    elseif(isfield(shape.orig, 'MeshElem'))
+        shape.tet  = shape.orig.MeshElem;
     end
 
-    % extract tet label if present
+    % extract hex label if present
     if(isfield(shape, 'tet') && isstruct(shape.tet))
         if(isfield(shape.tet, 'Properties') && isfield(shape.tet.Properties, 'Tag'))
             shape.tetlabel = shape.tet.Properties.Tag;
         end
         if(isfield(shape.tet, 'Data'))
             shape.tet = shape.tet.Data;
+        end
+    end
+
+    % hex element data
+    if(isfield(shape.orig, 'MeshHex8'))
+        shape.hex  = shape.orig.MeshHex8;
+    end
+
+    % extract hex label if present
+    if(isfield(shape, 'hex') && isstruct(shape.hex))
+        if(isfield(shape.hex, 'Properties') && isfield(shape.hex.Properties, 'Tag'))
+            shape.hexlabel = shape.hex.Properties.Tag;
+        end
+        if(isfield(shape.tet, 'Data'))
+            shape.hex = shape.hex.Data;
         end
     end
 

--- a/fileio/ft_read_headshape.m
+++ b/fileio/ft_read_headshape.m
@@ -26,7 +26,7 @@ function [shape] = ft_read_headshape(filename, varargin)
 %   'image'       = path to .jpg file
 %   'surface'     = specific surface to be read (only for caret spec files)
 %   'refine'      = number, used for refining Structure Sensor meshes (default = 1)
-%   'jsonopt'      = cell of ('name', 'value') pairs, options for reading JSON/JMesh files
+%   'jmeshopt'    = cell of ('name', 'value') pairs, options for reading JSON/JMesh files
 %
 % Supported input file formats include
 %   'matlab'       containing FieldTrip or BrainStorm headshapes or cortical meshes
@@ -1344,7 +1344,7 @@ switch fileformat
     shape.hex = shape.hex + 1; % this should be one-offset
 
   case {'neurojson_jmesh' 'neurojson_bmesh'}
-    extraopt = jsonopt('jsonopt', {}, varargin2struct(varargin{:}));
+    extraopt = jsonopt('jmeshopt', {}, varargin2struct(varargin{:}));
     if(fileformat == 'neurojson_bmesh')
         jmesh = loadbj(filename, extraopt{:});
     else

--- a/fileio/ft_read_mri.m
+++ b/fileio/ft_read_mri.m
@@ -676,7 +676,7 @@ switch dataformat
       mri.transform(1:3,1:3) = diag(tmp.vox(1:3))*mri.transform(1:3,1:3);
     end
 
-  case {'openjdata_jnii' 'openjdata_bnii'}
+  case {'neurojson_jnii' 'neurojson_bnii'}
     % this depends on two external toolboxes
     ft_hastoolbox('jsonlab', 1);
     ft_hastoolbox('jnifti', 1);

--- a/fileio/ft_write_headshape.m
+++ b/fileio/ft_write_headshape.m
@@ -233,47 +233,46 @@ switch fileformat
     ft_hastoolbox('jsonlab', 1);
 
     % construct a JMesh data structure
-    if(~isfield(mesh, 'orig'))
-        mesh.orig = struct;
-    end
+    jmesh = struct;
+
     if(isfield(mesh, 'info'))
-        mesh.orig.(encodevarname('_DataInfo_')) = mesh.info;
+        jmesh.(encodevarname('_DataInfo_')) = mesh.info;
     end
     if(isfield(mesh, 'pos'))
         if(isfield(mesh, 'poslabel'))
-            mesh.orig.MeshVertex3 = struct('Data', mesh.pos, 'Properties', struct('Tag', mesh.poslabel));
+            jmesh.MeshVertex3 = struct('Data', mesh.pos, 'Properties', struct('Tag', mesh.poslabel));
         else
-            mesh.orig.MeshVertex3 = mesh.pos;
+            jmesh.MeshVertex3 = mesh.pos;
         end
     end
     if(isfield(mesh, 'tri'))
         if(isfield(mesh, 'trilabel'))
-            mesh.orig.MeshTri3 = struct('Data', mesh.tri, 'Properties', struct('Tag', mesh.trilabel));
+            jmesh.MeshTri3 = struct('Data', mesh.tri, 'Properties', struct('Tag', mesh.trilabel));
         else
-            mesh.orig.MeshTri3 = mesh.tri;
+            jmesh.MeshTri3 = mesh.tri;
         end
     end
     if(isfield(mesh, 'tet'))
         if(isfield(mesh, 'tetlabel'))
-            mesh.orig.MeshTet4 = struct('Data', mesh.tet, 'Properties', struct('Tag', mesh.tetlabel));
+            jmesh.MeshTet4 = struct('Data', mesh.tet, 'Properties', struct('Tag', mesh.tetlabel));
         else
-            mesh.orig.MeshTet4 = mesh.tet;
+            jmesh.MeshTet4 = mesh.tet;
         end
     end
     if(isfield(mesh, 'hex'))
         if(isfield(mesh, 'hexlabel'))
-            mesh.orig.MeshHex8 = struct('Data', mesh.hex, 'Properties', struct('Tag', mesh.hexlabel));
+            jmesh.MeshHex8 = struct('Data', mesh.hex, 'Properties', struct('Tag', mesh.hexlabel));
         else
-            mesh.orig.MeshHex8 = mesh.hex;
+            jmesh.MeshHex8 = mesh.hex;
         end
     end
 
     % save data to JSON or binary JSON
     extraopt = jsonopt('jsonopt', {}, varargin2struct(varargin{:}));
     if(fileformat == 'neurojson_jmesh')
-        savejson('', mesh.orig, 'filename', filename, 'compression', 'zlib', extraopt{:});
+        savejson('', jmesh, 'filename', filename, 'compression', 'zlib', extraopt{:});
     else
-        savebj('', mesh.orig, 'filename', filename, 'compression', 'zlib', extraopt{:});
+        savebj('', jmesh, 'filename', filename, 'compression', 'zlib', extraopt{:});
     end
 
   case []

--- a/fileio/ft_write_headshape.m
+++ b/fileio/ft_write_headshape.m
@@ -266,6 +266,12 @@ switch fileformat
             jmesh.MeshHex8 = mesh.hex;
         end
     end
+    if(isfield(mesh, 'line'))
+        jmesh.MeshEdge = mesh.line;
+    end
+    if(isfield(mesh, 'poly'))
+        jmesh.MeshPLC = mesh.poly;
+    end
 
     % save data to JSON or binary JSON
     extraopt = jsonopt('jsonopt', {}, varargin2struct(varargin{:}));

--- a/fileio/ft_write_headshape.m
+++ b/fileio/ft_write_headshape.m
@@ -233,40 +233,48 @@ switch fileformat
     ft_hastoolbox('jsonlab', 1);
 
     % construct a JMesh data structure
-    meshdata=struct;
+    if(~isfield(mesh, 'orig'))
+        mesh.orig = struct;
+    end
     if(isfield(mesh, 'info'))
-        meshdata.(encodevarname('_DataInfo_')) = mesh.info;
+        mesh.orig.(encodevarname('_DataInfo_')) = mesh.info;
     end
     if(isfield(mesh, 'pos'))
         if(isfield(mesh, 'poslabel'))
-            meshdata.MeshVertex3 = struct('Data', mesh.pos, 'Properties', struct('Tag', mesh.poslabel));
+            mesh.orig.MeshVertex3 = struct('Data', mesh.pos, 'Properties', struct('Tag', mesh.poslabel));
         else
-            meshdata.MeshVertex3 = mesh.pos;
+            mesh.orig.MeshVertex3 = mesh.pos;
         end
     end
     if(isfield(mesh, 'tri'))
         if(isfield(mesh, 'trilabel'))
-            meshdata.MeshTri3 = struct('Data', mesh.tri, 'Properties', struct('Tag', mesh.trilabel));
+            mesh.orig.MeshTri3 = struct('Data', mesh.tri, 'Properties', struct('Tag', mesh.trilabel));
         else
-            meshdata.MeshTri3 = mesh.tri;
+            mesh.orig.MeshTri3 = mesh.tri;
         end
     end
     if(isfield(mesh, 'tet'))
         if(isfield(mesh, 'tetlabel'))
-            meshdata.MeshTet4 = struct('Data', mesh.tet, 'Properties', struct('Tag', mesh.tetlabel));
+            mesh.orig.MeshTet4 = struct('Data', mesh.tet, 'Properties', struct('Tag', mesh.tetlabel));
         else
-            meshdata.MeshTet4 = mesh.tet;
+            mesh.orig.MeshTet4 = mesh.tet;
+        end
+    end
+    if(isfield(mesh, 'hex'))
+        if(isfield(mesh, 'hexlabel'))
+            mesh.orig.MeshHex8 = struct('Data', mesh.hex, 'Properties', struct('Tag', mesh.hexlabel));
+        else
+            mesh.orig.MeshHex8 = mesh.hex;
         end
     end
 
     % save data to JSON or binary JSON
     extraopt = jsonopt('jsonopt', {}, varargin2struct(varargin{:}));
     if(fileformat == 'neurojson_jmesh')
-        savejson('', meshdata, 'filename', filename, 'compression', 'zlib', extraopt{:});
+        savejson('', mesh.orig, 'filename', filename, 'compression', 'zlib', extraopt{:});
     else
-        savebj('', meshdata, 'filename', filename, 'compression', 'zlib', extraopt{:});
+        savebj('', mesh.orig, 'filename', filename, 'compression', 'zlib', extraopt{:});
     end
-    clear meshdata
 
   case []
     ft_error('no output format specified');

--- a/fileio/ft_write_headshape.m
+++ b/fileio/ft_write_headshape.m
@@ -21,7 +21,7 @@ function ft_write_headshape(filename, mesh, varargin)
 %   'data'         = data matrix, size(1) should be number of vertices
 %   'unit'         = string, desired geometrical units for the data, for example 'mm'
 %   'coordsys'     = string, desired coordinate system for the data
-%   'jsonopt'      = cell of ('name', 'value') pairs, options for writing JSON/JMesh files
+%   'jmeshopt'     = cell of ('name', 'value') pairs, options for writing JSON/JMesh files
 %
 % Supported output formats are
 %   'freesurfer'  Freesurfer surf-file format, using write_surf from FreeSurfer
@@ -274,7 +274,7 @@ switch fileformat
     end
 
     % save data to JSON or binary JSON
-    extraopt = jsonopt('jsonopt', {}, varargin2struct(varargin{:}));
+    extraopt = jsonopt('jmeshopt', {}, varargin2struct(varargin{:}));
     if(fileformat == 'neurojson_jmesh')
         savejson('', jmesh, 'filename', filename, 'compression', 'zlib', extraopt{:});
     else

--- a/test/test_bug1992.m
+++ b/test/test_bug1992.m
@@ -1,0 +1,49 @@
+function test_bug1992
+
+% DEPENDENCY ft_filetype ft_read_headshape ft_write_headshape loadjson savejson loadbj savebj jsonopt
+
+filename = [tempname '.jmsh'];
+
+[pos, tri] = mesh_sphere(162);
+
+% combine them in a structure
+mesh1.pos = pos;
+mesh1.tri = int32(tri);
+mesh1.info = struct('JMeshVersion', '0.5', 'Dimension', 3, ...
+                    'AnnotationFormat', 'https://github.com/NeuroJSON/jmesh/blob/master/JMesh_specification.md', ...
+                    'SerialFormat', 'http://json.org');
+mesh1.poslabel = ones(1, size(pos,1));
+mesh1.trilabel = ones(1, size(tri,1));
+
+ft_write_headshape(filename, mesh1, 'format', 'neurojson_jmesh');
+mesh2 = ft_read_headshape(filename);
+assert(isequal(mesh1.pos, mesh2.pos));
+assert(isequal(mesh1.poslabel, mesh2.poslabel));
+assert(isequal(mesh1.tri, mesh2.tri));
+assert(isequal(mesh1.trilabel, mesh2.trilabel));
+delete(filename);
+
+ft_write_headshape(filename, mesh1, 'format', 'neurojson_jmesh', 'jsonopt', {'compact',1, 'compression', ''});
+mesh2 = ft_read_headshape(filename);
+assert(isequal(mesh1.tri, mesh2.tri));
+ratio = mesh1.pos(:)\mesh2.pos(:);
+assert(ratio>0.99 && ratio<1.01);
+assert(isequal(mesh1.poslabel, mesh2.poslabel));
+assert(isequal(mesh1.trilabel, mesh2.trilabel));
+delete(filename);
+
+filename = [tempname '.bmsh'];
+mesh1.info.SerialFormat = 'https://neurojson.org/bjdata/draft2';
+
+ft_write_headshape(filename, mesh1, 'format', 'neurojson_bmesh');
+mesh2 = ft_read_headshape(filename);
+assert(isequal(mesh1.pos, mesh2.pos));
+assert(isequal(mesh1.poslabel, mesh2.poslabel));
+assert(isequal(mesh1.tri, mesh2.tri));
+assert(isequal(mesh1.trilabel, mesh2.trilabel));
+delete(filename);
+
+
+
+
+

--- a/test/test_bug1992.m
+++ b/test/test_bug1992.m
@@ -9,6 +9,8 @@ filename = [tempname '.jmsh'];
 % combine them in a structure
 mesh1.pos = pos;
 mesh1.tri = int32(tri);
+mesh1.line = nchoosek(mesh1.tri(1,:),2);
+mesh1.poly = {[1,2,3], [4,7,8,5]};
 mesh1.info = struct('JMeshVersion', '0.5', 'Dimension', 3, ...
                     'AnnotationFormat', 'https://github.com/NeuroJSON/jmesh/blob/master/JMesh_specification.md', ...
                     'SerialFormat', 'http://json.org');
@@ -21,15 +23,19 @@ assert(isequal(mesh1.pos, mesh2.pos));
 assert(isequal(mesh1.poslabel, mesh2.poslabel));
 assert(isequal(mesh1.tri, mesh2.tri));
 assert(isequal(mesh1.trilabel, mesh2.trilabel));
+assert(isequal(mesh1.line, mesh2.line));
+assert(isequal(mesh1.poly, mesh2.poly));
 delete(filename);
 
 ft_write_headshape(filename, mesh1, 'format', 'neurojson_jmesh', 'jsonopt', {'compact',1, 'compression', ''});
-mesh2 = ft_read_headshape(filename);
+mesh2 = ft_read_headshape(filename, 'jsonopt', {'FormatVersion', 2});
 assert(isequal(mesh1.tri, mesh2.tri));
 ratio = mesh1.pos(:)\mesh2.pos(:);
 assert(ratio>0.99 && ratio<1.01);
 assert(isequal(mesh1.poslabel, mesh2.poslabel));
 assert(isequal(mesh1.trilabel, mesh2.trilabel));
+assert(isequal(mesh1.line, mesh2.line));
+assert(isequal(mesh1.poly, mesh2.poly));
 delete(filename);
 
 filename = [tempname '.bmsh'];
@@ -41,9 +47,6 @@ assert(isequal(mesh1.pos, mesh2.pos));
 assert(isequal(mesh1.poslabel, mesh2.poslabel));
 assert(isequal(mesh1.tri, mesh2.tri));
 assert(isequal(mesh1.trilabel, mesh2.trilabel));
+assert(isequal(mesh1.line, mesh2.line));
+assert(isequal(mesh1.poly, mesh2.poly));
 delete(filename);
-
-
-
-
-

--- a/test/test_bug1992.m
+++ b/test/test_bug1992.m
@@ -27,8 +27,8 @@ assert(isequal(mesh1.line, mesh2.line));
 assert(isequal(mesh1.poly, mesh2.poly));
 delete(filename);
 
-ft_write_headshape(filename, mesh1, 'format', 'neurojson_jmesh', 'jsonopt', {'compact',1, 'compression', ''});
-mesh2 = ft_read_headshape(filename, 'jsonopt', {'FormatVersion', 2});
+ft_write_headshape(filename, mesh1, 'format', 'neurojson_jmesh', 'jmeshopt', {'compact',1, 'compression', ''});
+mesh2 = ft_read_headshape(filename, 'jmeshopt', {'formatversion', 2});
 assert(isequal(mesh1.tri, mesh2.tri));
 ratio = mesh1.pos(:)\mesh2.pos(:);
 assert(ratio>0.99 && ratio<1.01);


### PR DESCRIPTION
here is a patch to allow fieldtrip to read/write JSON (.jmsh) and binary JSON (.bmsh) encoded mesh files.

close #1992