### PR TITLE
ft_appendsens: use chantype when present for checking consistency

### DIFF
--- a/ft_appendsens.m
+++ b/ft_appendsens.m
@@ -61,7 +61,11 @@ end
 % do a basic check whether the senstype, units, and coordinate systems match
 senstype = cell(1,length(varargin));
 for i=1:length(varargin)
-  senstype{i} = ft_senstype(varargin{i});
+  if isfield(varargin{i}, 'chantype') && numel(unique(varargin{i}.chantype))==1
+    senstype{i} = varargin{i}.chantype{1};
+  else
+    senstype{i} = ft_senstype(varargin{i});
+  end
 end
 typematch = all(strcmp(senstype{1}, senstype));
 


### PR DESCRIPTION
ft_appendsens checks the consistency of the sensor sets prior to merging, one of the criteria being their 'type'. It uses ft_senstype for this purpose (around line 65). However, this does not always work reliably when the sensor set has labels that trip ft_senstype up in believing the sensor type is, for instance, ext1020 instead of eeg, such as may happen with the idiosyncratic labels typically used for iEEG electrodes/channels. I noticed it does this even when a chantype field is already present, ignoring the information contained by that field. I think a proper fix for this would involve some major consideration of what information ft_senstype (and ft_datatype_sens, for that matter) should prioritize for different modalities (also as a function of ft version, as seems to be another variable). In the meantime, the present PR makes ft_appendsens exploit information from the chantype field during the consistency check, diverting to ft_senstype when necessary.