### PR TITLE
fix: accommodate a change to in_fopen_nk

### DIFF
--- a/fileio/private/read_brainstorm_header.m
+++ b/fileio/private/read_brainstorm_header.m
@@ -37,7 +37,11 @@ function [hdr] = read_brainstorm_header(filename)
 hdr.orig        = sFile.header;
 hdr.nChans      = sFile.header.num_channels;
 hdr.Fs          = sFile.header.sample_rate;
-hdr.nSamples    = sFile.epochs.samples(end)-sFile.epochs.samples(1)+1;
+if isfield(sFile.epochs, 'samples')     
+  hdr.nSamples    = round(sFile.epochs.samples(end) - sFile.epochs.samples(1) + 1);
+elseif isfield(sFile.epochs, 'times') % accommodates a change to in_fopen_nk in 2021
+  hdr.nSamples    = round((sFile.epochs.times(end) - sFile.epochs.times(1)) * hdr.Fs) + 1;
+end
 hdr.nSamplesPre = 0;
 hdr.nTrials     = length(sFile.epochs);
 hdr.label       = cell(hdr.nChans, 1);

--- a/fileio/private/read_brainstorm_header.m
+++ b/fileio/private/read_brainstorm_header.m
@@ -38,9 +38,9 @@ hdr.orig        = sFile.header;
 hdr.nChans      = sFile.header.num_channels;
 hdr.Fs          = sFile.header.sample_rate;
 if isfield(sFile.epochs, 'samples')     
-  hdr.nSamples    = round(sFile.epochs.samples(end) - sFile.epochs.samples(1) + 1);
+  hdr.nSamples    = sFile.epochs.samples(end) - sFile.epochs.samples(1) + 1;
 elseif isfield(sFile.epochs, 'times') % accommodates a change to in_fopen_nk in 2021
-  hdr.nSamples    = round((sFile.epochs.times(end) - sFile.epochs.times(1)) * hdr.Fs) + 1;
+  hdr.nSamples    = (sFile.epochs.times(end) - sFile.epochs.times(1)) * hdr.Fs + 1;
 end
 hdr.nSamplesPre = 0;
 hdr.nTrials     = length(sFile.epochs);


### PR DESCRIPTION
This PR fixes a change to external/brainstorm/in_open_nk introduced in 2021*. Specifically, the 'samples' field was renamed into 'times' and its values were divided by the sample frequency. As a result, private/read_brainstorm_header would error on the missing samples field when parsing the header information. The below code change fixes this issue as well as converts the times into samples based on the sample frequency.

*https://github.com/fieldtrip/fieldtrip/commit/c1114e1df9942423ebf142e5508fa6284415ef2c
prior:
sFile.epochs(i).samples = [0, hdr.ctl(1).data(i).num_samples - 1];
after:
sFile.epochs(i).times   = sFile.epochs(i).samples ./ hdr.sample_rate;
sFile.epochs(i).times   = [0, hdr.ctl(1).data(i).num_samples - 1] ./ hdr.sample_rate;