### PR TITLE
FIX: t-value to p-value conversion in ft_regressconfound

### DIFF
--- a/ft_regressconfound.m
+++ b/ft_regressconfound.m
@@ -267,7 +267,7 @@ switch cfg.output
       covar      = diag(regr'*regr)';                                         % regressor covariance
       bvar       = repmat(mse',1,size(covar,2))./repmat(covar,size(mse,2),1); % beta variance
       tval       = (beta'./sqrt(bvar))';                                      % betas -> t-values
-      prob       = 2*(tcdf(-abs(tval),dfe));                                  % p-values
+      prob       = 2*(tcdf(-abs(tval),dfe));                                  % t-values -> p-values
       clear err dfe mse bvar
       dataout.stat = reshape(tval, [nconf dimsiz(datdim)]);
       dataout.prob = reshape(prob, [nconf dimsiz(datdim)]);

--- a/ft_regressconfound.m
+++ b/ft_regressconfound.m
@@ -267,9 +267,8 @@ switch cfg.output
       covar      = diag(regr'*regr)';                                         % regressor covariance
       bvar       = repmat(mse',1,size(covar,2))./repmat(covar,size(mse,2),1); % beta variance
       tval       = (beta'./sqrt(bvar))';                                      % betas -> t-values
-      prob       = (1-tcdf(tval,dfe))*2;                                      % p-values
+      prob       = 2*(tcdf(-abs(tval),dfe));                                  % p-values
       clear err dfe mse bvar
-      % FIXME: drop in replace tcdf from the statfun/private dir
       dataout.stat = reshape(tval, [nconf dimsiz(datdim)]);
       dataout.prob = reshape(prob, [nconf dimsiz(datdim)]);
       if haspermuted


### PR DESCRIPTION
The t-value to p-value conversion was missing an absolute operation, as also suggested here:
https://www.mathworks.com/matlabcentral/answers/175091-how-to-calculate-2-tailed-p-value-using-t-value-and-degree-of-freedom

Thanks to Ben Graul (Dartmouth College) for spotting the issue.