### PR TITLE
TYPO - updated spelling Bonferoni into Bonferroni

### DIFF
--- a/test/test_tutorial_natmeg2014_statistics.m
+++ b/test/test_tutorial_natmeg2014_statistics.m
@@ -104,7 +104,7 @@ cfg.correctm  = 'no';
 TFR_stat1     = ft_freqstatistics(cfg, TFR_logpow);
 
 cfg.method    = 'analytic';
-cfg.correctm  = 'bonferoni';
+cfg.correctm  = 'bonferroni';
 TFR_stat2     = ft_freqstatistics(cfg, TFR_logpow);
 cfg.method    = 'analytic';
 cfg.correctm  = 'fdr';
@@ -182,7 +182,7 @@ cfg.correctm  = 'no';
 ERF_stat1     = ft_timelockstatistics(cfg, ERF_all);
 
 cfg.method    = 'analytic';
-cfg.correctm  = 'bonferoni';
+cfg.correctm  = 'bonferroni';
 ERF_stat2     = ft_timelockstatistics(cfg, ERF_all);
 
 cfg.method    = 'analytic';


### PR DESCRIPTION
this is a very minor change and should not have any functional consequences. Renamedval in ft_checkconfig seems already implemented