### PR TITLE
Eyelink

### DIFF
--- a/fileio/ft_read_event.m
+++ b/fileio/ft_read_event.m
@@ -1166,14 +1166,23 @@ switch eventformat
     % contain more information than the 's' -events
     fnames = {'eblink', 'efix', 'esacc'};
     tnames = {'BLINK',  'FIX',  'SACC'};
+    if isfield(asc, 'msg') && istable(asc.msg) && size(asc.msg,2)==2
+      fnames(end+1) = {'msg'};
+      tnames(end+1) = {'MSG'};
+    end
     for k=1:length(fnames)
       if isfield(asc, fnames{k}) && ~isempty(asc.(fnames{k}))
         bfs = asc.(fnames{k});
 
         timestamp = bfs.stime;
         sample    = (timestamp-hdr.FirstTimeStamp)/hdr.TimeStampPerSample + 1;
-        value     = bfs.eye;
-        duration  = bfs.dur;
+        if ~strcmp(fnames{k}, 'msg')
+          value     = bfs.eye;
+          duration  = bfs.dur;
+        else
+          value     = bfs.message;
+          duration  = nan(size(bfs,1),1);
+        end
 
         % note that in this dataformat the first input trigger can be before
         % the start of the data acquisition

--- a/fileio/private/read_eyelink_asc.m
+++ b/fileio/private/read_eyelink_asc.m
@@ -219,6 +219,14 @@ if ~isempty(asc.esacc)
   end
 end
 
+% try to also convert the messages into a table, don't know how uniform
+% this is in general, but the below assumes a 3-column matrix
+if ~isempty(asc.msg)
+  try
+    asc.msg = totable(asc.msg(:,2:end), {'stime', 'message'}, 1);
+  end
+end
+
 function lineout = convertline(linein, msgflag)
 
 % split the line by horizontal tabs, and the first output element

--- a/ft_heartrate.m
+++ b/ft_heartrate.m
@@ -21,7 +21,9 @@ function [dataout] = ft_heartrate(cfg, datain)
 % For the 'findpeaks' method the following additional options can be specified
 %   cfg.envelopewindow   = scalar, time in seconds (default = 10)
 %   cfg.peakseparation   = scalar, time in seconds
-%   cfg.threshold        = scalar, usually between 0 and 1 (default = 0.4)
+%   cfg.threshold        = scalar, usually between 0 and 1 (default = 0.4), 'MinPeakHeight' parameter for findpeaks function
+%   cfg.mindistance      = scalar, time in seconds for the minimal distance between consecutive peaks (default = 0), 
+%                          'MinPeakDistance' for findpeaks functions (after conversion from seconds into samples)
 %   cfg.flipsignal       = 'yes' or 'no', whether to flip the polarity of the signal (default is automatic)
 % and the data can be preprocessed on the fly using
 %   cfg.preproc.bpfilter = 'yes' or 'no'
@@ -108,6 +110,7 @@ cfg.method           = ft_getopt(cfg, 'method', 'findpeaks');
 cfg.envelopewindow   = ft_getopt(cfg, 'envelopewindow', 10);  % in seconds
 cfg.peakseparation   = ft_getopt(cfg, 'peakseparation', []);  % in seconds
 cfg.threshold        = ft_getopt(cfg, 'threshold', 0.4);      % between 0 and 1
+cfg.mindistance      = ft_getopt(cfg, 'mindistance', 0);
 cfg.feedback         = ft_getopt(cfg, 'feedback', 'yes');
 cfg.preproc          = ft_getopt(cfg, 'preproc', []);
 cfg.flipsignal       = ft_getopt(cfg, 'flipsignal', []);
@@ -205,7 +208,7 @@ switch cfg.method
       end
       
       % find the sample numbers where the filtered value increases above the threshold
-      [vals, peaks] = findpeaks(dat, 'MinPeakHeight', cfg.threshold);
+      [vals, peaks] = findpeaks(dat, 'MinPeakHeight', cfg.threshold, 'MinPeakDistance', round(cfg.mindistance*fsample));
       
       if istrue(cfg.feedback)
         subplot(4,1,3)


### PR DESCRIPTION
In order to facilitate alignment between eyelink data, and data that has been simultaneously acquired on another acquisition system, it would be nice to have the 'msg' also represented as events (after ft_read_event). This PR creates 'msg' type events, based on the assumption that the messages are represented in the ascii file by a 'sample' column + a 'message' string.