### PR TITLE
improve representation of events and triggers following fieldtrip2fiff

### DIFF
--- a/external/mne/fiff_write_events.m
+++ b/external/mne/fiff_write_events.m
@@ -35,7 +35,12 @@ eventlist = reshape(eventlist',numel(eventlist),1);
 %
 %   Start writing...
 %
-fid  = fiff_start_file(filename);
+if ischar(filename)
+  fid = fiff_start_file(filename);
+else
+  % assume the supplied filename to be a file identifier to an open file
+  fid = filename;
+end
 
 fiff_start_block(fid,FIFF.FIFFB_MNE_EVENTS);
     
@@ -46,4 +51,6 @@ end
 
 fiff_end_block(fid,FIFF.FIFFB_MNE_EVENTS);
 
-fiff_end_file(fid);
+if ischar(filename)
+  fiff_end_file(fid);
+end

--- a/fieldtrip2fiff.m
+++ b/fieldtrip2fiff.m
@@ -7,32 +7,39 @@ function fieldtrip2fiff(filename, data, varargin)
 %   fieldtrip2fiff(filename, data)
 % where filename is the name of the output file, and data is a raw data structure
 % as obtained from FT_PREPROCESSING, or a timelock structure obtained from
-% FT_TIMELOCKANALYSIS.
+% FT_TIMELOCKANALYSIS. If the input data is a raw data structure with a single
+% trial, a continuous fif-file will be written. If the input data contains multiple
+% trials, either in a timelock or raw format, and epoched fif-file will be written. 
+% If trials have different time axes, nans will be added to pad the trials to equal
+% length and time axis. If the input data contains an average across trials, an evoked
+% fif-file will be written.
 %
 % Additional options can be specified as key-value pairs:
-%   precision = string ('single'/'double'), determines the precision with which
-%               the numeric data is written to file, default is the class of the
-%               numeric data.
+%   precision = string ('single'/'double'), determines the precision with which the
+%               numeric data is written to file, default is the class of the data.
 %   coordsys  = string ('native'/'neuromag'), determines the coordinate system in which
 %               the MEG sensors are written (default = 'neuromag'). In case of 
-%               'neuromag' the MEG sensors are expressed in (approximate) neuroma^
+%               'neuromag' the MEG sensors are expressed in (approximate) neuromag
 %               coordinates, which may facilitate downstream handling of the fif-files
 %               in other software such as MNE-python. This is according to the
 %               official fif-file format definition. This option does not have an
 %               effect on EEG electrodes or fNIRS optodes.
-%   event     = structure as obtained from FT_READ_EVENT
+%   event     = structure as obtained from FT_READ_EVENT, note that the sampling in the
+%               event structure should be the same as the sampling of the data structure,
+%               i.e. the values in data.sampleinfo should be in line with event.sample, and
+%               the sampling rate should be the same. No check will be performed. Also, the 
+%               events will only be written to file if the input data is of type raw with
+%               a single trial.               
 %   eventtype = string or cell array of string with the event types to be
-%               written to file (default is all)
-% 
-% If the data comes from FT_PREPROCESSING and has only one trial, then it writes the
-% data into raw continuous format. 
+%               written to the continuous fif-file (default is all)
+%   hdr       = structure as obtained from FT_READ_HEADER
 % 
 % If present in the data, the original header is reused (also removing the non-used channels).
 % Otherwise, the function attempts to create the header, which might or might not be correct
-% (e.g. with respect to the scaling and the sensor locations. 
+% (e.g. with respect to the scaling and the sensor locations). 
 % 
-% The events are written in MNE format (three columns) into a file based on "filename", ending
-% with "-eve.fif".
+% The events are written in MNE format (three columns) into the continuous
+% fif-file, with a mapping string that allows for a richer interpretation of the events.
 % 
 % See also FT_DATATYPE_RAW, FT_DATATYPE_TIMELOCK
 
@@ -94,6 +101,9 @@ data   = ft_checkdata(data, 'datatype', {'raw', 'timelock'}, 'hassampleinfo', 'y
 istlck = ft_datatype(data, 'timelock') && isfield(data, 'avg');
 israw  = ft_datatype(data, 'raw') && numel(data.trial)==1;
 isepch = ft_datatype(data, 'timelock') || (ft_datatype(data, 'raw') && numel(data.trial)>1);
+if ~israw && ~isempty(event)
+  ft_error('events are only used for the writing of continuous files');
+end
 if isepch
   % this step ensures that all trials have a common time axis, and that variable length trials can 
   % be handled (injecting the shorter trials with NaNs)
@@ -266,6 +276,10 @@ if israw
     if ~isempty(eventtype)
       ft_info('Writing event matrix to %s\n', fifffile);
       [eventlist, mappings] = convertevent(event, eventtype);
+      
+      % adjust for the first sample in the data
+      eventlist(:,1) = eventlist(:,1) + 1 - data.sampleinfo(1);
+
       fiff_write_events(outfid, eventlist, mappings)
     end
   end

--- a/fieldtrip2fiff.m
+++ b/fieldtrip2fiff.m
@@ -365,13 +365,13 @@ end
 
 % FIXME: experimental attempt to assign digital trigger channels correctly
 % these are so far only from 4d or ctf systems
-i_labstim = strcmp(data.label, 'trigger');
+i_labstim = strcmp(ft_chantype(data.label), 'trigger');
 stype(i_labstim) = 2;
 %indx(i_labstim)  = i_stim;
 
 % FIXME: experimental attempt to assign digital response channels correctly
 % these are so far only from 4d or ctf systems
-i_labresp = strcmp(data.label, 'response');
+i_labresp = strcmp(ft_chantype(data.label), 'response');
 stype(i_labresp) = 3;
 %indx(i_labresp)  = i_resp;
 

--- a/fileio/ft_chantype.m
+++ b/fileio/ft_chantype.m
@@ -297,7 +297,7 @@ elseif ft_senstype(input, 'ctf') && isgrad
   chantype(sel) = {'refmag'};             % reference magnetometers
   sel = myregexp('^[GPQR][0-9][0-9]$', input.label);
   chantype(sel) = {'refgrad'};            % reference gradiometers
-  
+    
 elseif ft_senstype(input, 'ctf') && islabel
   % the channels have to be identified based on their name alone
   sel = myregexp('^M[ZLR][A-Z][0-9][0-9]$', label);
@@ -308,7 +308,13 @@ elseif ft_senstype(input, 'ctf') && islabel
   chantype(sel) = {'refmag'};             % reference magnetometers
   sel = myregexp('^[GPQR][0-9][0-9]$', label);
   chantype(sel) = {'refgrad'};            % reference gradiometers
-  
+  sel = myregexp('STIM', label);
+  chantype(sel) = {'trigger'};
+  sel = myregexp('UPPT001', label);
+  chantype(sel) = {'trigger'};
+  sel = myregexp('UPPT002', label);
+  chantype(sel) = {'response'};
+
 elseif ft_senstype(input, 'bti')
   if isfield(input, 'orig') && isfield(input.orig, 'config')
     configname = {input.orig.config.channel_data.name};
@@ -334,7 +340,8 @@ elseif ft_senstype(input, 'bti')
     chantype(configtype==2) = {'eeg'};
     chantype(configtype==3) = {'ref'}; % not known if mag or grad
     chantype(configtype==4) = {'aux'};
-    chantype(configtype==5) = {'trigger'};
+    chantype(configtype==5 & ~strcmp(configname, 'RESPONSE')) = {'trigger'};
+    chantype(configtype==5 &  strcmp(configname, 'RESPONSE')) = {'response'};
     
     % refine the distinction between refmag and refgrad to make the types
     % in grad and header consistent
@@ -353,7 +360,11 @@ elseif ft_senstype(input, 'bti')
     chantype(sel) = {'refmag'};
     sel = myregexp('^G[xyz][xyz]A$', label);
     chantype(sel) = {'refgrad'};
-    
+    sel = myregexp('STIMULUS', label);
+    chantype(sel) = {'trigger'};
+    sel = myregexp('RESPONSE', label);
+    chantype(sel) = {'response'};
+
     if isgrad && isfield(input, 'tra')
       gradtype = repmat({'unknown'}, size(input.label));
       gradtype(strncmp('A', input.label, 1)) = {'meg'};

--- a/fileio/ft_read_event.m
+++ b/fileio/ft_read_event.m
@@ -1772,7 +1772,6 @@ switch eventformat
       end
       tab   = tab(indx(indx>0),:);
       event = event(indx(indx>0));
-keyboard
 
     elseif isaverage
       % the length of each average can be variable

--- a/fileio/ft_read_event.m
+++ b/fileio/ft_read_event.m
@@ -1754,6 +1754,8 @@ switch eventformat
           % FIXME this needs to be done still
 
         end
+      catch
+        eventx = [];
       end
       event = appendstruct(event(:), eventx);
       

--- a/fileio/ft_read_header.m
+++ b/fileio/ft_read_header.m
@@ -1939,7 +1939,7 @@ switch headerformat
       catch
         % the "catch me" syntax is broken on MATLAB74, this fixes it
         me = lasterror;
-        if strcmp(me.identifier, 'MNE:fiff_read_epochs')
+        if strcmp(me.identifier, 'MNE:fiff_read_epochs') || strcmp(me.identifier, 'MNE:fiff_read_events')
           iscontinuous = 1;
         else
           rethrow(me)

--- a/fileio/ft_read_header.m
+++ b/fileio/ft_read_header.m
@@ -1939,7 +1939,7 @@ switch headerformat
       catch
         % the "catch me" syntax is broken on MATLAB74, this fixes it
         me = lasterror;
-        if strcmp(me.identifier, 'MNE:fiff_read_events')
+        if strcmp(me.identifier, 'MNE:fiff_read_epochs')
           iscontinuous = 1;
         else
           rethrow(me)

--- a/test/test_fieldtrip2fiff.m
+++ b/test/test_fieldtrip2fiff.m
@@ -144,7 +144,40 @@ datafif     = ft_preprocessing(cfg);
 assert(isequal(datafif.trial{1}, single(a1c)));
 
 %%
-% This section tests a bunch of MEG dataset, of different systems
+% This section checks whether event handling works to a certain extent
+% Use the 'Subject01.ds' dataset for basic testing of the writing and reading
+cfg         = [];
+cfg.dataset = fullfile(datadir, 'ctf151', 'Subject01.ds');
+cfg.channel = 'MEG';
+cfg.continuous = 'yes';
+data        = ft_preprocessing(cfg); % read in as a single chunk
+event       = ft_read_event(cfg.dataset); % as detected by fieldtrip
+
+fieldtrip2fiff(fullfile(savedir, 'data_without_stimchan_events.fif'), data);
+fieldtrip2fiff(fullfile(savedir, 'data_without_stimchan.fif'), data, 'event', event);
+
+cfg.channel = 'all';
+data        = ft_preprocessing(cfg);
+fieldtrip2fiff(fullfile(savedir, 'data_without_events.fif'), data);
+fieldtrip2fiff(fullfile(savedir, 'data.fif'), data, 'event', event);
+
+ev1 = ft_read_event(fullfile(savedir, 'data_without_stimchan_events.fif'));
+ev2 = ft_read_event(fullfile(savedir, 'data_without_stimchan.fif'));
+ev3 = ft_read_event(fullfile(savedir, 'data_without_events.fif'));
+ev4 = ft_read_event(fullfile(savedir, 'data.fif'));
+assert(numel(ev1)==0);
+assert(numel(ev2)==numel(event) && isequal([event.sample], [ev2.sample]));
+assert(numel(ev4)==numel(event) && isequal([event.sample], [ev4.sample]));
+assert(numel(ev3)==sum(strcmp({event.type},'STIM')));
+
+% delete the files again, they are pretty big
+delete(fullfile(savedir, 'data_without_stimchan_events.fif'));
+delete(fullfile(savedir, 'data_without_stimchan.fif'));
+delete(fullfile(savedir, 'data_without_events.fif'));
+delete(fullfile(savedir, 'data.fif'));
+
+%%
+% This section tests a bunch of MEG datasets, of different systems
 fname = {
   'bti148/c,rfhp0.1Hz'
   'bti248hcp/c,rfDC'

--- a/test/test_fieldtrip2fiff.m
+++ b/test/test_fieldtrip2fiff.m
@@ -2,6 +2,7 @@ function test_fieldtrip2fiff(mnedatadir)
 
 % WALLTIME 00:10:00
 % MEM 1gb
+% DEPENDENCY fieldtrip2fiff
 % DATA private
 
 %%


### PR DESCRIPTION
This PR intends to improve the writing of fif-files from FieldTrip, such that as much as possible information is retained:
-specifically: if a raw data structure with a single trial is written as a continuous file, and if there's a digital stim channel, the stim channel will be represented in the header such that it is correctly recognized as such upon reading the file into fieldtrip, which is good for ft_read_event
-also it is now possible to write an event(-like) structure into a fif-file, i.e. not as a companion <blabla>-eve.fif file, but directly into the bigger data file. I couldn't any documentation about whether this is not allowed, and it seems less random as compared to more arbitrary file naming conventions.
-note that only the sample index of the event is stored (along with a numeric code, and potentially a mapping that allows for a richer type/value definition). The offset and duration fields of a fieldtrip event structure can not be represented in the fif-file.

To be done:
-rearrange the code flow a bit to make it more generic (e.g. in the detection of stimulus channels), if possible
-add some checks and balance + ft_info (e.g. throw an error if an event structure is passed into the fieldtrip2fiff when the input data is not raw).