### PR TITLE
FIX #2352 - open file using ASCII-US encoding

### DIFF
--- a/fileio/private/read_nervus_header.m
+++ b/fileio/private/read_nervus_header.m
@@ -34,7 +34,7 @@ UNITSIZE = 16;
 ITEMNAMESIZE  = 64;
 
 % ---------------- Opening File------------------
-h = fopen_or_error(filename,'rb','ieee-le');
+h = fopen_or_error(filename,'rb','ieee-le','US-ASCII');
 
 nrvHdr = struct();
 nrvHdr.filename = filename;


### PR DESCRIPTION
@schoffelen I wonder whether we should do this more explicitly for other file formats as well. We don't encounter this problem very often, but this certainly not the first time. 

At other places in the code we do it explicitly when reading, for example

```
char(fread(fid, 16, 'uint8=>char'))
```

I think that any piece of code that freads a `char` without explicit specification of the character encoding is at risk.  
 