### PR TITLE
implemented realtime interface for the Sensys FGM3D TD fluxgate magnetometer 

### DIFF
--- a/realtime/example/ft_realtime_sensysproxy.m
+++ b/realtime/example/ft_realtime_sensysproxy.m
@@ -1,0 +1,160 @@
+function ft_realtime_sensysproxy(cfg)
+
+% FT_REALTIME_SENSYSPROXY reads real-time continuous fluxgate magnetometer
+% data from the serial interface provided by the Sensis FGM3D TD
+% application and writes the data to the FieldTrip buffer.
+%
+% Use as
+%   ft_realtime_sensysproxy(cfg)
+%
+% The configuration should contain
+%   cfg.filename    = string, name of the serial port (default = 'COM2')
+%   cfg.blocksize   = number, in seconds (default = 0.1)
+%   cfg.fsample     = sampling frequency (default = 1000)
+%
+% The target to write the data to is configured as
+%   cfg.target.datafile      = string, target destination for the data (default = 'buffer://localhost:1972')
+%   cfg.target.dataformat    = string, default is determined automatic
+%
+% To stop this realtime function, you have to press Ctrl-C
+%
+% See also FT_REALTIME_SIGNALPROXY, FT_REALTIME_SIGNALVIEWER
+
+% Copyright (C) 2023, Robert Oostenveld
+%
+% This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
+% for the documentation and details.
+%
+%    FieldTrip is free software: you can redistribute it and/or modify
+%    it under the terms of the GNU General Public License as published by
+%    the Free Software Foundation, either version 3 of the License, or
+%    (at your option) any later version.
+%
+%    FieldTrip is distributed in the hope that it will be useful,
+%    but WITHOUT ANY WARRANTY; without even the implied warranty of
+%    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%    GNU General Public License for more details.
+%
+%    You should have received a copy of the GNU General Public License
+%    along with FieldTrip. If not, see <http://www.gnu.org/licenses/>.
+%
+% $Id$
+
+cfg = ft_checkconfig(cfg);
+
+% set the defaults
+cfg.filename          = ft_getopt(cfg, 'filename', 'COM2');
+cfg.baudrate          = ft_getopt(cfg, 'baudrate', 921600);
+cfg.blocksize         = ft_getopt(cfg, 'blocksize', 0.1);
+cfg.fsample           = ft_getopt(cfg, 'fsample', 400);
+cfg.target            = ft_getopt(cfg, 'target');
+cfg.target.datafile   = ft_getopt(cfg.target, 'datafile', 'buffer://localhost:1972');
+cfg.target.dataformat = ft_getopt(cfg.target, 'dataformat', []);
+
+% these are not used at the moment, the defaults seem to work fine
+cfg.databits    = 8;
+cfg.flowcontrol = 'none';
+cfg.stopbits    = 1;
+cfg.parity      = 'none';
+
+% ensure that each block is an integer number of samples
+cfg.blocksize = round(cfg.blocksize*cfg.fsample)/cfg.fsample;
+
+% share the configuration details with the callback function
+setappdata(0, 'cfg', cfg)
+
+% the unicorn uses the SPP protocol, i.e. serial-over-bluetooth
+% open the serial device
+sensys = serialport(cfg.filename, cfg.baudrate);
+
+%%
+% this takes care of cleanup
+
+cleanup = onCleanup(@()myCleanupFun(sensys));
+
+% make sure the persistent variables are not reused from the last call
+clear readSerialData
+
+%%
+% start the callback function, it processes each line
+
+configureTerminator(sensys, "LF");
+configureCallback(sensys, "terminator", @readSerialData);
+
+% keep running forever, or until Ctrl-C
+stopwatch = tic;
+while (toc(stopwatch)<Inf) && strcmp(sensys.Status, 'open')
+    pause(0.1);
+end
+
+end % function
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% SUBFUNCTION
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+function readSerialData(sensys, event)
+
+% this is called on every line/sample that is received
+% but the data is not written that fast, so we need a buffer
+persistent buffer nchan bufsize counter
+
+cfg = getappdata(0, 'cfg');
+
+if isempty(buffer)
+    nchan = 5;
+    bufsize = cfg.blocksize*cfg.fsample;
+    buffer = nan(nchan, bufsize);
+    counter = 0;
+end
+
+% The format is as follows:
+% 1353411242214;0.0010416524;-0.0010926605;0.0014391395;0.0020856819<CR><LF>
+%
+% The separate values have the following meanings:
+% Timestamp;Value Channel 1;Value Channel 2;Value Channel 3;Absolute Value<CR><LF>
+
+line = char(readline(sensys));
+line = strrep(line, ',', '.');
+counter = counter + 1;
+dat = str2double(split(line, ';'));
+
+buffer(:,rem(counter,bufsize)+1) = dat';
+
+if counter==bufsize
+    % after the first block
+    hdr = [];
+    hdr.Fs = cfg.fsample;
+    hdr.nChans = nchan;
+    hdr.nSamples = counter;
+    hdr.nSamplesPre = 0;
+    hdr.label = {'timestamp', 'x', 'y', 'z', 'abs'};
+    % flush the file, write the header and subsequently write the data segment
+    try
+        ft_write_data(cfg.target.datafile, buffer, 'header', hdr, 'dataformat', cfg.target.dataformat, 'append', false);
+    catch
+        myCleanupFun(sensys);
+    end
+    fprintf('wrote header and %d channels, %d samples\n', nchan, counter);
+elseif mod(counter,bufsize)==0
+    % after each subsequent block
+    % write the data segment
+    try
+        ft_write_data(cfg.target.datafile, buffer, 'append', true);
+    catch
+        myCleanupFun(sensys);
+    end
+    fprintf('wrote %d channels, %d samples\n', nchan, counter);
+end % if count==1
+
+end % function
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% SUBFUNCTION
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+function myCleanupFun(sensys)
+disp('cleanup');
+configureCallback(sensys, "off");
+disp('stopped')
+clear sensys
+clear readSerialData
+end % function

--- a/realtime/example/ft_realtime_unicornproxy.m
+++ b/realtime/example/ft_realtime_unicornproxy.m
@@ -86,8 +86,7 @@ setappdata(0, 'cfg', cfg)
 
 % the unicorn uses the SPP protocol, i.e. serial-over-bluetooth
 % open the serial device
-unicorn = serialport(cfg.filename, cfg.baudrate)
-
+unicorn = serialport(cfg.filename, cfg.baudrate);
 
 %%
 % this takes care of cleanup


### PR DESCRIPTION
The Sensys FGM3D TD software application has a serial output which can be connected to a virtual serial port. The `ft_realtime_sensysproxy` that I implemented and added with this commit connects to the other end, reads the ascii-formatted data stream, parses it, and writes it to a FieldTrip buffer. Another application can subsequently process the data. See also https://www.fieldtriptoolbox.org/development/realtime/

Note that I don't expect that we'll be using the FieldTrip buffer in the long run, but this is a first step for prototyping the closed loop implementation.

tagging @mirandanaaktgeboren, @namrolyat and @emidpag who are involved in this project.