### PR TITLE
Docstring fix: unsupported option

### DIFF
--- a/ft_statistics_montecarlo.m
+++ b/ft_statistics_montecarlo.m
@@ -27,7 +27,6 @@ function [stat, cfg] = ft_statistics_montecarlo(cfg, dat, design, varargin)
 %   cfg.wvar             = number or list with indices, within-cell variable(s)
 %   cfg.cvar             = number or list with indices, control variable(s)
 %   cfg.feedback         = string, 'gui', 'text', 'textbar' or 'no' (default = 'text')
-%   cfg.randomseed       = string, 'yes', 'no' or a number (default = 'yes')
 %
 % If you use a cluster-based statistic, you can specify the following options that
 % determine how the single-sample or single-voxel statistics will be thresholded and


### PR DESCRIPTION
`ft_montecarlostatistic` lists `cfg.randomseed` as an option in the docstring, which has no effect and is not used in the function. 

I deleted it - should there be a warning thrown if someone sets it?