### PR TITLE
Use single quote

### DIFF
--- a/utilities/private/ft_test_update_dependency.m
+++ b/utilities/private/ft_test_update_dependency.m
@@ -52,7 +52,7 @@ for  i = 1:length(inlist)
     % Loop through each line to check if any line contains "% DEPENDENCY"
     containsDependency = false;
     for k = 1:numel(lines)
-        if contains(lines{k}, "% DEPENDENCY")
+        if contains(lines{k}, '% DEPENDENCY')
             containsDependency = true;
             break; 
         end


### PR DESCRIPTION
For backward compatibility with versions of MATLAB where the `string` class is not implemented.