### PR TITLE
ENH #2216 interactive registration between headshape and MRI

### DIFF
--- a/ft_interactiverealign.m
+++ b/ft_interactiverealign.m
@@ -9,12 +9,13 @@ function [cfg] = ft_interactiverealign(cfg)
 %
 % The configuration structure should contain the individuals geometrical object that
 % has to be realigned
-%   cfg.individual.elec           = structure
-%   cfg.individual.grad           = structure
+%   cfg.individual.elec           = structure, see FT_READ_SENS
+%   cfg.individual.grad           = structure, see FT_READ_SENS
+%   cfg.individual.opto           = structure, see FT_READ_SENS
 %   cfg.individual.headmodel      = structure, see FT_PREPARE_HEADMODEL
 %   cfg.individual.headshape      = structure, see FT_READ_HEADSHAPE
 %   cfg.individual.mri            = structure, see FT_READ_MRI
-%   cfg.individual.mesh           = structure
+%   cfg.individual.mesh           = structure, see FT_PREPARE_MESH
 % You can specify the style with which the objects are displayed using
 %   cfg.individual.headmodelstyle = 'vertex', 'edge', 'surface' or 'both' (default = 'edge')
 %   cfg.individual.headshapestyle = 'vertex', 'edge', 'surface' or 'both' (default = 'vertex')
@@ -22,12 +23,13 @@ function [cfg] = ft_interactiverealign(cfg)
 % The configuration structure should also contain the geometrical object of a
 % template that serves as target
 %   cfg.template.axes             = string, 'yes' or 'no (default = 'no')
-%   cfg.template.elec             = structure
-%   cfg.template.grad             = structure
+%   cfg.template.elec             = structure, see FT_READ_SENS
+%   cfg.template.grad             = structure, see FT_READ_SENS
+%   cfg.template.opto             = structure, see FT_READ_SENS
 %   cfg.template.headmodel        = structure, see FT_PREPARE_HEADMODEL
 %   cfg.template.headshape        = structure, see FT_READ_HEADSHAPE
 %   cfg.template.mri              = structure, see FT_READ_MRI
-%   cfg.template.mesh             = structure
+%   cfg.template.mesh             = structure, see FT_PREPARE_MESH
 % You can specify the style with which the objects are displayed using
 %   cfg.template.headmodelstyle   = 'vertex', 'edge', 'surface' or 'both' (default = 'edge')
 %   cfg.template.headshapestyle   = 'vertex', 'edge', 'surface' or 'both' (default = 'vertex')
@@ -98,7 +100,7 @@ cfg.translate      = ft_getopt(cfg, 'translate', [0 0 0]);
 cfg.transformorder = ft_getopt(cfg, 'transformorder', {'rotate', 'translate', 'scale'});
 
 % get the other options
-cfg.showalpha                 = ft_getopt(cfg, 'showalpha', 'yes');
+cfg.showalpha                 = ft_getopt(cfg, 'showalpha'); % default is set below
 cfg.showlight                 = ft_getopt(cfg, 'showlight', 'yes');
 cfg.showapply                 = ft_getopt(cfg, 'showapply', 'yes');
 cfg.unit                      = ft_getopt(cfg, 'unit', 'mm');
@@ -106,6 +108,8 @@ cfg.individual.elec           = ft_getopt(cfg.individual, 'elec', []);
 cfg.individual.elecstyle      = ft_getopt(cfg.individual, 'elecstyle', {}); % key-value pairs
 cfg.individual.grad           = ft_getopt(cfg.individual, 'grad', []);
 cfg.individual.gradstyle      = ft_getopt(cfg.individual, 'gradstyle', {}); % key-value pairs
+cfg.individual.opto           = ft_getopt(cfg.individual, 'opto', []);
+cfg.individual.optostyle      = ft_getopt(cfg.individual, 'optostyle', {}); % key-value pairs
 cfg.individual.headshape      = ft_getopt(cfg.individual, 'headshape', []);
 if ~isempty(cfg.individual.headshape) && isfield(cfg.individual.headshape, 'tri')
   cfg.individual.headshapestyle = ft_getopt(cfg.individual, 'headshapestyle', 'surface');
@@ -124,6 +128,8 @@ cfg.template.elec             = ft_getopt(cfg.template, 'elec', []);
 cfg.template.elecstyle        = ft_getopt(cfg.template, 'elecstyle', {}); % key-value pairs
 cfg.template.grad             = ft_getopt(cfg.template, 'grad', []);
 cfg.template.gradstyle        = ft_getopt(cfg.template, 'gradstyle', {}); % key-value pairs
+cfg.template.opto             = ft_getopt(cfg.template, 'opto', []);
+cfg.template.optostyle        = ft_getopt(cfg.template, 'optostyle', {}); % key-value pairs
 cfg.template.headshape        = ft_getopt(cfg.template, 'headshape', []);
 if ~isempty(cfg.template.headshape) && isfield(cfg.template.headshape, 'tri')
   cfg.template.headshapestyle   = ft_getopt(cfg.template, 'headshapestyle', 'surface');
@@ -171,14 +177,16 @@ if ~isempty(cfg.template.headshape) && isfield(cfg.template.headshape, 'color')
   end
 end
 
-% only show and use the global alpha level if it is not specified for any of the individual objects
-showalpha = istrue(cfg.showalpha);
-for fn1={'individual', 'template'}
-  fn1 = fn1{1};
-  for fn2={'elecstyle', 'gradstyle', 'headshapestyle', 'headmodelstyle', 'mristyle', 'meshstyle'}
-    fn2 = fn2{1};
-    style = cfg.(fn1).(fn2);
-    showalpha = showalpha & ~any(endsWith(style(1:2:end), 'alpha'));
+if isempty(cfg.showalpha)
+  % only show the global alpha level if not specified for any of the individual objects
+  cfg.showalpha = true;
+  for fn1={'individual', 'template'}
+    fn1 = fn1{1};
+    for fn2={'elecstyle', 'gradstyle', 'headshapestyle', 'headmodelstyle', 'mristyle', 'meshstyle'}
+      fn2 = fn2{1};
+      style = cfg.(fn1).(fn2);
+      cfg.showalpha = cfg.showalpha & ~any(endsWith(style(1:2:end), 'alpha'));
+    end
   end
 end
 
@@ -186,12 +194,17 @@ template   = struct(cfg.template);
 individual = struct(cfg.individual);
 
 % ensure that they are consistent with the latest FieldTrip version
-if ~isempty(template.elec)
-  template.elec = ft_datatype_sens(template.elec);
+for fn1={'individual', 'template'}
+  fn1 = fn1{1};
+  for fn2={'elec', 'grad', 'opto'}
+    fn2 = fn2{1};
+    if ~isempty(cfg.(fn1).(fn2))
+      cfg.(fn1).(fn2) = ft_datatype_sens(cfg.(fn1).(fn2));
+    end
+  end
 end
-if ~isempty(individual.elec)
-  individual.elec = ft_datatype_sens(individual.elec);
-end
+
+% ensure that they are consistent with the latest FieldTrip version
 if ~isempty(template.headshape)
   template.headshape = fixpos(template.headshape);
 end
@@ -265,17 +278,11 @@ setappdata(fig, 'scale',          cfg.scale);
 setappdata(fig, 'translate',      cfg.translate);
 setappdata(fig, 'coordsys',       coordsys); % can be unknown
 setappdata(fig, 'unit',           cfg.unit);
-setappdata(fig, 'toggle_labels',  true);
-setappdata(fig, 'toggle_axes',    true);
-setappdata(fig, 'toggle_grid',    true);
+setappdata(fig, 'labels',         true);
+setappdata(fig, 'axes',           true);
+setappdata(fig, 'grid',           true);
+setappdata(fig, 'camlight',       true);
 setappdata(fig, 'cfg',            cfg);
-
-% add the GUI elements
-axmax = 150 * ft_scalingfactor('mm', cfg.unit);
-axis([-axmax axmax -axmax axmax -axmax axmax]);
-cb_creategui(gcf);
-cb_redraw(gcf);
-rotate3d on
 
 if isempty(coordsys) || strcmp(coordsys, 'unknown')
   ft_notice('the template coordinate system is unknown, selecting the viewpoint is not possible');
@@ -287,6 +294,14 @@ else
   ft_info('the positive Y-axis is pointing to %s', labely);
   ft_info('the positive Z-axis is pointing to %s', labelz);
 end
+
+% add the GUI elements
+axmax = 150 * ft_scalingfactor('mm', cfg.unit);
+axis([-axmax axmax -axmax axmax -axmax axmax]);
+cb_creategui(gcf);
+cb_redraw(gcf);
+cb_help(cfg);
+rotate3d on
 
 cleanup = false;
 while ~cleanup
@@ -332,61 +347,61 @@ cfg       = getappdata(fig, 'cfg');
 CONTROL_WIDTH   = 0.04;
 CONTROL_HEIGHT  = 0.05;
 CONTROL_HOFFSET = 0.75;
-CONTROL_VOFFSET = 0.50;
+CONTROL_VOFFSET = 0.60;
 
 % rotateui
-uicontrol('tag', 'rotateui', 'parent',  fig, 'units', 'normalized', 'style', 'text', 'string', 'rotate', 'callback', [])
-uicontrol('tag', 'rx',   'parent',  fig, 'units', 'normalized', 'style', 'edit', 'string', rotate(1), 'callback', @cb_redraw)
-uicontrol('tag', 'ry',   'parent',  fig, 'units', 'normalized', 'style', 'edit', 'string', rotate(2), 'callback', @cb_redraw)
-uicontrol('tag', 'rz',   'parent',  fig, 'units', 'normalized', 'style', 'edit', 'string', rotate(3), 'callback', @cb_redraw)
-ft_uilayout(fig, 'tag', 'rotateui', 'BackgroundColor', [0.8 0.8 0.8], 'width',  2*CONTROL_WIDTH, 'height',  CONTROL_HEIGHT, 'hpos',  CONTROL_HOFFSET,                 'vpos',  CONTROL_VOFFSET+CONTROL_HEIGHT);
-ft_uilayout(fig, 'tag', 'rx',   'BackgroundColor', [0.8 0.8 0.8], 'width',  CONTROL_WIDTH,   'height',  CONTROL_HEIGHT, 'hpos',  CONTROL_HOFFSET+3*CONTROL_WIDTH, 'vpos',  CONTROL_VOFFSET+CONTROL_HEIGHT);
-ft_uilayout(fig, 'tag', 'ry',   'BackgroundColor', [0.8 0.8 0.8], 'width',  CONTROL_WIDTH,   'height',  CONTROL_HEIGHT, 'hpos',  CONTROL_HOFFSET+4*CONTROL_WIDTH, 'vpos',  CONTROL_VOFFSET+CONTROL_HEIGHT);
-ft_uilayout(fig, 'tag', 'rz',   'BackgroundColor', [0.8 0.8 0.8], 'width',  CONTROL_WIDTH,   'height',  CONTROL_HEIGHT, 'hpos',  CONTROL_HOFFSET+5*CONTROL_WIDTH, 'vpos',  CONTROL_VOFFSET+CONTROL_HEIGHT);
+uicontrol('tag', 'rotateui', 'parent',  fig, 'units', 'normalized', 'style', 'text', 'string', 'rotate',  'callback', [])
+uicontrol('tag', 'rx',       'parent',  fig, 'units', 'normalized', 'style', 'edit', 'string', rotate(1), 'callback', @cb_redraw)
+uicontrol('tag', 'ry',       'parent',  fig, 'units', 'normalized', 'style', 'edit', 'string', rotate(2), 'callback', @cb_redraw)
+uicontrol('tag', 'rz',       'parent',  fig, 'units', 'normalized', 'style', 'edit', 'string', rotate(3), 'callback', @cb_redraw)
+ft_uilayout(fig, 'tag', 'rotateui', 'width',  2*CONTROL_WIDTH, 'height',  CONTROL_HEIGHT, 'hpos',  CONTROL_HOFFSET,                 'vpos',  CONTROL_VOFFSET+3*CONTROL_HEIGHT);
+ft_uilayout(fig, 'tag', 'rx',       'width',  CONTROL_WIDTH,   'height',  CONTROL_HEIGHT, 'hpos',  CONTROL_HOFFSET+3*CONTROL_WIDTH, 'vpos',  CONTROL_VOFFSET+3*CONTROL_HEIGHT);
+ft_uilayout(fig, 'tag', 'ry',       'width',  CONTROL_WIDTH,   'height',  CONTROL_HEIGHT, 'hpos',  CONTROL_HOFFSET+4*CONTROL_WIDTH, 'vpos',  CONTROL_VOFFSET+3*CONTROL_HEIGHT);
+ft_uilayout(fig, 'tag', 'rz',       'width',  CONTROL_WIDTH,   'height',  CONTROL_HEIGHT, 'hpos',  CONTROL_HOFFSET+5*CONTROL_WIDTH, 'vpos',  CONTROL_VOFFSET+3*CONTROL_HEIGHT);
 
 % scaleui
-uicontrol('tag', 'scaleui', 'parent',  fig, 'units', 'normalized', 'style', 'text', 'string', 'scale', 'callback', [])
+uicontrol('tag', 'scaleui', 'parent',  fig, 'units', 'normalized', 'style', 'text', 'string', 'scale',  'callback', [])
 uicontrol('tag', 'sx',      'parent',  fig, 'units', 'normalized', 'style', 'edit', 'string', scale(1), 'callback', @cb_redraw)
 uicontrol('tag', 'sy',      'parent',  fig, 'units', 'normalized', 'style', 'edit', 'string', scale(2), 'callback', @cb_redraw)
 uicontrol('tag', 'sz',      'parent',  fig, 'units', 'normalized', 'style', 'edit', 'string', scale(3), 'callback', @cb_redraw)
-ft_uilayout(fig, 'tag', 'scaleui', 'BackgroundColor', [0.8 0.8 0.8], 'width',  2*CONTROL_WIDTH, 'height',  CONTROL_HEIGHT, 'hpos',  CONTROL_HOFFSET,                 'vpos',  CONTROL_VOFFSET-0*CONTROL_HEIGHT);
-ft_uilayout(fig, 'tag', 'sx',      'BackgroundColor', [0.8 0.8 0.8], 'width',  CONTROL_WIDTH,   'height',  CONTROL_HEIGHT, 'hpos',  CONTROL_HOFFSET+3*CONTROL_WIDTH, 'vpos',  CONTROL_VOFFSET-0*CONTROL_HEIGHT);
-ft_uilayout(fig, 'tag', 'sy',      'BackgroundColor', [0.8 0.8 0.8], 'width',  CONTROL_WIDTH,   'height',  CONTROL_HEIGHT, 'hpos',  CONTROL_HOFFSET+4*CONTROL_WIDTH, 'vpos',  CONTROL_VOFFSET-0*CONTROL_HEIGHT);
-ft_uilayout(fig, 'tag', 'sz',      'BackgroundColor', [0.8 0.8 0.8], 'width',  CONTROL_WIDTH,   'height',  CONTROL_HEIGHT, 'hpos',  CONTROL_HOFFSET+5*CONTROL_WIDTH, 'vpos',  CONTROL_VOFFSET-0*CONTROL_HEIGHT);
+ft_uilayout(fig, 'tag', 'scaleui', 'width',  2*CONTROL_WIDTH, 'height',  CONTROL_HEIGHT, 'hpos',  CONTROL_HOFFSET,                 'vpos',  CONTROL_VOFFSET+2*CONTROL_HEIGHT);
+ft_uilayout(fig, 'tag', 'sx',      'width',  CONTROL_WIDTH,   'height',  CONTROL_HEIGHT, 'hpos',  CONTROL_HOFFSET+3*CONTROL_WIDTH, 'vpos',  CONTROL_VOFFSET+2*CONTROL_HEIGHT);
+ft_uilayout(fig, 'tag', 'sy',      'width',  CONTROL_WIDTH,   'height',  CONTROL_HEIGHT, 'hpos',  CONTROL_HOFFSET+4*CONTROL_WIDTH, 'vpos',  CONTROL_VOFFSET+2*CONTROL_HEIGHT);
+ft_uilayout(fig, 'tag', 'sz',      'width',  CONTROL_WIDTH,   'height',  CONTROL_HEIGHT, 'hpos',  CONTROL_HOFFSET+5*CONTROL_WIDTH, 'vpos',  CONTROL_VOFFSET+2*CONTROL_HEIGHT);
 
 % translateui
-uicontrol('tag', 'translateui', 'parent',  fig, 'units', 'normalized', 'style', 'text', 'string', 'translate', 'callback', [])
+uicontrol('tag', 'translateui', 'parent',  fig, 'units', 'normalized', 'style', 'text', 'string', 'translate',  'callback', [])
 uicontrol('tag', 'tx',          'parent',  fig, 'units', 'normalized', 'style', 'edit', 'string', translate(1), 'callback', @cb_redraw)
 uicontrol('tag', 'ty',          'parent',  fig, 'units', 'normalized', 'style', 'edit', 'string', translate(2), 'callback', @cb_redraw)
 uicontrol('tag', 'tz',          'parent',  fig, 'units', 'normalized', 'style', 'edit', 'string', translate(3), 'callback', @cb_redraw)
-ft_uilayout(fig, 'tag', 'translateui', 'BackgroundColor', [0.8 0.8 0.8], 'width',  2*CONTROL_WIDTH, 'height',  CONTROL_HEIGHT, 'hpos',  CONTROL_HOFFSET,                 'vpos',  CONTROL_VOFFSET-1*CONTROL_HEIGHT);
-ft_uilayout(fig, 'tag', 'tx',          'BackgroundColor', [0.8 0.8 0.8], 'width',  CONTROL_WIDTH,   'height',  CONTROL_HEIGHT, 'hpos',  CONTROL_HOFFSET+3*CONTROL_WIDTH, 'vpos',  CONTROL_VOFFSET-1*CONTROL_HEIGHT);
-ft_uilayout(fig, 'tag', 'ty',          'BackgroundColor', [0.8 0.8 0.8], 'width',  CONTROL_WIDTH,   'height',  CONTROL_HEIGHT, 'hpos',  CONTROL_HOFFSET+4*CONTROL_WIDTH, 'vpos',  CONTROL_VOFFSET-1*CONTROL_HEIGHT);
-ft_uilayout(fig, 'tag', 'tz',          'BackgroundColor', [0.8 0.8 0.8], 'width',  CONTROL_WIDTH,   'height',  CONTROL_HEIGHT, 'hpos',  CONTROL_HOFFSET+5*CONTROL_WIDTH, 'vpos',  CONTROL_VOFFSET-1*CONTROL_HEIGHT);
+ft_uilayout(fig, 'tag', 'translateui', 'width',  2*CONTROL_WIDTH, 'height',  CONTROL_HEIGHT, 'hpos',  CONTROL_HOFFSET,                 'vpos',  CONTROL_VOFFSET+1*CONTROL_HEIGHT);
+ft_uilayout(fig, 'tag', 'tx',          'width',  CONTROL_WIDTH,   'height',  CONTROL_HEIGHT, 'hpos',  CONTROL_HOFFSET+3*CONTROL_WIDTH, 'vpos',  CONTROL_VOFFSET+1*CONTROL_HEIGHT);
+ft_uilayout(fig, 'tag', 'ty',          'width',  CONTROL_WIDTH,   'height',  CONTROL_HEIGHT, 'hpos',  CONTROL_HOFFSET+4*CONTROL_WIDTH, 'vpos',  CONTROL_VOFFSET+1*CONTROL_HEIGHT);
+ft_uilayout(fig, 'tag', 'tz',          'width',  CONTROL_WIDTH,   'height',  CONTROL_HEIGHT, 'hpos',  CONTROL_HOFFSET+5*CONTROL_WIDTH, 'vpos',  CONTROL_VOFFSET+1*CONTROL_HEIGHT);
+
+% alpha ui
+uicontrol('tag', 'alphaui', 'parent',  fig, 'units', 'normalized', 'style', 'text', 'string', 'alpha', 'value', [], 'callback', [], 'Visible', istrue(cfg.showalpha));
+uicontrol('tag', 'alpha',   'parent',  fig, 'units', 'normalized', 'style', 'edit', 'string', '0.6',   'value', [], 'callback', @cb_redraw, 'Visible', istrue(cfg.showalpha));
+ft_uilayout(fig, 'tag', 'alphaui',  'BackgroundColor', [0.8 0.8 0.8], 'width',  3*CONTROL_WIDTH, 'height',  CONTROL_HEIGHT, 'vpos',  CONTROL_VOFFSET-2*CONTROL_HEIGHT, 'hpos',  CONTROL_HOFFSET);
+ft_uilayout(fig, 'tag', 'alpha',    'BackgroundColor', [0.8 0.8 0.8], 'width',  3*CONTROL_WIDTH, 'height',  CONTROL_HEIGHT, 'vpos',  CONTROL_VOFFSET-2*CONTROL_HEIGHT, 'hpos',  CONTROL_HOFFSET+3*CONTROL_WIDTH);
 
 % control buttons
-uicontrol('tag', 'viewpointbtn',  'parent',  fig, 'units', 'normalized', 'style', 'popup',      'string', 'top|bottom|left|right|front|back', 'value',  1, 'callback', @cb_viewpoint);
-uicontrol('tag', 'redisplaybtn',  'parent',  fig, 'units', 'normalized', 'style', 'pushbutton', 'string', 'redisplay',    'value', [], 'callback', @cb_redisplay);
-uicontrol('tag', 'applybtn',      'parent',  fig, 'units', 'normalized', 'style', 'pushbutton', 'string', 'apply',        'value', [], 'callback', @cb_apply, 'visible', istrue(cfg.showapply));
-uicontrol('tag', 'toggle labels', 'parent',  fig, 'units', 'normalized', 'style', 'pushbutton', 'string', 'toggle label', 'value',  getappdata(fig, 'toggle_labels'), 'callback', @cb_redraw);
-uicontrol('tag', 'toggle axes',   'parent',  fig, 'units', 'normalized', 'style', 'pushbutton', 'string', 'toggle axes',  'value',  getappdata(fig, 'toggle_axes'),   'callback', @cb_redraw);
-uicontrol('tag', 'toggle grid',   'parent',  fig, 'units', 'normalized', 'style', 'pushbutton', 'string', 'toggle grid',  'value',  getappdata(fig, 'toggle_grid'),   'callback', @cb_redraw);
-uicontrol('tag', 'quitbtn',       'parent',  fig, 'units', 'normalized', 'style', 'pushbutton', 'string', 'quit',         'value',  1,  'callback', @cb_quit);
-ft_uilayout(fig, 'tag', 'viewpointbtn',   'BackgroundColor', [0.8 0.8 0.8], 'width',  6*CONTROL_WIDTH, 'height',  CONTROL_HEIGHT, 'vpos',  CONTROL_VOFFSET-2*CONTROL_HEIGHT, 'hpos',  CONTROL_HOFFSET);
-ft_uilayout(fig, 'tag', 'redisplaybtn',   'BackgroundColor', [0.8 0.8 0.8], 'width',  6*CONTROL_WIDTH, 'height',  CONTROL_HEIGHT, 'vpos',  CONTROL_VOFFSET-4*CONTROL_HEIGHT, 'hpos',  CONTROL_HOFFSET);
-ft_uilayout(fig, 'tag', 'applybtn',       'BackgroundColor', [0.8 0.8 0.8], 'width',  6*CONTROL_WIDTH, 'height',  CONTROL_HEIGHT, 'vpos',  CONTROL_VOFFSET-5*CONTROL_HEIGHT, 'hpos',  CONTROL_HOFFSET);
-ft_uilayout(fig, 'tag', 'toggle labels',  'BackgroundColor', [0.8 0.8 0.8], 'width',  6*CONTROL_WIDTH, 'height',  CONTROL_HEIGHT, 'vpos',  CONTROL_VOFFSET-6*CONTROL_HEIGHT, 'hpos',  CONTROL_HOFFSET);
-ft_uilayout(fig, 'tag', 'toggle axes',    'BackgroundColor', [0.8 0.8 0.8], 'width',  6*CONTROL_WIDTH, 'height',  CONTROL_HEIGHT, 'vpos',  CONTROL_VOFFSET-7*CONTROL_HEIGHT, 'hpos',  CONTROL_HOFFSET);
-ft_uilayout(fig, 'tag', 'toggle grid',    'BackgroundColor', [0.8 0.8 0.8], 'width',  6*CONTROL_WIDTH, 'height',  CONTROL_HEIGHT, 'vpos',  CONTROL_VOFFSET-8*CONTROL_HEIGHT, 'hpos',  CONTROL_HOFFSET);
-ft_uilayout(fig, 'tag', 'quitbtn',        'BackgroundColor', [0.8 0.8 0.8], 'width',  6*CONTROL_WIDTH, 'height',  CONTROL_HEIGHT, 'vpos',  CONTROL_VOFFSET-9*CONTROL_HEIGHT, 'hpos',  CONTROL_HOFFSET);
-
-if istrue(cfg.showalpha)
-  % alpha ui
-  uicontrol('tag', 'alphaui', 'parent',  fig, 'units', 'normalized', 'style', 'text', 'string', 'alpha', 'value', [], 'callback', []);
-  uicontrol('tag', 'alpha',   'parent',  fig, 'units', 'normalized', 'style', 'edit', 'string', '0.6', 'value', [], 'callback', @cb_redraw);
-  ft_uilayout(fig, 'tag', 'alphaui',  'BackgroundColor', [0.8 0.8 0.8], 'width',  3*CONTROL_WIDTH, 'height',  CONTROL_HEIGHT, 'vpos',  CONTROL_VOFFSET-3*CONTROL_HEIGHT, 'hpos',  CONTROL_HOFFSET);
-  ft_uilayout(fig, 'tag', 'alpha',    'BackgroundColor', [0.8 0.8 0.8], 'width',  3*CONTROL_WIDTH, 'height',  CONTROL_HEIGHT, 'vpos',  CONTROL_VOFFSET-3*CONTROL_HEIGHT, 'hpos',  CONTROL_HOFFSET+3*CONTROL_WIDTH);
-end
+uicontrol('tag', 'viewpointbtn',  'parent',  fig, 'units', 'normalized', 'style', 'popup',      'string', 'top|bottom|left|right|front|back', 'value', 1, 'callback', @cb_viewpoint);
+uicontrol('tag', 'camlightbtn',   'parent',  fig, 'units', 'normalized', 'style', 'popup',      'string', 'none|camlight|uniform',            'value', 1, 'callback', @cb_camlight, 'Visible', istrue(cfg.showlight));
+uicontrol('tag', 'axesbtn',       'parent',  fig, 'units', 'normalized', 'style', 'checkbox',   'string', 'axes',         'value', getappdata(fig, 'axes'),     'callback', @cb_axes);
+uicontrol('tag', 'labelsbtn',     'parent',  fig, 'units', 'normalized', 'style', 'checkbox',   'string', 'label',        'value', getappdata(fig, 'labels'),   'callback', @cb_labels);
+uicontrol('tag', 'gridbtn',       'parent',  fig, 'units', 'normalized', 'style', 'checkbox',   'string', 'grid',         'value', getappdata(fig, 'grid'),     'callback', @cb_grid);
+uicontrol('tag', 'redisplaybtn',  'parent',  fig, 'units', 'normalized', 'style', 'pushbutton', 'string', 'redisplay',    'value', [],                          'callback', @cb_redisplay);
+uicontrol('tag', 'applybtn',      'parent',  fig, 'units', 'normalized', 'style', 'pushbutton', 'string', 'apply',        'value', [],                          'callback', @cb_apply,    'Visible', istrue(cfg.showapply));
+uicontrol('tag', 'quitbtn',       'parent',  fig, 'units', 'normalized', 'style', 'pushbutton', 'string', 'quit',         'value', 1,                           'callback', @cb_quit);
+ft_uilayout(fig, 'tag', 'viewpointbtn',                                     'width',  6*CONTROL_WIDTH, 'height',  CONTROL_HEIGHT, 'vpos',  CONTROL_VOFFSET-3*CONTROL_HEIGHT, 'hpos',  CONTROL_HOFFSET);
+ft_uilayout(fig, 'tag', 'camlightbtn',                                      'width',  6*CONTROL_WIDTH, 'height',  CONTROL_HEIGHT, 'vpos',  CONTROL_VOFFSET-4*CONTROL_HEIGHT, 'hpos',  CONTROL_HOFFSET);
+ft_uilayout(fig, 'tag', 'axesbtn',                                          'width',  6*CONTROL_WIDTH, 'height',  CONTROL_HEIGHT, 'vpos',  CONTROL_VOFFSET-5*CONTROL_HEIGHT, 'hpos',  CONTROL_HOFFSET);
+ft_uilayout(fig, 'tag', 'labelsbtn',                                        'width',  6*CONTROL_WIDTH, 'height',  CONTROL_HEIGHT, 'vpos',  CONTROL_VOFFSET-6*CONTROL_HEIGHT, 'hpos',  CONTROL_HOFFSET);
+ft_uilayout(fig, 'tag', 'gridbtn',                                          'width',  6*CONTROL_WIDTH, 'height',  CONTROL_HEIGHT, 'vpos',  CONTROL_VOFFSET-7*CONTROL_HEIGHT, 'hpos',  CONTROL_HOFFSET);
+ft_uilayout(fig, 'tag', 'redisplaybtn',   'BackgroundColor', [0.8 0.8 0.8], 'width',  6*CONTROL_WIDTH, 'height',  CONTROL_HEIGHT, 'vpos',  CONTROL_VOFFSET-8*CONTROL_HEIGHT, 'hpos',  CONTROL_HOFFSET);
+ft_uilayout(fig, 'tag', 'applybtn',       'BackgroundColor', [0.8 0.8 0.8], 'width',  6*CONTROL_WIDTH, 'height',  CONTROL_HEIGHT, 'vpos',  CONTROL_VOFFSET-9*CONTROL_HEIGHT, 'hpos',  CONTROL_HOFFSET);
+ft_uilayout(fig, 'tag', 'quitbtn',        'BackgroundColor', [0.8 0.8 0.8], 'width',  6*CONTROL_WIDTH, 'height',  CONTROL_HEIGHT, 'vpos',  CONTROL_VOFFSET-10*CONTROL_HEIGHT, 'hpos',  CONTROL_HOFFSET);
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % SUBFUNCTION
@@ -400,6 +415,9 @@ transform      = getappdata(fig, 'transform');
 coordsys       = getappdata(fig, 'coordsys');
 unit           = getappdata(fig, 'unit');
 cfg            = getappdata(fig, 'cfg');
+
+% disable all GUI elements
+set(findall(fig, 'type', 'UIControl'), 'Enable', 'off')
 
 % get the transformation details
 rx = str2double(get(findobj(fig, 'tag', 'rx'), 'string'));
@@ -462,11 +480,11 @@ if istrue(template.axes)
 end
 
 if ~isempty(template.mri)
-  ft_plot_ortho(template.mri.anatomy, 'transform', template.mri.transform, 'unit', template.mri.unit, 'style', 'intersect', 'intersectmesh', individual.headshape, individual.mristyle{:});
+  ft_plot_ortho(template.mri.anatomy, 'transform', template.mri.transform, 'unit', template.mri.unit, 'style', 'intersect', 'intersectmesh', individual.headshape, template.mristyle{:});
 end
 
 if ~isempty(individual.mri)
-  ft_plot_ortho(individual.mri.anatomy, 'transform', individual.mri.transform, 'unit', individual.mri.unit, 'style', 'intersect', 'intersectmesh', template.headshape, template.mristyle{:});
+  ft_plot_ortho(individual.mri.anatomy, 'transform', individual.mri.transform, 'unit', individual.mri.unit, 'style', 'intersect', 'intersectmesh', template.headshape, individual.mristyle{:});
 end
 
 if ~isempty(template.elec)
@@ -525,27 +543,59 @@ if isstruct(individual.mesh) && isfield(individual.mesh, 'pos') && ~isempty(indi
   ft_plot_mesh(individual.mesh, individual.meshstyle{:});
 end
 
-if istrue(cfg.showlight)
-  % apply uniform light from all angles
-  lighting gouraud
-  l = lightangle(0,  90); set(l, 'Color', 0.45*[1 1 1])
-  l = lightangle(0, -90); set(l, 'Color', 0.45*[1 1 1])
-  l = lightangle(  0, 0); set(l, 'Color', 0.45*[1 1 1])
-  l = lightangle( 90, 0); set(l, 'Color', 0.45*[1 1 1])
-  l = lightangle(180, 0); set(l, 'Color', 0.45*[1 1 1])
-  l = lightangle(270, 0); set(l, 'Color', 0.45*[1 1 1])
-end
-
 if istrue(cfg.showalpha)
   % only apply the global alpha level when it is not explicitly set for the individual objects
   alpha(str2double(get(findobj(fig, 'tag', 'alpha'), 'string')));
 end
 
-if strcmp(get(h, 'tag'), 'toggle labels')
-  setappdata(fig, 'toggle_labels', ~getappdata(fig, 'toggle_labels'))
-end
+cb_camlight(h, []);
+cb_axes(h, []);
+cb_labels(h, []);
+cb_grid(h, []);
 
-if getappdata(fig, 'toggle_labels')
+% restore the current view
+view(az, el);
+
+% re-enable all GUI elements
+set(findall(fig, 'type', 'UIControl'), 'Enable', 'on')
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% SUBFUNCTION
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+function cb_camlight(h, eventdata)
+fig = getparent(h);
+delete(findall(fig, 'Type', 'light'));  % remove all existing lights
+switch get(findall(fig, 'tag', 'camlightbtn'), 'value')
+  case 1 % none
+    lighting none
+  case 2 % camlight
+    lighting gouraud
+    camlight
+  case 3 % uniform
+    lighting gouraud
+    uniformlight
+end
+uiresume;
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% SUBFUNCTION
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+function cb_axes(h, eventdata)
+fig = getparent(h);
+if get(findall(fig, 'tag', 'axesbtn'), 'value')
+  axis on
+else
+  axis off
+end
+uiresume;
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% SUBFUNCTION
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+function cb_labels(h, eventdata)
+fig  = getparent(h);
+unit = getappdata(fig, 'unit');
+if get(findall(fig, 'tag', 'labelsbtn'), 'value')
   xlabel(sprintf('x (%s)', unit))
   ylabel(sprintf('y (%s)', unit))
   zlabel(sprintf('z (%s)', unit))
@@ -554,29 +604,19 @@ else
   ylabel('')
   zlabel('')
 end
+uiresume;
 
-if strcmp(get(h, 'tag'), 'toggle axes')
-  setappdata(fig, 'toggle_axes', ~getappdata(fig, 'toggle_axes'))
-end
-
-if getappdata(fig, 'toggle_axes')
-  axis on
-else
-  axis off
-end
-
-if strcmp(get(h, 'tag'), 'toggle grid')
-  setappdata(fig, 'toggle_grid', ~getappdata(fig, 'toggle_grid'))
-end
-
-if getappdata(fig, 'toggle_grid')
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% SUBFUNCTION
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+function cb_grid(h, eventdata)
+fig = getparent(h);
+if get(findall(fig, 'tag', 'gridbtn'), 'value')
   grid on
 else
   grid off
 end
-
-% restore the current view
-view(az, el);
+uiresume;
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % SUBFUNCTION
@@ -628,6 +668,17 @@ end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % SUBFUNCTION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+function cb_help(h, eventdata)
+
+fprintf('\n');
+fprintf('==================================================================================\n');
+fprintf('Press "h" to show this help.\n');
+fprintf('Press "q" or close the window when you are done.\n');
+fprintf('Press "v" to update the light position.\n');
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% SUBFUNCTION
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 function cb_keyboard(h, eventdata)
 
 fig = getparent(h);
@@ -659,13 +710,12 @@ switch key
     
   case 'q'
     cb_quit(h);
+
+  case 'h'
+    cb_help(h);
     
   case 'v' % camlight angle reset
-    delete(findall(fig,'Type','light')) % shut out the lights
-    % add a new light from the current camera position
-    lighting gouraud
-    material shiny
-    camlight
+    cb_camlight(h);
     
   otherwise
     % do nothing
@@ -676,11 +726,9 @@ end % switch key
 % SUBFUNCTION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 function cb_redisplay(h, eventdata)
-
-fig       = getparent(h);
+fig = getparent(h);
 setappdata(fig, 'init', true);
 cb_redraw(h);
-
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % SUBFUNCTION
@@ -692,7 +740,6 @@ coordsys  = getappdata(fig, 'coordsys');
 
 % get the index of the option that was selected
 val = get(h, 'value');
-
 viewpoint = {'top', 'bottom', 'left', 'right', 'front', 'back'};
 setviewpoint(gca, coordsys, viewpoint{val});
 
@@ -702,13 +749,9 @@ uiresume;
 % SUBFUNCTION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 function cb_quit(h, eventdata)
-
 fig = getparent(h);
-setappdata(fig, 'cleanup',  true);
-
-% ensure to apply the current transformation
+setappdata(fig, 'cleanup', true); % ensure that it will apply the current transformation
 cb_apply(h);
-
 uiresume;
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -732,7 +775,7 @@ if ischar(style)
     case 'edge'
       style = {'vertexcolor', 'none', 'edgecolor', 'k', 'facecolor', 'none'};
     case 'surface'
-      style = {'vertexcolor', 'none', 'edgecolor', 'none', 'facecolor', 'skin', 'material', 'dull'};
+      style = {'vertexcolor', 'none', 'edgecolor', 'none', 'facecolor', 'skin'};
     case 'both'
       style = {'vertexcolor', 'none', 'edgecolor', 'k', 'facecolor', 'skin'};
     otherwise

--- a/ft_meshrealign.m
+++ b/ft_meshrealign.m
@@ -34,11 +34,11 @@ function [mesh_realigned] = ft_meshrealign(cfg, mesh)
 % displayed and you have to click on the fidicuals.
 %
 % When cfg.method = 'fiducial' you can specify
+%   cfg.mri            = structure, see FT_READ_MRI
+%   cfg.headmodel      = structure, see FT_PREPARE_HEADMODEL
 %   cfg.elec           = structure, see FT_READ_SENS
 %   cfg.grad           = structure, see FT_READ_SENS
 %   cfg.opto           = structure, see FT_READ_SENS
-%   cfg.headmodel      = structure, see FT_PREPARE_HEADMODEL
-%   cfg.mri            = structure, see FT_READ_MRI
 % If none of these is specified, the x-, y- and z-axes will be shown.
 %
 % To facilitate data-handling and distributed computing you can use

--- a/ft_meshrealign.m
+++ b/ft_meshrealign.m
@@ -3,9 +3,10 @@ function [mesh_realigned] = ft_meshrealign(cfg, mesh)
 % FT_MESHREALIGN rotates, translates and optionally scales a surface description of
 % the head or of the cortex. The different methods are described in detail below.
 %
-% INTERACTIVE - This displays the mesh surface together with the axis of the
-% coordinate system, and you manually (using the graphical user interface) adjust the
-% rotation, translation and scaling parameters.
+% INTERACTIVE - This displays the mesh surface together with an anatomical MRI, with
+% electrodes, with gradiometers, or simply with the axis of the coordinate system,
+% and you manually (using the graphical user interface) adjust the rotation,
+% translation and scaling parameters.
 %
 % FIDUCIAL - The coordinate system is updated according to the definition of the
 % coordinates of anatomical landmarks or fiducials that are specified in the
@@ -32,6 +33,15 @@ function [mesh_realigned] = ft_meshrealign(cfg, mesh)
 % mesh. If the fiducials are not specified in the configuration, the mesh is
 % displayed and you have to click on the fidicuals.
 %
+% When cfg.method = 'fiducial' you can specify
+%   cfg.elec           = structure, see FT_READ_SENS
+%   cfg.grad           = structure, see FT_READ_SENS
+%   cfg.opto           = structure, see FT_READ_SENS
+%   cfg.headmodel      = structure, see FT_PREPARE_HEADMODEL
+%   cfg.headshape      = structure, see FT_READ_HEADSHAPE
+%   cfg.mri            = structure, see FT_READ_MRI
+% If none of these is specified, the x-, y- and z-axes will be shown.
+%
 % To facilitate data-handling and distributed computing you can use
 %   cfg.inputfile   =  ...
 %   cfg.outputfile  =  ...
@@ -42,7 +52,7 @@ function [mesh_realigned] = ft_meshrealign(cfg, mesh)
 %
 % See also FT_READ_HEADSHAPE, FT_PREPARE_MESH, FT_ELECTRODEREALIGN, FT_VOLUMEREALIGN
 
-% Copyrights (C) 2017-2022, Robert Oostenveld
+% Copyrights (C) 2017-2023, Robert Oostenveld
 %
 % This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
 % for the documentation and details.
@@ -96,6 +106,12 @@ cfg.fiducial     = ft_getopt(cfg, 'fiducial');
 cfg.fiducial.nas = ft_getopt(cfg.fiducial, 'nas');
 cfg.fiducial.lpa = ft_getopt(cfg.fiducial, 'lpa');
 cfg.fiducial.rpa = ft_getopt(cfg.fiducial, 'rpa');
+cfg.headshape    = ft_getopt(cfg, 'headshape');
+cfg.headmodel    = ft_getopt(cfg, 'headmodel');
+cfg.elec         = ft_getopt(cfg, 'elec');
+cfg.grad         = ft_getopt(cfg, 'grad');
+cfg.opto         = ft_getopt(cfg, 'opto');
+cfg.mri          = ft_getopt(cfg, 'mri');
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % the actual computation is done in the middle part
@@ -111,12 +127,41 @@ switch cfg.method
 
     tmpcfg = [];
     tmpcfg.unit = mesh_realigned.unit;
-    tmpcfg.template.axes = 'yes';
-    tmpcfg.template.headshape.pos       = zeros(3,3);           % three vertices
-    tmpcfg.template.headshape.tri       = [1 2 3];              % one triangle
-    tmpcfg.template.headshape.unit      = mesh_realigned.unit;  % give it the same units
-    tmpcfg.template.headshape.coordsys  = cfg.coordsys;         % this is the target coordsys
-    tmpcfg.template.headshapestyle = {'vertexcolor', 'none', 'edgecolor', 'none', 'facecolor', 'none'};
+    tmpcfg.template = [];
+    if ~isempty(cfg.headshape)
+      tmpcfg.template.headshape = cfg.headshape;
+    end      
+    if ~isempty(cfg.headmodel)
+      tmpcfg.template.headmodel = cfg.headmodel;
+    end      
+    if ~isempty(cfg.elec)
+      tmpcfg.template.elec = cfg.elec;
+    end      
+    if ~isempty(cfg.grad)
+      tmpcfg.template.grad = cfg.grad;
+    end      
+    if ~isempty(cfg.opto)
+      tmpcfg.template.opto = cfg.opto;
+    end      
+    if ~isempty(cfg.mri)
+      tmpcfg.template.mri = cfg.mri;
+      % show the MRI with the intersection of the mesh
+      tmpcfg.showalpha = 'no';
+      tmpcfg.showlight = 'no';
+      tmpcfg.template.mristyle = {'facealpha', 1};
+      tmpcfg.individual.headshapestyle = {'facealpha', 0}; % this is for the mesh we are working on
+    end
+    if isempty(tmpcfg.template)
+      % only show the axes
+      tmpcfg.template.axes = 'yes';
+      tmpcfg.template.headshape.pos       = zeros(3,3);           % three vertices
+      tmpcfg.template.headshape.tri       = [1 2 3];              % one triangle
+      tmpcfg.template.headshape.unit      = mesh_realigned.unit;  % give it the same units
+      tmpcfg.template.headshape.coordsys  = cfg.coordsys;         % this is the target coordsys
+      tmpcfg.template.headshapestyle = {'vertexcolor', 'none', 'edgecolor', 'none', 'facecolor', 'none'};
+    end
+
+    % this is the object that is to be moved/rotated/scaled
     tmpcfg.individual.headshape = mesh_realigned;
     tmpcfg = ft_interactiverealign(tmpcfg);
     % keep the homogenous transformation

--- a/ft_meshrealign.m
+++ b/ft_meshrealign.m
@@ -4,9 +4,9 @@ function [mesh_realigned] = ft_meshrealign(cfg, mesh)
 % the head or of the cortex. The different methods are described in detail below.
 %
 % INTERACTIVE - This displays the mesh surface together with an anatomical MRI, with
-% electrodes, with gradiometers, or simply with the axis of the coordinate system,
-% and you manually (using the graphical user interface) adjust the rotation,
-% translation and scaling parameters.
+% a head model, with electrodes, with gradiometers, with optodes, or simply with the
+% axis of the coordinate system, and you manually (using the graphical user
+% interface) adjust the rotation, translation and scaling parameters.
 %
 % FIDUCIAL - The coordinate system is updated according to the definition of the
 % coordinates of anatomical landmarks or fiducials that are specified in the
@@ -38,7 +38,6 @@ function [mesh_realigned] = ft_meshrealign(cfg, mesh)
 %   cfg.grad           = structure, see FT_READ_SENS
 %   cfg.opto           = structure, see FT_READ_SENS
 %   cfg.headmodel      = structure, see FT_PREPARE_HEADMODEL
-%   cfg.headshape      = structure, see FT_READ_HEADSHAPE
 %   cfg.mri            = structure, see FT_READ_MRI
 % If none of these is specified, the x-, y- and z-axes will be shown.
 %
@@ -106,12 +105,11 @@ cfg.fiducial     = ft_getopt(cfg, 'fiducial');
 cfg.fiducial.nas = ft_getopt(cfg.fiducial, 'nas');
 cfg.fiducial.lpa = ft_getopt(cfg.fiducial, 'lpa');
 cfg.fiducial.rpa = ft_getopt(cfg.fiducial, 'rpa');
-cfg.headshape    = ft_getopt(cfg, 'headshape');
+cfg.mri          = ft_getopt(cfg, 'mri');
 cfg.headmodel    = ft_getopt(cfg, 'headmodel');
 cfg.elec         = ft_getopt(cfg, 'elec');
 cfg.grad         = ft_getopt(cfg, 'grad');
 cfg.opto         = ft_getopt(cfg, 'opto');
-cfg.mri          = ft_getopt(cfg, 'mri');
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % the actual computation is done in the middle part
@@ -128,9 +126,14 @@ switch cfg.method
     tmpcfg = [];
     tmpcfg.unit = mesh_realigned.unit;
     tmpcfg.template = [];
-    if ~isempty(cfg.headshape)
-      tmpcfg.template.headshape = cfg.headshape;
-    end      
+    if ~isempty(cfg.mri)
+      tmpcfg.template.mri = cfg.mri;
+      % show the MRI with the intersection of the mesh
+      tmpcfg.showalpha = 'no';
+      tmpcfg.showlight = 'no';
+      tmpcfg.template.mristyle = {'facealpha', 1};
+      tmpcfg.individual.headshapestyle = {'facealpha', 0}; % this is for the mesh that is to be moved/rotated/scaled
+    end
     if ~isempty(cfg.headmodel)
       tmpcfg.template.headmodel = cfg.headmodel;
     end      
@@ -143,14 +146,6 @@ switch cfg.method
     if ~isempty(cfg.opto)
       tmpcfg.template.opto = cfg.opto;
     end      
-    if ~isempty(cfg.mri)
-      tmpcfg.template.mri = cfg.mri;
-      % show the MRI with the intersection of the mesh
-      tmpcfg.showalpha = 'no';
-      tmpcfg.showlight = 'no';
-      tmpcfg.template.mristyle = {'facealpha', 1};
-      tmpcfg.individual.headshapestyle = {'facealpha', 0}; % this is for the mesh we are working on
-    end
     if isempty(tmpcfg.template)
       % only show the axes
       tmpcfg.template.axes = 'yes';
@@ -161,7 +156,7 @@ switch cfg.method
       tmpcfg.template.headshapestyle = {'vertexcolor', 'none', 'edgecolor', 'none', 'facecolor', 'none'};
     end
 
-    % this is the object that is to be moved/rotated/scaled
+    % this is the mesh that is to be moved/rotated/scaled
     tmpcfg.individual.headshape = mesh_realigned;
     tmpcfg = ft_interactiverealign(tmpcfg);
     % keep the homogenous transformation

--- a/plotting/ft_plot_headshape.m
+++ b/plotting/ft_plot_headshape.m
@@ -13,6 +13,7 @@ function hs = ft_plot_headshape(headshape, varargin)
 %
 % Optional arguments should come in key-value pairs and can include
 %   'facecolor'    = [r g b] values or string, for example 'brain', 'cortex', 'skin', 'black', 'red', 'r', or an Nx3 or Nx1 array where N is the number of faces
+%   'facealpha'    = transparency, between 0 and 1 (default = 1)
 %   'vertexcolor'  = [r g b] values or string, for example 'brain', 'cortex', 'skin', 'black', 'red', 'r', or an Nx3 or Nx1 array where N is the number of vertices
 %   'vertexsize'   = scalar value specifying the size of the vertices (default = 10)
 %   'fidcolor'     = [r g b] values or string, for example 'red', 'r', or an Nx3 or Nx1 array where N is the number of fiducials
@@ -83,6 +84,7 @@ end
 % get the optional input arguments
 vertexcolor = ft_getopt(varargin, 'vertexcolor',  defaultvertexcolor);
 facecolor   = ft_getopt(varargin, 'facecolor',    defaultfacecolor);
+facealpha   = ft_getopt(varargin, 'facealpha',    1);
 edgecolor   = ft_getopt(varargin, 'edgecolor',    defaultedgecolor);
 vertexsize  = ft_getopt(varargin, 'vertexsize',   10);
 material_   = ft_getopt(varargin, 'material');            % do not confuse with /Applications/MATLAB_R2020b.app/toolbox/matlab/graph3d/material.m
@@ -114,7 +116,7 @@ if ~holdflag
 end
 
 mesh = keepfields(headshape, {'pos', 'tri', 'tet', 'hex', 'color', 'unit', 'coordsys'});
-h  = ft_plot_mesh(mesh, 'vertexcolor', vertexcolor, 'vertexsize', vertexsize, 'facecolor', facecolor, 'edgecolor', edgecolor, 'material', material_, 'axes', axes_, 'tag', tag);
+h  = ft_plot_mesh(mesh, 'vertexcolor', vertexcolor, 'vertexsize', vertexsize, 'facecolor', facecolor, 'facealpha', facealpha, 'edgecolor', edgecolor, 'material', material_, 'axes', axes_, 'tag', tag);
 hs = [hs; h];
 
 if isfield(headshape, 'fid')

--- a/plotting/ft_plot_mesh.m
+++ b/plotting/ft_plot_mesh.m
@@ -117,14 +117,40 @@ contourlinewidth  = ft_getopt(varargin, 'contourlinewidth', 3);
 contourlinestyle  = ft_getopt(varargin, 'contourlinestyle', '-');
 
 haspos   = isfield(mesh, 'pos');   % vertices
+hascolor = isfield(mesh, 'color'); % color code for vertices
 hastri   = isfield(mesh, 'tri');   % triangles   as a Mx3 matrix with vertex indices
 hastet   = isfield(mesh, 'tet');   % tetraheders as a Mx4 matrix with vertex indices
 hashex   = isfield(mesh, 'hex');   % hexaheders  as a Mx8 matrix with vertex indices
-hasline  = isfield(mesh, 'line');  % line segments in 3-D
-haspoly  = isfield(mesh, 'poly');  % polygons describing a surface in 3-D
-hascolor = isfield(mesh, 'color'); % color code for vertices
+hasline  = isfield(mesh, 'line');  % lines       as a Mx2 matrix with vertex indices
+haspoly  = isfield(mesh, 'poly');  % polygons    as a MxP matrix with vertex indices
+
+if ~isempty(unit)
+  mesh = ft_convert_units(mesh, unit);
+end
+
+if hastri+hastet+hashex+hasline+haspoly>1
+  % the code further down cannot deal with simultaneous triangles, tetraheders and/or hexaheders
+  % therefore we plot them one by one
+  if hastri
+    ft_plot_mesh(removefields(mesh, {'tet', 'hex', 'line', 'poly'}), varargin{:});
+  end
+  if hastet
+    ft_plot_mesh(removefields(mesh, {'tri', 'hex', 'line', 'poly'}), varargin{:});
+  end
+  if hashex
+    ft_plot_mesh(removefields(mesh, {'tri', 'tet', 'line', 'poly'}), varargin{:});
+  end
+  if hasline
+    ft_plot_mesh(removefields(mesh, {'tri', 'tet', 'hex', 'poly'}), varargin{:});
+  end
+  if haspoly
+    ft_plot_mesh(removefields(mesh, {'tri', 'tet', 'hex', 'line'}), varargin{:});
+  end
+  return
+end
 
 if isempty(surfaceonly)
+  % set the default depending on the input mesh
   if hastet
     ft_warning('only visualizing the outer surface of the tetrahedral mesh, see the "surfaceonly" option')
     surfaceonly = true;
@@ -136,22 +162,20 @@ if isempty(surfaceonly)
   end
 end
 
-if ~isempty(unit)
-  mesh = ft_convert_units(mesh, unit);
-end
+% convert string into boolean values
+faceindex   = istrue(faceindex);   % yes=view the face number
+vertexindex = istrue(vertexindex); % yes=view the vertex number
+surfaceonly = istrue(surfaceonly); % yes/no
 
 if surfaceonly
   mesh = mesh2edge(mesh);
   % update the flags that indicate which surface/volume elements are present
-  hastri   = isfield(mesh, 'tri');  % triangles   as a Mx3 matrix with vertex indices
-  hastet   = isfield(mesh, 'tet');  % tetraheders as a Mx4 matrix with vertex indices
-  hashex   = isfield(mesh, 'hex');  % hexaheders  as a Mx8 matrix with vertex indices
-  haspoly  = isfield(mesh, 'poly'); % polygons
+  hastri   = isfield(mesh, 'tri');   % triangles   as a Mx3 matrix with vertex indices
+  hastet   = isfield(mesh, 'tet');   % tetraheders as a Mx4 matrix with vertex indices
+  hashex   = isfield(mesh, 'hex');   % hexaheders  as a Mx8 matrix with vertex indices
+  hasline  = isfield(mesh, 'line');  % lines       as a Mx2 matrix with vertex indices
+  haspoly  = isfield(mesh, 'poly');  % polygons    as a MxP matrix with vertex indices
 end
-
-% convert string into boolean values
-faceindex   = istrue(faceindex);   % yes=view the face number
-vertexindex = istrue(vertexindex); % yes=view the vertex number
 
 if isempty(vertexcolor)
   if haspos && hascolor && (hastri || hastet || hashex || hasline || haspoly)
@@ -221,12 +245,8 @@ else
 end
 
 if isempty(pos)
-  hs=[];
+  hs = [];
   return
-end
-
-if hastri+hastet+hashex+hasline+haspoly>1
-  ft_error('cannot deal with simultaneous triangles, tetraheders and/or hexaheders')
 end
 
 if hastri
@@ -281,7 +301,7 @@ if haspos
 end
 
 if ~isempty(material_)
-  material(material_); % dull, shiny or default
+  material(material_); % dull, default, shiny or metal
 end
 
 % the vertexcolor can be specified either as a RGB color for each vertex, or as a single value at each vertex
@@ -310,7 +330,7 @@ switch maskstyle
       % the color is indicated as a single character or as a single RGB triplet
       set(hs, 'FaceColor', facecolor);
     end
-    
+
     % facealpha is a scalar, or an vector matching the number of vertices
     if size(pos,1)==numel(facealpha)
       set(hs, 'FaceVertexAlphaData', facealpha);
@@ -319,29 +339,29 @@ switch maskstyle
       % the default is 1, so that does not have to be set
       set(hs, 'FaceAlpha', facealpha);
     end
-    
+
     if edgealpha~=1
       % the default is 1, so that does not have to be set
       set(hs, 'EdgeAlpha', edgealpha);
     end
-    
+
     if ~(all(facealpha==1) && edgealpha==1)
       if ~isempty(alphalim)
         alim(gca, alphalim);
       end
       alphamap(alphamapping);
     end
-    
+
   case 'colormix'
     % ensure facecolor to be 1x3
     assert(isequal(size(facecolor),[1 3]), 'facecolor should be 1x3');
-    
+
     % ensure facealpha to be nvertex x 1
     if numel(facealpha)==1
       facealpha = repmat(facealpha, size(pos,1), 1);
     end
     assert(isequal(numel(facealpha),size(pos,1)), 'facealpha should be %dx1', size(pos,1));
-    
+
     bgcolor = repmat(facecolor, [numel(vertexcolor) 1]);
     rgb     = bg_rgba2rgb(bgcolor, vertexcolor, cmap, clim, facealpha, alphamapping, alphalim);
     set(hs, 'FaceVertexCData', rgb, 'facecolor', 'interp');
@@ -351,7 +371,7 @@ end
 if ~isempty(contour)
   if ~iscell(contour), contour = {contour}; end
   if ~iscell(contourlinestyle), contourlinestyle = {contourlinestyle}; end
-  
+
   if ischar(contourcolor)
     if numel(contour)>numel(contourcolor)
       contourcolor = repmat(contourcolor(:), [numel(contour) 1]);
@@ -362,15 +382,15 @@ if ~isempty(contour)
   if size(contourcolor,2)==3 && numel(contour)>size(contourcolor,1), contourcolor = repmat(contourcolor, [numel(contour) 1] ); end
   if numel(contour)>numel(contourlinewidth), contourlinewidth = repmat(contourlinewidth, [1 numel(contour)]); end
   if numel(contour)>numel(contourlinestyle), contourlinestyle = repmat(contourlinestyle, [1 numel(contour)]); end
-  
+
   for m = 1:numel(contour)
     C    = full(triangle2connectivity(tri));
     clus = findcluster(contour{m},C,0);
-    
+
     for cl = 1:max(clus)
       idxcl = find(clus==cl);
       [xbnd, ybnd, zbnd] = extract_contour(pos,tri,idxcl,contour{m});
-      
+
       % draw each individual line segment of the intersection
       p = [];
       for i = 1:length(xbnd)
@@ -395,7 +415,7 @@ end
 
 if ~isequal(vertexcolor, 'none') && ~vertexpotential
   % plot the vertices as points
-  
+
   if isempty(vertexcolor)
     % use black for all points
     if isscalar(vertexsize)
@@ -418,7 +438,7 @@ if ~isequal(vertexcolor, 'none') && ~vertexpotential
         end
       end
     end
-    
+
   elseif ischar(vertexcolor) && numel(vertexcolor)==1
     % one color for all points
     if isscalar(vertexsize)
@@ -441,7 +461,7 @@ if ~isequal(vertexcolor, 'none') && ~vertexpotential
         end
       end
     end
-    
+
   elseif ischar(vertexcolor) && numel(vertexcolor)==size(pos,1)
     % one color for each point
     if size(pos,2)==2
@@ -463,7 +483,7 @@ if ~isequal(vertexcolor, 'none') && ~vertexpotential
         end
       end
     end
-    
+
   elseif ~ischar(vertexcolor) && size(vertexcolor,1)==1
     % one RGB color for all points
     if size(pos,2)==2
@@ -473,7 +493,7 @@ if ~isequal(vertexcolor, 'none') && ~vertexpotential
       hs = plot3(pos(:,1), pos(:,2), pos(:,3), vertexmarker);
       set(hs, 'MarkerSize', vertexsize, 'MarkerEdgeColor', vertexcolor);
     end
-    
+
   elseif ~ischar(vertexcolor) && size(vertexcolor,1)==size(pos,1) && size(vertexcolor,2)==3
     % one RGB color for each point
     if size(pos,2)==2
@@ -495,11 +515,11 @@ if ~isequal(vertexcolor, 'none') && ~vertexpotential
         end
       end
     end
-    
+
   else
     ft_error('Unknown color specification for the vertices');
   end
-  
+
 end % plotting the vertices as points
 
 if vertexindex

--- a/plotting/ft_plot_ortho.m
+++ b/plotting/ft_plot_ortho.m
@@ -19,6 +19,7 @@ function [hx, hy, hz] = ft_plot_ortho(dat, varargin)
 %
 % The following options are supported and passed on to FT_PLOT_SLICE
 %   'clim'                = [min max], lower and upper color limits
+%   'facealpha'           = 
 %   'transform'           = 4x4 homogeneous transformation matrix specifying the mapping from voxel space to the coordinate system in which the data are plotted
 %   'location'            = 1x3 vector specifying the intersection point at which the three slices will be plotted. The coordinates should be expressed in the coordinate system of the data. 
 %   'datmask'             = 3D-matrix with the same size as the matrix dat, serving as opacitymap if the second input argument to the function contains a matrix, this will be used as the mask
@@ -141,7 +142,7 @@ switch style
       % swap the first 2 dimensions because of meshgrid vs ndgrid issues
       varargin{2*sel} = ori(2,:);
       set(gcf,'currentaxes',Hx);
-      hx = ft_plot_slice(dat, varargin{:});
+      hx = ft_plot_slice(dat, varargin{:}, 'tag', 'x');
       set(Hx, 'view', [0 0]); %, 'xlim', [0.5 size(dat,1)-0.5], 'zlim', [0.5 size(dat,3)-0.5]);
       if isempty(parents)
         % only change axis behavior if no parents are specified
@@ -158,7 +159,7 @@ switch style
       end
       varargin{2*sel} = ori(1,:);
       set(gcf,'currentaxes',Hy);
-      hy = ft_plot_slice(dat, varargin{:});
+      hy = ft_plot_slice(dat, varargin{:}, 'tag', 'y');
       set(Hy, 'view', [90 0]); %, 'ylim', [0.5 size(dat,2)-0.5], 'zlim', [0.5 size(dat,3)-0.5]);
       if isempty(parents)
         % only change axis behavior if no parents are specified
@@ -175,7 +176,7 @@ switch style
       end
       varargin{2*sel} = ori(3,:);
       set(gcf,'currentaxes',Hz);
-      hz = ft_plot_slice(dat, varargin{:});
+      hz = ft_plot_slice(dat, varargin{:}, 'tag', 'z');
       set(Hz, 'view', [0 90]); %, 'xlim', [0.5 size(dat,1)-0.5], 'ylim', [0.5 size(dat,2)-0.5]);
       if isempty(parents)
         % only change axis behavior if no parents are specified
@@ -190,13 +191,14 @@ switch style
     end
     
     varargin{2*sel} = ori(1,:);
-    hx = ft_plot_slice(dat, varargin{:});
+    hx = ft_plot_slice(dat, varargin{:}, 'tag', 'x');
     
     varargin{2*sel} = ori(2,:);
-    hy = ft_plot_slice(dat, varargin{:});
+    hy = ft_plot_slice(dat, varargin{:}, 'tag', 'y');
     
     varargin{2*sel} = ori(3,:);
-    hz = ft_plot_slice(dat, varargin{:});
+    hz = ft_plot_slice(dat, varargin{:}, 'tag', 'z');
+
     axis equal; axis tight; axis vis3d; axis off
     view(3);
     

--- a/plotting/ft_plot_ortho.m
+++ b/plotting/ft_plot_ortho.m
@@ -19,7 +19,7 @@ function [hx, hy, hz] = ft_plot_ortho(dat, varargin)
 %
 % The following options are supported and passed on to FT_PLOT_SLICE
 %   'clim'                = [min max], lower and upper color limits
-%   'facealpha'           = 
+%   'facealpha'           = transparency when no mask is specified, between 0 and 1 (default = 1)
 %   'transform'           = 4x4 homogeneous transformation matrix specifying the mapping from voxel space to the coordinate system in which the data are plotted
 %   'location'            = 1x3 vector specifying the intersection point at which the three slices will be plotted. The coordinates should be expressed in the coordinate system of the data. 
 %   'datmask'             = 3D-matrix with the same size as the matrix dat, serving as opacitymap if the second input argument to the function contains a matrix, this will be used as the mask

--- a/plotting/ft_plot_slice.m
+++ b/plotting/ft_plot_slice.m
@@ -31,7 +31,7 @@ function [surfhandle, T2] = ft_plot_slice(dat, varargin)
 %   'interpmethod' = string specifying the method for the interpolation, see INTERPN (default = 'nearest')
 %   'colormap'     = string, see COLORMAP
 %   'clim'         = 1x2 vector specifying the min and max for the colorscale
-%   'facealpha'    = 
+%   'facealpha'    = transparency when no mask is specified, between 0 and 1 (default = 1)
 %
 % You can plot the slices from the volume together with an intersection of the slices
 % with a triangulated surface mesh (e.g. a cortical sheet) using

--- a/test/inspect_issue2216.m
+++ b/test/inspect_issue2216.m
@@ -47,3 +47,14 @@ cfg = [];
 cfg.method = 'interactive';
 cfg.mri = mri;
 ft_meshrealign(cfg, headshape)
+
+%%
+% this should now also work
+
+cfg = [];
+cfg.method = 'interactive';
+cfg.headmodel = [];
+cfg.headmodel.r = 92;
+cfg.headmodel.o = [0 0 40];
+ft_meshrealign(cfg, headshape)
+

--- a/test/inspect_issue2216.m
+++ b/test/inspect_issue2216.m
@@ -1,0 +1,49 @@
+function inspect_issue2216
+
+% WALLTIME 00:10:00
+% DEPENDENCY ft_meshrealign ft_interactiverealign ft_plot_ortho ft_plot_slice
+
+load(dccnpath('issue2216.mat')); % contains mri and headshape
+
+%%
+% one required change was to plot all three intersecting meshes without the first two being deleted
+
+f = figure;
+[hx, hy, hz] = ft_plot_ortho(mri, 'intersectmesh', headshape, 'style', 'subplot');
+
+%%
+
+f = figure;
+[hx, hy, hz] = ft_plot_ortho(mri, 'intersectmesh', headshape, 'style', 'intersect');
+
+
+%%
+% another was to allow the headshape to be transparent (or not) without having to use a global "alpha"
+
+f = figure;
+ft_plot_headshape(headshape, 'facealpha', 0.5);
+
+%%
+% another was to allow the mri to be transparent (or not) without having to use a global "alpha"
+
+f = figure;
+ft_plot_ortho(mri, 'style', 'intersect', 'facealpha', 0.5);
+
+%%
+% some changes were in ft_interactiverealign
+% the following should NOT show the global alpha
+
+cfg = [];
+cfg.template.mri = mri;
+cfg.template.mristyle = {'facealpha', 1.0};
+cfg.individual.headshape = headshape;
+cfg.individual.headshapestyle = {'facealpha', 1, 'material', 'dull'}; 
+ft_interactiverealign(cfg)
+
+%%
+% some changes in ft_meshrealign, which calls ft_interactiverealign
+
+cfg = [];
+cfg.method = 'interactive';
+cfg.mri = mri;
+ft_meshrealign(cfg, headshape)


### PR DESCRIPTION
- plot all three intersecting meshes with ft_plot_orho without the first two being deleted
- allow the headshape to be transparent (or not)
- allow the mri to be transparent (or not)
- change the default handling for showalpha in ft_interactiverealign
- added optodes to ft_interactiverealign for completeness
- don't change the material
- print help for interactive realign
- make camlight dropdown menu with none|camlight|uniform