### PR TITLE
ENH - allow ft_channelrepair to deal with neighboring bad channels

### DIFF
--- a/ft_channelrepair.m
+++ b/ft_channelrepair.m
@@ -19,8 +19,9 @@ function [data] = ft_channelrepair(cfg, data)
 %   cfg.order          = order of the polynomial interpolation (default = 4 for methods 'spline' and 'slap')
 %   cfg.senstype       = string, which type of data to repair. Can be 'meg', 'eeg' or 'nirs' (default is automatic)
 %
-% The weighted neighbour approach cannot be used reliably to repair multiple
-% bad channels that lie next to each other.
+% The weighted and average method are less reliably in case multiple bad channels lie
+% next to each other. In that case the bad channels will be removed from the
+% neighbours and not considered for interpolation.
 %
 % If you want to reconstruct channels that are absent in your data, those
 % channels may also be missing from the sensor definition (grad, elec or opto)
@@ -54,7 +55,7 @@ function [data] = ft_channelrepair(cfg, data)
 %
 % See also FT_MEGREALIGN, FT_MEGPLANAR, FT_PREPARE_NEIGHBOURS, FT_INTERPOLATENAN
 
-% Copyright (C) 2004-2009, Robert Oostenveld
+% Copyright (C) 2004-2024, Robert Oostenveld
 % Copyright (C) 2012-2013, Jörn M. Horschig, Jason Farquhar
 % Copyright (C) 2021, Jan-Mathijs Schoffelen
 
@@ -122,6 +123,14 @@ dtype = ft_datatype(data);
 % check if the input data is valid for this function
 data = ft_checkdata(data, 'datatype', 'raw', 'feedback', 'yes');
 
+% do a sanity check on the input configuration
+if ~isempty(cfg.missingchannel) && any(ismember(cfg.missingchannel, data.label))
+  ft_error('cfg.missingchannel is meant to specify channels that are NOT present in the input data structure, please use cfg.badchannel')
+end
+if ~isempty(cfg.missingchannel) && any(ismember(cfg.missingchannel, data.label))
+  ft_error('cfg.badchannel is meant to specify channels that ARE present in the input data structure, please use cfg.missingchannel ')
+end
+
 % select trials of interest
 tmpcfg = keepfields(cfg, {'trials', 'tolerance', 'showcallinfo', 'trackcallinfo', 'trackusage', 'trackdatainfo', 'trackmeminfo', 'tracktimeinfo', 'checksize'});
 data = ft_selectdata(tmpcfg, data);
@@ -143,7 +152,6 @@ if ismember(cfg.method, {'nan', 'average'})
 end
 
 if needsens
-  
   % sometimes the data can have both gradiometers, electrodes and/or optodes
   % but this function can only deal with one type of data at a time
   if isempty(cfg.senstype)
@@ -166,8 +174,8 @@ if needsens
   % this will prefer sens from cfg over sens from data
   sens = ft_fetch_sens(cfg, data);
   
-  % check if any of the channel positions contains NaNs; this happens when
-  % component data are backprojected to the sensor level
+  % check if any of the channel positions contains NaNs
+  % this happens when component data are backprojected to the sensor level
   if any(isnan(sens.chanpos(:)))
     ft_error('The channel positions contain NaNs; this prohibits correct behavior of the function. Please replace the input channel definition with one that contains valid channel positions');
   end
@@ -187,7 +195,7 @@ else
   isnirs = ft_senstype(data, 'opto');
   % determine the detailled type, e.g. ctf151 or neuromag122
   sensortype = ft_senstype(data);
-end
+end % if needsens
 
 if ismeg && ~any(strcmp(sensortype, {'ctf151', 'ctf275', 'bti148', 'bti248', 'babysquid74'}))
   % MEG systems with only magnetometers or axial gradiometers are easy, planar systems are not
@@ -217,6 +225,17 @@ interp.time    = data.time;
 
 switch cfg.method
   case {'weighted' 'average'}
+
+    for i=1:numel(cfg.neighbours)
+      sel = ismember(cfg.neighbours(i).neighblabel, cat(1, cfg.badchannel(:), cfg.missingchannel(:)));
+      if any(sel)
+        if ismember(cfg.neighbours(i).label, cat(1, cfg.badchannel(:), cfg.missingchannel(:)))
+          % only give the warning for the bad or missing channels, not for the good ones
+          ft_warning('removing bad or missing channel from the neighbour definition for "%s"', cfg.neighbours(i).label);
+        end
+        cfg.neighbours(i).neighblabel = cfg.neighbours(i).neighblabel(~sel);
+      end
+    end
     
     % first repair badchannels
     if ~isempty(cfg.badchannel)
@@ -260,7 +279,8 @@ switch cfg.method
         repair(k, list) = repair(k, list) ./ sum(repair(k, list));
       end
       
-      % use sparse matrix to speed up computations
+      % use a sparse matrix to speed up computations
+      % a side effect of the sparse multiplication is that nans on the bad channels are ignored
       repair = sparse(repair);
       
       % compute the missing data for each trial and set the ones that could not be reconstructed to nan
@@ -328,7 +348,8 @@ switch cfg.method
         repair(k, list) = repair(k, list) ./ sum(repair(k, list));
       end
       
-      % use sparse matrix to speed up computations
+      % use a sparse matrix to speed up computations
+      % a side effect of the sparse multiplication is that nans on the bad channels are ignored
       repair = sparse(repair);
       
       fprintf('\n');
@@ -347,7 +368,7 @@ switch cfg.method
     if ~isempty(cfg.badchannel) || ~isempty(cfg.missingchannel)
       fprintf('Spherical spline and surface Laplacian interpolation will treat bad and missing channels the same. Missing channels will be concatenated at the end of your data structure.\n');
     end
-    % subselect only those sensors that are in the data or in badchannel or missingchannel
+    % select only those sensors that are present in the data, in badchannel, or in missingchannel
     badchannels   = union(cfg.badchannel, cfg.missingchannel);
     sensidx       = ismember(sens.label, union(data.label, badchannels));
     label    = sens.label(sensidx);
@@ -380,7 +401,7 @@ switch cfg.method
     chanpos(missidx, :)                  = [];
     
     % select good channels only for interpolation
-    [goodchanlabels, goodindx] = setdiff(label, badchannels);
+    [goodchannels, goodindx] = setdiff(label, badchannels);
     allchans = false;
     if isempty(goodindx)
       goodindx = 1:numel(label);

--- a/ft_channelrepair.m
+++ b/ft_channelrepair.m
@@ -19,7 +19,7 @@ function [data] = ft_channelrepair(cfg, data)
 %   cfg.order          = order of the polynomial interpolation (default = 4 for methods 'spline' and 'slap')
 %   cfg.senstype       = string, which type of data to repair. Can be 'meg', 'eeg' or 'nirs' (default is automatic)
 %
-% The weighted and average method are less reliably in case multiple bad channels lie
+% The weighted and average method are less reliable in case multiple bad channels lie
 % next to each other. In that case the bad channels will be removed from the
 % neighbours and not considered for interpolation.
 %

--- a/ft_defaults.m
+++ b/ft_defaults.m
@@ -19,6 +19,7 @@ function ft_defaults
 %   ft_default.trackcallinfo     = string, can be 'yes' or 'no' (default = 'yes')
 %   ft_default.trackusage        = false, or string with salt for one-way encryption of identifying information (by default this is enabled and an automatic salt is created)
 %   ft_default.trackdatainfo     = string, can be 'yes' or 'no' (default = 'no')
+%   ft_default.keepprevious      = string, can be 'yes' or 'no' (default = 'yes')
 %   ft_default.outputfilepresent = string, can be 'keep', 'overwrite', 'error' (default = 'overwrite')
 %   ft_default.debug             = string, can be 'display', 'displayonerror', 'displayonsuccess', 'save', 'saveonerror', saveonsuccess' or 'no' (default = 'no')
 %   ft_default.toolbox.signal    = string, can be 'compat' or 'matlab' (default is automatic, see below)

--- a/ft_prepare_neighbours.m
+++ b/ft_prepare_neighbours.m
@@ -280,7 +280,6 @@ switch cfg.method
     neighbours = compneighbstructfromtri(chanpos, label, tri);
     
   case 'parcellation'
-    
     if ~isfield(data, cfg.parcellation)
       ft_error('required field %s not present in the input atlas', cfg.parcellation);
     end

--- a/test/test_ft_channelrepair.m
+++ b/test/test_ft_channelrepair.m
@@ -226,3 +226,53 @@ for tr=1:numel(data_eeg_interp.trial)
   end
 end
 
+%% part 4 - deal with bad channels that are neighbours of each other
+
+data_bad = [];
+data_bad.label = {'1', '2', '3', '4'};
+data_bad.trial{1} = zeros(4,1000);
+data_bad.trial{1}(1,:) = 1;
+data_bad.trial{1}(2,:) = nan;  % bad channel
+data_bad.trial{1}(3,:) = nan;  % bad channel
+data_bad.trial{1}(4,:) = 4;
+data_bad.time{1} = (1:1000)/1000;
+
+cfg = [];
+cfg.trials = 1;
+cfg.badchannel = []; % the nans will be auto-detected as bad
+cfg.method = 'average';
+
+cfg.neighbours(1).label = '1';
+cfg.neighbours(1).neighblabel = {'1', '2', '3', '4'};
+cfg.neighbours(2).label = '2';
+cfg.neighbours(2).neighblabel = {'1', '2', '3', '4'};
+cfg.neighbours(3).label = '3';
+cfg.neighbours(3).neighblabel = {'1', '2', '3', '4'};
+cfg.neighbours(4).label = '4';
+cfg.neighbours(4).neighblabel = {'1', '2', '3', '4'};
+
+data_repaired = ft_channelrepair(cfg, data_bad);
+
+% this is how it was before, the result is not what you would expect because the bad channels are neighbours of each other
+%
+% data_repaired.trial{1}(:,1)
+% ans =
+%      1
+%      0
+%      0
+%      4
+
+% this is how it is after updating the code such that bad channels are removed from the neighbours
+%
+% data_repaired.trial{1}(:,1)
+% ans =
+%     1.0000
+%     2.5000
+%     2.5000
+%     4.0000
+
+assert(data_repaired.trial{1}(1)==1)
+assert(data_repaired.trial{1}(2)==2.5)
+assert(data_repaired.trial{1}(3)==2.5)
+assert(data_repaired.trial{1}(4)==4)
+

--- a/utilities/dccnpath.m
+++ b/utilities/dccnpath.m
@@ -145,8 +145,8 @@ if ~isfield(ft_default, 'dccnpath') || isempty(ft_default.dccnpath)
 end
 
 % we do not want it to end with a '/' or '\'
-strip(ft_default.dccnpath, 'right', '/');
-strip(ft_default.dccnpath, 'right', '\');
+ft_default.dccnpath = strip(ft_default.dccnpath, 'right', '/');
+ft_default.dccnpath = strip(ft_default.dccnpath, 'right', '\');
 
 % alternative0 is the same as the input filename, but potentially updated for windows
 if ~ispc


### PR DESCRIPTION
@NataschaRoos and I came across the situation that we want to identify some bad channels in some trials, i.e. in a sparse way, where certain channels in certain trials are replaced by nans. Subsequently we want to interpolate them.

The interpolation goes like this:

```
for i=1:numel(data_bad.trial)
  cfg = [];
  cfg.trials = i;
  cfg.badchannel = []; % this will be autodetected based on nans
  data_repaired_singletrial{i} = ft_channelrepair(cfg, data_bad);
end

data_repaired = ft_appenddata([], data_repaired_singletrial{:});
```

However, we came across the situation that bad channels are neighbours. This pull request updates ft_channelrepair such that bad and missing channels are removed from the `cfg.neighbours` definition prior to interpolating.   