### PR TITLE
Updated support for QZFM_UCL data #2130

### DIFF
--- a/fileio/ft_chantype.m
+++ b/fileio/ft_chantype.m
@@ -236,7 +236,7 @@ elseif isheader && issubfield(input, 'orig.chs.coil_type')
   for sel=find([input.orig.chs.kind]==602)' % Resp
     chantype(sel) = {'respiration'};
   end
-  
+
 elseif ft_senstype(input, 'babysquid74')
   % the name can be something like "MEG 001" or "MEG001" or "MEG 0113" or "MEG0113"
   % i.e. with two or three digits and with or without a space
@@ -308,7 +308,17 @@ elseif ft_senstype(input, 'ctf') && islabel
   chantype(sel) = {'refmag'};             % reference magnetometers
   sel = myregexp('^[GPQR][0-9][0-9]$', label);
   chantype(sel) = {'refgrad'};            % reference gradiometers
-  
+
+elseif isheader && ft_senstype(input,'QZFM_UCL')
+    chantype = input.orig.channels.type;
+    
+    sel = myregexp('^MEGMAG$', chantype);
+    chantype(sel) = {'megmag'};            % magnetometers
+    sel = myregexp('^MEGREFMAG$', chantype);
+    chantype(sel) = {'refmag'};            % reference magnetemeters
+    sel = myregexp('TRIG', chantype);
+    chantype(sel) = {'trigger'};           % trigger channels
+    
 elseif ft_senstype(input, 'bti')
   if isfield(input, 'orig') && isfield(input.orig, 'config')
     configname = {input.orig.config.channel_data.name};

--- a/fileio/ft_filetype.m
+++ b/fileio/ft_filetype.m
@@ -1271,7 +1271,10 @@ elseif filetype_check_extension(filename, '.nedf')
   type = 'neuroelectrics_nedf';
   manufacturer = 'Neurolectrics';
   content = 'EEG binary data (Enobio & Starstim)';
-
+elseif filetype_check_extension(filename, '.bin') && exist([filename(1:(end-4)) '.json'], 'file')
+  type = 'QZFM_UCL';
+  manufacturer = 'QuSpin';
+  content = 'OPM-MEG data';
   % some other known file types
 elseif filetype_check_extension(filename, '.hdf5')
   type = 'gtec_hdf5';

--- a/fileio/ft_read_data.m
+++ b/fileio/ft_read_data.m
@@ -1568,7 +1568,10 @@ switch dataformat
         dat(spikesel(i),j) = dat(spikesel(i),j) + 1;
       end
     end
-    
+   
+  case {'QZFM_UCL'}
+    dat = opm_fil(filename, hdr, begsample, endsample, chanindx);
+
   case 'read_nex_data' % this is an alternative reader for nex files
     dat = read_nex_data(filename, hdr, begsample, endsample, chanindx);
     

--- a/fileio/ft_read_header.m
+++ b/fileio/ft_read_header.m
@@ -2589,7 +2589,16 @@ switch headerformat
     end
     hdr.label = hdr.label(:);
     hdr.nChans = length(hdr.label);
-
+    
+  case {'QZFM_UCL'}
+      % Use the opm_fil function
+      hdr = opm_fil(filename);
+      % Fix the hdr.chantype using ft_chantype
+      hdr.chantype = ft_chantype(hdr);
+      % This is needed so ft_read_header doesn't over-ride with raw BIDS
+      % info
+      readbids = 'no';
+        
   case {'ricoh_ave', 'ricoh_con', 'ricoh_mrk'}
     % header can be read with Ricoh MEG Reader
     hdr = read_ricoh_header(filename);

--- a/test/test_issue1395.m
+++ b/test/test_issue1395.m
@@ -48,6 +48,14 @@ cfg.dataset = datafile;
 data = ft_preprocessing(cfg);
 
 %%
+% Test without specifying cfg.headerformat and cfg.dataformat and
+% cfg.eventformat
+cfg         = [];
+cfg.dataset = datafile;
+data_auto   = ft_preprocessing(cfg);
+clear data_auto
+
+%%
 
 cfg = [];
 cfg.headerformat = 'opm_fil';

--- a/utilities/ft_channelselection.m
+++ b/utilities/ft_channelselection.m
@@ -250,6 +250,7 @@ end
 
 if isempty(senstype)
   senstype = ft_senstype(datachannel);
+  disp(datachannel);
 end
 
 switch senstype
@@ -364,10 +365,10 @@ switch senstype
     % all itab MEG channels start with MAG
     labelmeg = datachannel(strncmp('MAG', datachannel, length('MAG')));
 
-  case{'qzfm_gen2'}
-    % This is for use with QZFM_Gen2 Optically Pumped Magnetometers manufactured by QuSpin Inc.
+  case{'QZFM_UCL'}
+    % This is for use with UCL-OPM Lab which uses QZFM Optically Pumped 
+    % % Magnetometers manufactured by QuSpin Inc. 
     % SPECS: https://quspin.com/qzfm-gen-2-update/
-
     labelmeg    = datachannel(strncmp('meg', datachantype, 3));
     labelmegref = datachannel(strncmp('refmag', datachantype, 3));
 

--- a/utilities/ft_channelselection.m
+++ b/utilities/ft_channelselection.m
@@ -250,7 +250,6 @@ end
 
 if isempty(senstype)
   senstype = ft_senstype(datachannel);
-  disp(datachannel);
 end
 
 switch senstype


### PR DESCRIPTION
#2130

- So we are now thinking of including HelmetManufacturer and HelmetManufacturersModelName in the json file. The latter would contain a text field with something like: 'slotnumber-56_location-wholehead_fit-custom'

- I have used the grad.type = 'QZFM_UCL' to differentiate ourselves from other facilities using QZFM sensors

All seems to work fine with existing test data.

- Issue: I can't seem to get ft_channelselection working without providing a third input argument (i.e. it's not picking up the senstype automatically for some reason)