### PR TITLE
FIX #2326 - fixed time range selection for select_topoplotER in ft_multiplotER

### DIFF
--- a/ft_multiplotER.m
+++ b/ft_multiplotER.m
@@ -52,17 +52,14 @@ function [cfg] = ft_multiplotER(cfg, varargin)
 %                       can be a single style for all datasets, or a cell-array containing one style for each dataset
 %   cfg.linewidth     = linewidth in points (default = 0.5)
 %   cfg.linecolor     = color(s) used for plotting the dataset(s). The default is defined in LINEATTRIBUTES_COMMON, see
-%                       the help of this function for more information
+%                       the help of this function for more information.
 %   cfg.directionality = '', 'inflow' or 'outflow' specifies for connectivity measures whether the
 %                       inflow into a node, or the outflow from a node is plotted. The (default) behavior
 %                       of this option depends on the dimord of the input data (see below).
 %   cfg.layout        = specify the channel layout for plotting using one of the supported ways (see below).
-%   cfg.select        = 'intersect' or 'union' (default = 'intersect')
-%                       with multiple input arguments determines the
-%                       pre-selection of the data that is considered for
-%                       plotting.
-%   cfg.viewmode      = 'layout', or 'butterfly' (default = 'layout'), using the spatial layout as in cfg.layout for the
-%                       visualisation, or a butterfly plot
+%   cfg.select        = 'intersect' or 'union' with multiple input arguments determines the
+%                       pre-selection of the data that is considered for plotting (default = 'intersect')
+%   cfg.viewmode      = 'topographic' or 'butterfly', whether to use the topographic channel layout or a butterfly plot (default = 'topographic')
 %
 % The following options for the scaling of the EEG, EOG, ECG, EMG, MEG and NIRS channels
 % is optional and can be used to bring the absolute numbers of the different
@@ -191,6 +188,7 @@ cfg = ft_checkconfig(cfg, 'renamedval', {'directionality', 'feedback', 'inflow'}
 cfg = ft_checkconfig(cfg, 'renamedval', {'directionality', 'feedforward', 'outflow'});
 cfg = ft_checkconfig(cfg, 'renamedval', {'zlim', 'absmax', 'maxabs'});
 cfg = ft_checkconfig(cfg, 'renamed',    {'newfigure', 'figure'});
+cfg = ft_checkconfig(cfg, 'renamedval', {'viewmode', 'layout', 'topographic'});
 % cfg = ft_checkconfig(cfg, 'deprecated', {'xparam'});
 
 % set the defaults
@@ -225,7 +223,7 @@ cfg.frequency      = ft_getopt(cfg, 'frequency',      'all'); % needed for frequ
 cfg.latency        = ft_getopt(cfg, 'latency',        'all'); % needed for latency selection with TFR data, FIXME, probably not used
 cfg.renderer       = ft_getopt(cfg, 'renderer');              % let MATLAB decide on the default
 cfg.select         = ft_getopt(cfg, 'select',         'intersect'); % for ft_selectdata
-cfg.viewmode       = ft_getopt(cfg, 'viewmode',       'layout');
+cfg.viewmode       = ft_getopt(cfg, 'viewmode',       'topographic');
 
 % some options constrain the default value for other options
 if isequal(cfg.linecolor, 'spatial')
@@ -429,14 +427,23 @@ end
 
 % Read or create the layout that will be used for plotting
 tmpcfg = keepfields(cfg, {'layout', 'channel', 'rows', 'columns', 'commentpos', 'skipcomnt', 'scalepos', 'skipscale', 'projection', 'viewpoint', 'rotate', 'width', 'height', 'elec', 'grad', 'opto', 'showcallinfo', 'trackcallinfo', 'trackusage', 'trackdatainfo', 'trackmeminfo', 'tracktimeinfo', 'checksize'});
-tmpcfg = ft_setopt(tmpcfg, 'color', cfg.linecolor);
 if isequal(cfg.viewmode, 'butterfly')
-  if isfield(tmpcfg, 'layout')
-    tmpcfg.layouttopo = tmpcfg.layout;
-  end
-  tmpcfg.layout     = 'butterfly';
+  % use channel colors matching the spatial locations by default
+  tmpcfg.color = ft_getopt(cfg, 'linecolor', 'spatial');
+  % create two layouts, one for butterfly and another for topographic
+  cfg.topolayout = ft_prepare_layout(tmpcfg, varargin{1}); % this will be passed to singleplot and topoplot
+  tmpcfg.layout = 'butterfly';
+  cfg.layout = ft_prepare_layout(tmpcfg, varargin{1});
+  % copy the topographic colors over to the butterfly layout
+  [chanindx1, chanindx2] = match_str(cfg.layout.label, cfg.topolayout.label);
+  cfg.layout.color = zeros(length(cfg.layout.label), 3); % RGB triplets
+  cfg.layout.color(chanindx1,:) = cfg.topolayout.color(chanindx2,:);
+else
+  % create only the topographic layout, use it for both
+  cfg.topolayout = ft_prepare_layout(tmpcfg, varargin{1}); % this will be passed to singleplot and topoplot
+  cfg.layout = cfg.topolayout;
 end
-cfg.layout = ft_prepare_layout(tmpcfg, varargin{1});
+
 
 % Take the subselection of channels that is contained in the layout, this is the same in all datasets
 [selchan, sellay] = match_str(varargin{1}.label, cfg.layout.label);
@@ -557,17 +564,22 @@ for m=1:length(selchan)
   end
 end % for number of channels
 
-% plot the layout, labels and outline
-ft_plot_layout(cfg.layout, 'box', cfg.box, 'label', cfg.showlabels, 'outline', cfg.showoutline, 'point', 'no', 'mask', 'no', 'fontsize', cfg.fontsize, 'labelyoffset', 1.4*median(cfg.layout.height/2), 'labelalignh', 'center', 'chanindx', find(~ismember(cfg.layout.label, {'COMNT', 'SCALE'})), 'interpreter', cfg.interpreter);
-if isfield(cfg.layout, 'layout')
+if strcmp(cfg.viewmode, 'topographic')
+  % plot the layout, labels and outline for each channel
+  ft_plot_layout(cfg.layout, 'box', cfg.box, 'label', cfg.showlabels, 'outline', cfg.showoutline, 'point', 'no', 'mask', 'no', 'fontsize', cfg.fontsize, 'labelyoffset', 1.4*median(cfg.layout.height/2), 'labelalignh', 'center', 'chanindx', find(~ismember(cfg.layout.label, {'COMNT', 'SCALE'})), 'interpreter', cfg.interpreter);
+elseif strcmp(cfg.viewmode, 'butterfly')
+  % plot the layout in the upper left corner
   hlim = get(gca, 'xlim');
   vlim = get(gca, 'ylim');
   hpos = hlim(1)+diff(hlim)*0.1;
   vpos = vlim(1)+diff(vlim)*0.9;
   h    = 0.2*diff(vlim);
   w    = 0.2*diff(hlim);
-  [i1, i2] = match_str(cfg.channel, cfg.layout.layout.label);
-  ft_plot_layout(cfg.layout.layout, 'box', 'no', 'label', 'off', 'point', 'yes', 'pointcolor', linecolor(i1, :), 'pointsize', 5, 'pointsymbol', 'o', 'hpos', hpos, 'vpos', vpos, 'height', h, 'width', w);
+  % the linecolor is sorted according to cfg.channel, the pointcolor should be according to the layout
+  [chanindx1, chanindx2] = match_str(cfg.topolayout.label, cfg.channel);
+  pointcolor = zeros(length(cfg.topolayout.label), 3);
+  pointcolor(chanindx1,:) = linecolor(chanindx2, :);
+  ft_plot_layout(cfg.topolayout, 'box', 'no', 'label', 'off', 'point', 'yes', 'pointcolor', pointcolor, 'pointsize', 5, 'pointsymbol', 'o', 'hpos', hpos, 'vpos', vpos, 'height', h, 'width', w, 'chanindx', chanindx1);
 end
 
 % write comment
@@ -639,12 +651,6 @@ set(gcf, 'NumberTitle', 'off');
 
 % Make the figure interactive
 if strcmp(cfg.interactive, 'yes')
-  if all(cfg.layout.pos(:,1)==cfg.layout.pos(1,1) & cfg.layout.pos(:,2)==cfg.layout.pos(2,2)) && isfield(cfg.layout, 'layout')
-    % it's a butterfly layout, which does not work well in interactive
-    % mode, replace it with the one that (hopefully) has topographical
-    % information
-    cfg.layout = cfg.layout.layout;
-  end
   % add the cfg/data/channel information to the figure under identifier linked to this axis
   ident                 = ['axh' num2str(round(sum(clock.*1e6)))]; % unique identifier for this axis
   set(gca, 'tag', ident);
@@ -710,7 +716,7 @@ ft_plot_text(hlim(1), vlim(2), [num2str(vlim(2), 3) ' '], placement{:}, 'Horizon
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% SUBFUNCTION which is called after selecting channels in case of cfg.interactive='yes'
+% SUBFUNCTION which is called after selecting channels with cfg.interactive='yes'
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 function select_singleplotER(label, varargin)
 % fetch cfg/data based on axis indentifier given as tag
@@ -729,7 +735,7 @@ if ~isempty(label)
   % ensure that the new figure appears at the same position
   cfg.figure = 'yes';
   cfg.position = get(gcf, 'Position');
-  
+  cfg.layout = cfg.topolayout; % in case cfg.viewmode='butterfly
   selchan = match_str(datvarargin{1}.label, cfg.channel);
   cfg.linecolor = linecolor(selchan, :, :); % make a subselection for the correct inheritance of the line colors
   ft_singleplotER(cfg, datvarargin{:});
@@ -745,7 +751,16 @@ ident    = get(gca, 'tag');
 info     = guidata(gcf);
 cfg      = info.(ident).cfg;
 varargin = info.(ident).varargin;
+
 if ~isempty(range)
+  % the range is not what it appears, since the figure was constructed with FT_PLOT_VECTOR
+  % this critically depends on AXIS TIGHT being done earlier
+  xlim_plot = get(gca, 'xlim');
+  xlim_real = varargin{1}.time([1 end]);
+  % map the range that was selected in the plot onto the real range of the data
+  p = polyfit(xlim_plot, xlim_real, 1);
+  range([1 2]) = polyval(p, range([1 2]));
+
   cfg = removefields(cfg, 'inputfile');   % the reading has already been done and varargin contains the data
   cfg = removefields(cfg, 'showlabels');  % this is not allowed in topoplotER
   cfg.baseline = 'no';                    % make sure the next function does not apply a baseline correction again
@@ -763,5 +778,7 @@ if ~isempty(range)
   % ensure that the new figure appears at the same position
   cfg.figure = 'yes';
   cfg.position = get(gcf, 'Position');
+  cfg.layout = cfg.topolayout; % use the topographic layout, not the butterfly layout
+
   ft_topoplotER(cfg, varargin{:});
 end

--- a/ft_prepare_layout.m
+++ b/ft_prepare_layout.m
@@ -72,8 +72,8 @@ function [layout, cfg] = ft_prepare_layout(cfg, data)
 %                      specificies channels to use for determining channel box size (default = 'all', recommended for MEG/EEG, a selection is recommended for iEEG)
 %   cfg.skipscale   = 'yes' or 'no', whether the scale should be included in the layout or not (default = 'no')
 %   cfg.skipcomnt   = 'yes' or 'no', whether the comment should be included in the layout or not (default = 'no')
-%   cfg.color       = 'spatial', Nx3 matrix, or [] (default). If not empty, an Nx3 color matrix will be added to the layout, based on the
-%                     positions of the electrodes, or based on the specified matrix
+%   cfg.color       = empty, 'spatial', or Nx3 matrix, if non-empty, an Nx3 color matrix based on the position 
+% %                   of the sensors will be added (default = [])
 %
 % If you use cfg.headshape or cfg.mri to create a headshape outline, the input
 % geometry should be expressed in the same units and coordinate system as the input
@@ -94,12 +94,6 @@ function [layout, cfg] = ft_prepare_layout(cfg, data)
 %   cfg.layout = 'circular'   will distribute the channels on a circle
 %   cfg.width  = scalar (default is automatic)
 %   cfg.height = scalar (default is automatic)
-%   cfg.layouttopo = filename or struct (default is empty)
-%
-% For a butterfly layout, the option cfg.layouttopo will add an extra field to the layout, containing the spatial layout
-% of the sensor array. This can be used to plot the spatial distribution of the color-coded channels, as in ft_multiplotER
-% with cfg.viewmode = 'butterfly'. If it's defined empty, but if the input data argument contains a sensor description, then it
-% will be created from this
 %
 % For an sEEG shaft the option cfg.layout='vertical' or 'horizontal' is useful to
 % represent the channels in a linear sequence . In this case you can also specify the
@@ -208,8 +202,7 @@ cfg.width        = ft_getopt(cfg, 'width',      []);
 cfg.height       = ft_getopt(cfg, 'height',     []);
 cfg.commentpos   = ft_getopt(cfg, 'commentpos', 'layout');
 cfg.scalepos     = ft_getopt(cfg, 'scalepos',   'layout');
-cfg.color        = ft_getopt(cfg, 'color');
-cfg.layouttopo   = ft_getopt(cfg, 'layouttopo', []);
+cfg.color        = ft_getopt(cfg, 'color',      []);
 
 if isempty(cfg.skipscale)
   if ischar(cfg.layout) && any(strcmp(cfg.layout, {'ordered', 'vertical', 'horizontal', 'butterfly', 'circular'}))
@@ -371,32 +364,26 @@ elseif isequal(cfg.layout, 'butterfly')
   layout.mask    = {};
   layout.outline = {};
   
-  layout.label{end+1}  = 'SCALE';
-  layout.pos(end+1, :) = layout.pos(1,:);
-  layout.width(end+1)  = layout.width(1);
-  layout.height(end+1) = layout.height(1);
-  
-  tmpcfg = removefields(cfg, {'layout' 'layouttopo'});
-  tmpcfg.skipscale = 'yes';
-  tmpcfg.skipcmnt  = 'yes';
-  if ~isempty(cfg.layouttopo)
-    tmpcfg.layout = cfg.layouttopo;
-  end
-  try
-    % failure may happen if the tmpcfg.layout = [], and if the data does
-    % not contain a sensor description.
-    tmplayout = ft_prepare_layout(tmpcfg, data);
-    layout.layout = tmplayout;
+  if ~istrue(cfg.skipscale)
+    layout.label{end+1}  = 'SCALE';
+    layout.pos(end+1, :) = layout.pos(1,:);
+    layout.width(end+1)  = layout.width(1);
+    layout.height(end+1) = layout.height(1);
   end
   
-  if isequal(cfg.color, 'spatial') && exist('tmplayout', 'var')
-    % this requires the 'normal' layout, so that the
-    % sensor positions can be used for the color coding
-    [chanindx1, chanindx2] = match_str(layout.label, tmplayout.label);
-    layout.color = zeros(numel(layout.label), 3);
-    layout.color(chanindx1, :) = tmplayout.color(chanindx2, :);
+  if strcmp(cfg.color, 'spatial')
+    try
+      % make one with the default settings to copy the spatial colors
+      tmpcfg = keepfields(cfg, {'channel', 'color', 'skipcomnt', 'skipscale'});
+      tmpcfg = ft_setopt(tmpcfg, 'showcallinfo', 'no');
+      tmpcfg = ft_setopt(tmpcfg, 'trackcallinfo', 'no');
+      tmplayout = ft_prepare_layout(tmpcfg, data);
+      layout.color = tmplayout.color;
+    catch
+      % it will fail if the data does not contain grad or elec
+      ft_warning('cannot determine spatial colors');
+    end
   end
-    
 
 elseif isequal(cfg.layout, 'vertical') || isequal(cfg.layout, 'horizontal')
   assert(iscell(cfg.channel), 'cfg.channel should be a cell-array of strings');
@@ -1223,9 +1210,9 @@ elseif ~isempty(cfg.output) && strcmpi(cfg.style, '3d')
 end
 
 if isequal(cfg.color, 'spatial') && ~isfield(layout, 'color')
-  % create a channel specific rgb-value based on their X/Y positions and a
+  % create a channel-specific RGB value based on their X/Y positions and a
   % computed Z position, assuming the channels on the positive half sphere
-  sel = match_str(layout.label, setdiff(layout.label,{'COMNT';'SCALE'}));
+  sel = match_str(layout.label, setdiff(layout.label, {'COMNT';'SCALE'}));
   xy  = sqrt(sum(layout.pos(sel,:).^2,2));
   z   = sqrt(max(xy).^2 - xy.^2);
   

--- a/plotting/ft_plot_layout.m
+++ b/plotting/ft_plot_layout.m
@@ -115,10 +115,21 @@ end
 
 % make a selection of the channels
 if ~isempty(chanindx)
+  nchan = length(layout.label);
   layout.pos    = layout.pos(chanindx,:);
   layout.width  = layout.width(chanindx);
   layout.height = layout.height(chanindx);
   layout.label  = layout.label(chanindx);
+  if numel(pointsymbol)==nchan
+    pointsymbol = pointsymbol(chanindx);
+  end
+  if numel(pointsize)==nchan
+    pointsize = pointsize(chanindx);
+  end
+  if size(pointcolor,1)==nchan
+    pointcolor = pointcolor(chanindx,:); % these are RGB triplets
+  end
+  clear nchan
 end
 
 % the units can be arbitrary (e.g. relative or pixels), so we need to compute the right scaling factor and offset

--- a/private/lineattributes_common.m
+++ b/private/lineattributes_common.m
@@ -9,17 +9,17 @@ function [linecolor, linestyle, linewidth] = lineattributes_common(cfg, varargin
 % 
 % It is not yet used by
 %   ft_connectivityplot
+%   ft_prepare_layout
 % 
 % Use as
-% 
-% [linecolor, linestyle, linewidth] = lineattributes_common(cfg, varargin)
+%   [linecolor, linestyle, linewidth] = lineattributes_common(cfg, varargin)
 % 
 % The input varargin are the data object(s) which are the input of the caller function.
 % The output consists of:
 % 
-%   linecolor = N x 3 x M matrix with rgb-values for N channels and M data arguments
-%   linestyle = N x M cell array with linestyle for N channels and M data arguments
-%   linewidth = N x M matrix with linewidth for N channels and M data arguments  
+%   linecolor = N x 3 x M matrix with RGB values for N channels and M data arguments
+%   linestyle = N x M     cell-array with linestyle for N channels and M data arguments
+%   linewidth = N x M     matrix with linewidth for N channels and M data arguments  
 % 
 % The configuration can have the following parameters:
 %   cfg.colorgroups = char or numeric vector determining whether the
@@ -35,7 +35,7 @@ function [linecolor, linestyle, linewidth] = lineattributes_common(cfg, varargin
 %   cfg.linewidth   = scalar, or NxM matrix
 %
 % If cfg.linecolor is a char, it should either be a sequence of characters that can be translated into
-% and rgb value (i.e. any of 'rbgcmykw'), or it can be 'spatial', in which case a color will be assigned
+% an RGB value (i.e., any of 'rbgcmykw'), or it can be 'spatial', in which case a color will be assigned
 % based on the layout.color field. Typically, this will be a color that is based on the x/y/z position of 
 % the corresponding sensor.
 
@@ -160,7 +160,7 @@ else
     linecolor = repmat(linecolor(1:Nchan,:), [1 1 Ndata]);
     
   elseif strcmp(cfg.colorgroups, 'allblack')
-    
+    % all channels are black, same across conditions
     linecolor = zeros(Nchan, 3, Ndata);
     
   elseif strcmp(cfg.colorgroups, 'chantype')
@@ -176,6 +176,10 @@ else
   elseif startsWith(cfg.colorgroups, 'labelchar')
     % channel groups are defined by the Nth letter of the channel label
     labelchar_num = sscanf(cfg.colorgroups, 'labelchar%d');
+    if isempty(labelchar_num)
+      ft_error('you must specify a number between 0 and 9 for N in labelcharN');
+    end
+
     vec_letters = num2str(zeros(Nchan,1));
     for iChan = 1:Nchan
       vec_letters(iChan) = label{iChan}(labelchar_num);

--- a/test/test_ft_prepare_layout.m
+++ b/test/test_ft_prepare_layout.m
@@ -11,7 +11,7 @@ function test_ft_prepare_layout
 interactive = false;
 
 % this corresponds to the ftp directory
-cd(dccnpath('/home/common/matlab/fieldtrip/data/ftp/tutorial/layout'));
+cd(dccnpath('/home/common/matlab/fioeldtrip/data/ftp/tutorial/layout'));
 
 %%
 % make it from a figure
@@ -30,7 +30,7 @@ end
 % channel 35 is at Fpz
 % the nose is along +Y
 
-clear all
+clear
 close all
 
 elec = ft_read_sens('easycap-M10.txt');
@@ -68,10 +68,10 @@ figure; ft_plot_layout(layout)
 % simple projection of CT151 gradiometers
 % the nose is along +X
 
-clear all
+clear
 close all
 
-load ctf151.mat % the mat files contains the variable "sens"
+sens = ft_read_sens('ctf151.mat');
 
 figure
 ft_plot_sens(sens, 'label', 'label', 'chantype', 'meggrad')
@@ -101,10 +101,10 @@ figure; ft_plot_layout(layout); title(cfg.projection)
 % simple projection of CT151 gradiometers
 % the nose is along +X
 
-clear all
+clear
 close all
 
-load ctf151.mat % the mat files contains the variable "sens"
+sens = ft_read_sens('ctf151.mat');
 
 figure
 ft_plot_sens(sens, 'label', 'label', 'chantype', 'meggrad')
@@ -139,10 +139,10 @@ figure; ft_plot_layout(layout)
 % simple projection of CT151 gradiometers
 % the nose is along +X
 
-clear all
+clear
 close all
 
-load ctf151.mat % the mat files contains the variable "sens"
+sens = ft_read_sens('ctf151.mat');
 
 figure
 ft_plot_sens(sens, 'label', 'label', 'chantype', 'meggrad')
@@ -183,10 +183,10 @@ figure; ft_plot_layout(layout); title(cfg.viewpoint);
 % WORKS if elec/grad and headshape contain the same coordsys
 % WORKS for most common coordsys options
 
-clear all
+clear
 close all
 
-load ctf151.mat % the mat files contains the variable "sens"
+sens = ft_read_sens('ctf151.mat');
 headshape = ft_read_headshape('Subject01.shape');
 headshape.coordsys = 'ctf';
 
@@ -230,10 +230,10 @@ figure; ft_plot_layout(layout); title(cfg.viewpoint)
 % WORKS if elec/grad and mri contain the same coordsys AND mri either has brain field or can be segmented on the fly (other segmentations can be achieved via ft_prepare_mesh and cfg.headshape)
 % WORKS for most common coordsys options
 
-clear all
+clear
 close all
 
-load ctf151.mat % the mat files contains the variable "sens"
+sens = ft_read_sens('ctf151.mat');
 load segmentedmri
 
 figure
@@ -315,7 +315,7 @@ figure; ft_plot_layout(layout); title(cfg.viewpoint)
 %%
 % test the non-topographic layouts
 
-clear all
+clear
 close all
 
 elec = ft_read_sens('easycap-M10.txt');
@@ -332,7 +332,7 @@ end
 
 %% test the ordered/horizontal/vertical layouts for iEEG
 
-clear all
+clear
 close all
 
 nchan = 10;

--- a/utilities/dccnpath.m
+++ b/utilities/dccnpath.m
@@ -55,11 +55,11 @@ assert(startsWith(filename, '/home/common/matlab/fieldtrip/data'));
 
 % alternative0 applies inside the DCCN network when using the standard data location
 if ispc
-  alternative0 = strrep(filename,'/home','H:');
-  alternative0 = strrep(alternative0,'/','\');
+  alternative0 = strrep(filename, '/home', 'H:');
+  alternative0 = strrep(alternative0, '/', '\');
 else
-  alternative0 = strrep(filename,'H:','/home');
-  alternative0 = strrep(alternative0,'\','/');
+  alternative0 = strrep(filename, 'H:', '/home');
+  alternative0 = strrep(alternative0, '\', '/');
 end
 
 if exist(alternative0, 'file') || exist(alternative0, 'dir')
@@ -68,23 +68,52 @@ if exist(alternative0, 'file') || exist(alternative0, 'dir')
   return
 end
 
-% alternative1 applies with a local file in the present working directory
+% the simple alternative1 applies with a local file in the present working directory
 % this is often convenient when initially setting up a new test script while the data is not yet uploaded
 [p, f, x] = fileparts(alternative0);
 alternative1 = [f x];
 
-if strcmp(alternative1, 'test')
-  % this should not be used when the filename is only "test", since that is too generic
-  warning('the name "test" is too generic')
-  alternative1 = '';
-elseif strcmp(alternative1, 'ctf')
-  % this should not be used when the filename is only "ctf", since that is too generic
-  warning('the name "ctf" is too generic')
+skip = {
+  % subdirectories like fieldtrip/xxx
+  'bin'
+  'compat'
+  'connectivity'
+  'contrib'
+  'external'
+  'fileio'
+  'forward'
+  'inverse'
+  'plotting'
+  'preproc'
+  'private'
+  'qsub'
+  'realtime'
+  'specest'
+  'src'
+  'statfun'
+  'template'
+  'test'
+  'trialfun'
+  'utilities'
+  % subdirectories like fieldtrip/template/xxx
+  'dewar'
+  'headmodel'
+  'sourcemodel'
+  'anatomy'
+  'electrode'
+  'layout'
+  'atlas'
+  'gradiometer'
+  'neighbours'
+  };
+if any(strcmp(alternative1, skip))
+  % this should not be used for subdirectories underneath fieldtrip
+  warning('the simple alternative1 cannot be used for "%s"', alternative1)
   alternative1 = '';
 end
 
 if exist(alternative1, 'file') || exist(alternative1, 'dir')
-  if ~isempty(x) && ~isequal(x,'.ds')   % if alternative1 is a file
+  if ~isempty(x) && ~isequal(x, '.ds')   % if alternative1 is a file
     filenamepath = which(alternative1); % also output the path that alternative1 is located at
     ft_notice('using present working directory %s', filenamepath);
     filename = filenamepath;


### PR DESCRIPTION
The problem reported by @RaoXie in #2326 was due to the time range selection assuming that the x-axis of the figure corresponded to the time scale of the data. That is not the case, as the figure is still constructed by plotting many channels on top of each other according to the butterfly layout.  Whenever a layout is involved ft_plot_vector makes use of local pseudo-axes.
 
Furthermore
- renamed viewmode layout into topographic
- do not recursively store the topographic layout in the butterfly layout
- added check and informative error for labelcharN
- make chanindx selection in pointsymbol, pointsize, pointcolor