### PR TITLE
ENH - small update to CTF channels.tsv

### DIFF
--- a/data2bids.m
+++ b/data2bids.m
@@ -1180,6 +1180,7 @@ if need_channels_tsv
 
   % there are some chanel types used in FieldTrip that are named differently in BIDS
   channels_tsv.type(strcmpi(channels_tsv.type, 'unknown'))     = {'OTHER'};
+  channels_tsv.type(strcmpi(channels_tsv.type, 'reserved'))    = {'OTHER'};
   channels_tsv.type(strcmpi(channels_tsv.type, 'clock'))       = {'SYSCLOCK'};
   channels_tsv.type(strcmpi(channels_tsv.type, 'meggrad'))     = {'MEGGRADAXIAL'};
   channels_tsv.type(strcmpi(channels_tsv.type, 'megplanar'))   = {'MEGGRADPLANAR'};


### PR DESCRIPTION
in an attempt to bidsify some CTF data, the bids-validator (v1.8.0, and v.1.12.0) complained about the formatting of the channels.tsv

the culprit seems to be the fact that the higher HLC channels (i.e. > 13) get the type 'reserved', copied over from the data's header. This value is not allowed in BIDS.

the suggested change is to translate the header's type 'reserved' into 'other'