### PR TITLE
ft2fiff

### DIFF
--- a/fieldtrip2fiff.m
+++ b/fieldtrip2fiff.m
@@ -312,7 +312,16 @@ elseif isepch
   events = [((0:nsmp:(nsmp*(ntrl-1))))' zeros(ntrl,1) trg];
   vals = unique(trg);
   vals = [(1:numel(vals))' vals]';
-  eventid = sprintf('event%d: %d;',vals(:));
+
+  % remap the event values in the matrix to index into the unique values,
+  % to be able to the the reverse interpretation correctly
+  tmp = events(:,3);
+  for k = 1:numel(vals(2,:))
+    tmp(events(:,3)==vals(2,k)) = k;
+  end
+  events(:,3) = tmp;
+
+  eventid = sprintf('event_%d: %d,',vals(:));
   eventid = eventid(1:end-1); % remove the last comma
 
   epochs.epoch = data.trial;

--- a/fieldtrip2fiff.m
+++ b/fieldtrip2fiff.m
@@ -321,7 +321,7 @@ elseif isepch
   end
   events(:,3) = tmp;
 
-  eventid = sprintf('event_%d: %d,',vals(:));
+  eventid = sprintf('event_%d: %d;',vals(:));
   eventid = eventid(1:end-1); % remove the last comma
 
   epochs.epoch = data.trial;
@@ -550,7 +550,7 @@ end
 mappings  = '';
 eventlist = zeros(0,3);
 for k = 1:numel(ev)
-  mappings  = sprintf('%s, %s:%d', mappings, ev(k).id, k);
+  mappings  = sprintf('%s; %s:%d', mappings, ev(k).id, k);
 
   smp = ev(k).sample(:)-1; % in the fiff-file the samples are 0 based
   eventlist = cat(1, eventlist, [smp zeros(numel(smp),1) ones(numel(smp),1).*k]); 

--- a/fileio/ft_read_event.m
+++ b/fileio/ft_read_event.m
@@ -1731,7 +1731,14 @@ switch eventformat
 
         % convert the event matrix into a struct-array
         if ~isempty(mappings)
-          mappings = tokenize(mappings, ',')';
+          num_comma     = sum(hdr.orig.epochs.event_id==',');
+          num_semicolon = sum(hdr.orig.epochs.event_id==';');
+          if num_comma>num_semicolon
+            sep = ',';
+          else
+            sep = ';';
+          end
+          mappings = tokenize(mappings, sep)';
           for k = 1:numel(mappings)
             tok = tokenize(flip(deblank(flip(mappings{k},2)),2), ':');
             type{k,1} = tok{1};
@@ -1792,8 +1799,15 @@ switch eventformat
       end
       
     elseif isepoched
+      num_comma     = sum(hdr.orig.epochs.event_id==',');
+      num_semicolon = sum(hdr.orig.epochs.event_id==';');
+      if num_comma>num_semicolon
+        sep = ',';
+      else
+        sep = ';';
+      end      
       begsample = cumsum([1 repmat(hdr.nSamples, hdr.nTrials-1, 1)']);
-      events_id = reshape(split(split(hdr.orig.epochs.event_id, ','), ':'), [], 2); % should be nx2, avoids 2x1 in case of a single event_id
+      events_id = reshape(split(split(hdr.orig.epochs.event_id, sep), ':'), [], 2); % should be nx2, avoids 2x1 in case of a single event_id
       if all(cellfun(@ischar, events_id(:, 1))) && all(contains(events_id(:,1), '_'))
         % this assumes a numeric mapping between the numbers in the
         % events_id (second column) and the number after the '_' in the first column


### PR DESCRIPTION
fix regression test failure: event_id interpretation (parsing of string) based on either ',' or ';', made writing by default with ';', which seems how it should be.