### PR TITLE
make splitting of label on "-" optional

### DIFF
--- a/data2bids.m
+++ b/data2bids.m
@@ -18,6 +18,10 @@ function [cfg] = data2bids(cfg, varargin)
 % data input argument allows you to write preprocessed electrophysiological data
 % and/or realigned and defaced anatomical MRI to disk.
 %
+% The implementation in this function aims to correspond to the latest BIDS version.
+% See https://bids-specification.readthedocs.io/ for the full specification
+% and http://bids.neuroimaging.io/ for further details.
+%
 % The configuration structure should contains
 %   cfg.method       = string, can be 'decorate', 'copy' or 'convert', see below (default is automatic)
 %   cfg.dataset      = string, filename of the input data
@@ -47,8 +51,8 @@ function [cfg] = data2bids(cfg, varargin)
 %
 % Although you can explicitly specify cfg.outputfile yourself, it is recommended to
 % use the following configuration options. This results in a BIDS compliant output
-% directory and file name. With these options data2bids will also write, or if
-% already present update the participants.tsv and scans.tsv files.
+% directory and file name. With these options data2bids will also write or, if
+% already present, update the participants.tsv and scans.tsv files.
 %   cfg.bidsroot                = string, top level directory for the BIDS output
 %   cfg.sub                     = string, subject name
 %   cfg.ses                     = string, optional session name
@@ -66,16 +70,45 @@ function [cfg] = data2bids(cfg, varargin)
 %   cfg.space                   = string
 %   cfg.desc                    = string
 %
-% When specifying the output directory in cfg.bidsroot, you can also specify
-% additional information to be added as extra columns in the participants.tsv and
-% scans.tsv files. For example:
+% If you specify cfg.bidsroot, this function will also write the dataset_description.json
+% file. Among others you can specify the following fields:
+%   cfg.dataset_description.writesidecar        = 'yes' or 'no' (default = 'yes')
+%   cfg.dataset_description.Name                = string
+%   cfg.dataset_description.BIDSVersion         = string
+%   cfg.dataset_description.License             = string
+%   cfg.dataset_description.Authors             = cell-array of strings
+%   cfg.dataset_description.ReferencesAndLinks  = cell-array of strings
+%   cfg.dataset_description.EthicsApprovals     = cell-array of strings
+%   cfg.dataset_description.Funding             = cell-array of strings
+%   cfg.dataset_description.Acknowledgements    = string
+%   cfg.dataset_description.HowToAcknowledge    = string
+%   cfg.dataset_description.DatasetDOI          = string
+%
+% If you specify cfg.bidsroot, you can also specify additional information to be
+% added as extra columns in the participants.tsv and scans.tsv files. For example:
 %   cfg.participants.age        = scalar
 %   cfg.participants.sex        = string, 'm' or 'f'
 %   cfg.scans.acq_time          = string, should be formatted according to RFC3339 as '2019-05-22T15:13:38'
 %   cfg.sessions.acq_time       = string, should be formatted according to RFC3339 as '2019-05-22T15:13:38'
 %   cfg.sessions.pathology      = string, recommended when different from healthy
-% In case any of these values is specified as empty (i.e. []) or as nan, it will be
-% written to the tsv file as 'n/a'.
+% If any of these values is specified as [] or as nan, it will be written to 
+% the tsv file as 'n/a'.
+%
+% General BIDS options that apply to all data types are
+%   cfg.InstitutionName             = string
+%   cfg.InstitutionAddress          = string
+%   cfg.InstitutionalDepartmentName = string
+%   cfg.Manufacturer                = string
+%   cfg.ManufacturersModelName      = string
+%   cfg.DeviceSerialNumber          = string
+%   cfg.SoftwareVersions            = string
+%
+% General BIDS options that apply to all functional data types are
+%   cfg.TaskName                    = string
+%   cfg.TaskDescription             = string
+%   cfg.Instructions                = string
+%   cfg.CogAtlasID                  = string
+%   cfg.CogPOID                     = string
 %
 % For anatomical and functional MRI data you can specify cfg.dicomfile to read the
 % detailed MRI scanner and sequence details from the header of that DICOM file. This
@@ -117,37 +150,7 @@ function [cfg] = data2bids(cfg, varargin)
 % it as cfg.opto or you can specify a filename with optode information.
 %   cfg.opto                    = structure with optode positions or filename,see FT_READ_SENS
 %
-% General BIDS options that apply to all data types are
-%   cfg.InstitutionName             = string
-%   cfg.InstitutionAddress          = string
-%   cfg.InstitutionalDepartmentName = string
-%   cfg.Manufacturer                = string
-%   cfg.ManufacturersModelName      = string
-%   cfg.DeviceSerialNumber          = string
-%   cfg.SoftwareVersions            = string
-%
-% If you specify cfg.bidsroot, this function will also write the dataset_description.json
-% file. Among others you can specify the following fields
-%   cfg.dataset_description.writesidecar        = 'yes' or 'no' (default = 'yes')
-%   cfg.dataset_description.Name                = string
-%   cfg.dataset_description.BIDSVersion         = string
-%   cfg.dataset_description.License             = string
-%   cfg.dataset_description.Authors             = cell-array of strings
-%   cfg.dataset_description.ReferencesAndLinks  = cell-array of strings
-%   cfg.dataset_description.EthicsApprovals     = cell-array of strings
-%   cfg.dataset_description.Funding             = cell-array of strings
-%   cfg.dataset_description.Acknowledgements    = string
-%   cfg.dataset_description.HowToAcknowledge    = string
-%   cfg.dataset_description.DatasetDOI          = string
-%
-% General BIDS options that apply to all functional data types are
-%   cfg.TaskName                    = string
-%   cfg.TaskDescription             = string
-%   cfg.Instructions                = string
-%   cfg.CogAtlasID                  = string
-%   cfg.CogPOID                     = string
-%
-% There are more BIDS options for the mri/meg/eeg/ieegÂ data type specific sidecars.
+% There are more BIDS options for the mri/meg/eeg/ieeg data type specific sidecars.
 % Rather than listing them all here, please open this function in the MATLAB editor,
 % and scroll down a bit to see what those are. In general the information in the JSON
 % files is specified by a field that is specified in CamelCase
@@ -156,17 +159,13 @@ function [cfg] = data2bids(cfg, varargin)
 %   cfg.eeg.SomeOption              = string, please check the MATLAB code
 %   cfg.ieeg.SomeOption             = string, please check the MATLAB code
 %   cfg.nirs.SomeOption             = string, please check the MATLAB code
-%   cfg.coordsystem.someoption      = string, please check the MATLAB code
+%   cfg.coordsystem.SomeOption      = string, please check the MATLAB code
 % The information for TSV files is specified with a column header in lowercase or
 % snake_case and represents a list of items
-%   cfg.channels.someoption         = cell-array, please check the MATLAB code
-%   cfg.events.someoption           = cell-array, please check the MATLAB code
-%   cfg.electrodes.someoption       = cell-array, please check the MATLAB code
-%   cfg.optodes.someoption          = cell-array, please check the MATLAB code
-%
-% The implementation in this function aims to correspond to the latest BIDS version.
-% See https://bids-specification.readthedocs.io/ for the full specification
-% and http://bids.neuroimaging.io/ for further details.
+%   cfg.channels.some_option        = cell-array, please check the MATLAB code
+%   cfg.events.some_option          = cell-array, please check the MATLAB code
+%   cfg.electrodes.some_option      = cell-array, please check the MATLAB code
+%   cfg.optodes.some_option         = cell-array, please check the MATLAB code
 %
 % See also FT_DATAYPE_RAW, FT_DATAYPE_VOLUME, FT_DATATYPE_SENS, FT_DEFINETRIAL,
 % FT_PREPROCESSING, FT_READ_MRI, FT_READ_EVENT
@@ -186,7 +185,7 @@ function [cfg] = data2bids(cfg, varargin)
 % officially supported data types.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-% Copyright (C) 2018-2023, Robert Oostenveld
+% Copyright (C) 2018-2024, Robert Oostenveld
 %
 % This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
 % for the documentation and details.
@@ -352,7 +351,6 @@ if istable(cfg.scans)
 end
 
 %% Dataset description
-
 cfg.dataset_description                     = ft_getopt(cfg, 'dataset_description'                       );
 cfg.dataset_description.writesidecar        = ft_getopt(cfg.dataset_description, 'writesidecar', 'yes'   );
 cfg.dataset_description.Name                = ft_getopt(cfg.dataset_description, 'Name'                  ); % REQUIRED. Name of the dataset.
@@ -366,14 +364,12 @@ cfg.dataset_description.Funding             = ft_getopt(cfg.dataset_description,
 cfg.dataset_description.EthicsApprovals     = ft_getopt(cfg.dataset_description, 'EthicsApprovals'       ); % OPTIONAL. List of ethics committee approvals of the research protocols and/or protocol identifiers.
 cfg.dataset_description.ReferencesAndLinks  = ft_getopt(cfg.dataset_description, 'ReferencesAndLinks'    ); % OPTIONAL. List of references to publication that contain information on the dataset, or links.
 cfg.dataset_description.DatasetDOI          = ft_getopt(cfg.dataset_description, 'DatasetDOI'            ); % OPTIONAL. The Document Object Identifier of the dataset (not the corresponding paper).
-
-% this is a structure, and in the json file an object
-default.Name        = 'FieldTrip';
-default.Version     = ft_version();
-default.Description = 'data2bids converter';
-default.URI         = 'https://www.fieldtriptoolbox.org';
-cfg.dataset_description.GeneratedBy         = ft_getopt(cfg.dataset_description, 'GeneratedBy', {default});
-clear default
+% GeneratedBy is here a MATLAB structure, and in the file a JSON object
+cfg.dataset_description.GeneratedBy             = ft_getopt(cfg.dataset_description, 'GeneratedBy', struct);
+cfg.dataset_description.GeneratedBy.Name        = ft_getopt(cfg.dataset_description.GeneratedBy, 'Name', 'FieldTrip');
+cfg.dataset_description.GeneratedBy.Version     = ft_getopt(cfg.dataset_description.GeneratedBy, 'Version', ft_version);
+cfg.dataset_description.GeneratedBy.Description = ft_getopt(cfg.dataset_description.GeneratedBy, 'Description', 'data2bids converter');
+cfg.dataset_description.GeneratedBy.URI         = ft_getopt(cfg.dataset_description.GeneratedBy, 'URI', 'https://www.fieldtriptoolbox.org');
 
 %% Generic fields for all data types
 cfg.TaskName                          = ft_getopt(cfg, 'TaskName'                    ); % REQUIRED. Name of the task (for resting state use the 'rest' prefix). Different Tasks SHOULD NOT have the same name. The Task label is derived from this field by removing all non alphanumeric ([a-zA-Z0-9]) characters.

--- a/fileio/ft_read_header.m
+++ b/fileio/ft_read_header.m
@@ -2942,6 +2942,14 @@ hdr.label = fixlabels(hdr.label);
 if isfield(hdr, 'chantype'), hdr.chantype = fixchantype(hdr.chantype); end
 if isfield(hdr, 'chanunit'), hdr.chanunit = fixchanunit(hdr.chanunit); end
 
+% ensure that these are double precision and not integers, otherwise
+% subsequent computations that depend on these might be messed up
+hdr.Fs          = double(hdr.Fs);
+hdr.nSamples    = double(hdr.nSamples);
+hdr.nSamplesPre = double(hdr.nSamplesPre);
+hdr.nTrials     = double(hdr.nTrials);
+hdr.nChans      = double(hdr.nChans);
+
 if ~isempty(splitlabel) && istrue(splitlabel)
   % this is default for CTF and FieldLine v3
   for i=1:numel(hdr.label)
@@ -2965,14 +2973,6 @@ if ~isempty(splitlabel) && istrue(splitlabel)
   end
 end
 
-% ensure that these are double precision and not integers, otherwise
-% subsequent computations that depend on these might be messed up
-hdr.Fs          = double(hdr.Fs);
-hdr.nSamples    = double(hdr.nSamples);
-hdr.nSamplesPre = double(hdr.nSamplesPre);
-hdr.nTrials     = double(hdr.nTrials);
-hdr.nChans      = double(hdr.nChans);
-
 if inflated
   % compressed file has been unzipped on the fly, clean up
   if strcmp(headerformat, 'brainvision_vhdr')
@@ -2990,6 +2990,7 @@ if cache && exist(headerfile, 'file')
   cacheheader.details = dir(headerfile);
   % fprintf('added header to cache\n');
 end
+
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % SUBFUNCTION to determine the file size in bytes

--- a/fileio/ft_read_header.m
+++ b/fileio/ft_read_header.m
@@ -17,6 +17,7 @@ function [hdr] = ft_read_header(filename, varargin)
 %   'headerformat'   = name of a MATLAB function that takes the filename as input (default is automatic)
 %   'password'       = password structure for encrypted data set (for dhn_med10, mayo_mef30, mayo_mef21)
 %   'readbids'       = string, 'yes', no', or 'ifmakessense', whether to read information from the BIDS sidecar files (default = 'ifmakessense')
+%   'splitlabel'     = string, 'yes' or 'no', split the channel labels on the '-' and return the first part (default = 'yes' for CTF and FieldLine, 'no' for others)
 %
 % This returns a header structure with the following fields
 %   hdr.Fs          = sampling frequency
@@ -96,7 +97,7 @@ function [hdr] = ft_read_header(filename, varargin)
 % See also FT_READ_DATA, FT_READ_EVENT, FT_WRITE_DATA, FT_WRITE_EVENT,
 % FT_CHANTYPE, FT_CHANUNIT
 
-% Copyright (C) 2003-2021 Robert Oostenveld
+% Copyright (C) 2003-2024 Robert Oostenveld
 %
 % This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
 % for the documentation and details.
@@ -190,6 +191,7 @@ coildeffile    = ft_getopt(varargin, 'coildeffile');      % empty, or a filename
 chantype       = ft_getopt(varargin, 'chantype', {});
 password       = ft_getopt(varargin, 'password', struct([]));
 readbids       = ft_getopt(varargin, 'readbids', 'ifmakessense');
+splitlabel     = ft_getopt(varargin, 'splitlabel');       % default for CTF and FieldLine is dealt with below
 
 % this should be a cell array
 if ~iscell(chantype); chantype = {chantype}; end
@@ -283,7 +285,7 @@ if cache && exist(headerfile, 'file') && ~isempty(cacheheader)
         % for realtime analysis end-of-file-chasing the res4 does not correctly
         % estimate the number of samples, so we compute it on the fly
         sz = 0;
-        files = dir([filename '/*.*meg4']);
+        files = dir([filename filesep '*.*meg4']);
         for j=1:numel(files)
           sz = sz + files(j).bytes;
         end
@@ -657,7 +659,11 @@ switch headerformat
   case {'ctf_ds', 'ctf_meg4', 'ctf_res4'}
     % check the presence of the required low-level toolbox
     ft_hastoolbox('ctf', 1);
-    orig             = readCTFds(filename);
+
+    % default for CTF is to remove the site-specific numbers from each channel name, e.g. 'MZC01-1706' becomes 'MZC01'
+    splitlabel = ft_getopt(varargin, 'splitlabel', true);
+
+    orig = readCTFds(filename);
     if isempty(orig)
       % this is to deal with data from the 64 channel system and the error
       % readCTFds: .meg4 file header=MEG4CPT   Valid header options:  MEG41CP  MEG42CP
@@ -669,10 +675,7 @@ switch headerformat
     hdr.nSamplesPre  = orig.res4.preTrigPts;
     hdr.nTrials      = orig.res4.no_trials;
     hdr.label        = cellstr(orig.res4.chanNames);
-    for i=1:numel(hdr.label)
-      % remove the site-specific numbers from each channel name, e.g. 'MZC01-1706' becomes 'MZC01'
-      hdr.label{i} = strtok(hdr.label{i}, '-');
-    end
+
     % read the balance coefficients, these are used to compute the synthetic gradients
     try
       coeftype = cellstr(char(orig.res4.scrr(:).coefType));
@@ -1926,6 +1929,11 @@ switch headerformat
       coilaccuracy = 0;
     end
 
+    if ft_senstype(hdr, 'fieldline_v3')
+      % default for FieldLine v3 is to remove the electronics chassis number from the channel names
+      splitlabel = ft_getopt(varargin, 'splitlabel', true);
+    end
+
     % add a gradiometer structure for forward and inverse modelling
     try
       [grad, elec] = mne2grad(info, strcmp(coordsys, 'dewar'), coilaccuracy, coildeffile);
@@ -1937,20 +1945,6 @@ switch headerformat
       end
     catch
       disp(lasterr);
-    end
-
-    % remove the electronics chassis number from the fieldline channel names
-    if ft_senstype(hdr, 'fieldline_v3') && any(contains(hdr.label, '-s'))
-      for i=1:length(hdr.label)
-        tok = split(hdr.label{i}, '-');
-        hdr.label{i} = tok{1};
-      end
-    end
-    if isfield(hdr, 'grad') && ft_senstype(hdr.grad, 'fieldline_v3') && any(contains(hdr.grad.label, '-s'))
-      for i=1:length(hdr.grad.label)
-        tok = split(hdr.grad.label{i}, '-');
-        hdr.grad.label{i} = tok{1};
-      end
     end
 
     iscontinuous  = 0;
@@ -2947,6 +2941,29 @@ end % if readbids and isbids
 hdr.label = fixlabels(hdr.label);
 if isfield(hdr, 'chantype'), hdr.chantype = fixchantype(hdr.chantype); end
 if isfield(hdr, 'chanunit'), hdr.chanunit = fixchanunit(hdr.chanunit); end
+
+if ~isempty(splitlabel) && istrue(splitlabel)
+  % this is default for CTF and FieldLine v3
+  for i=1:numel(hdr.label)
+    hdr.label{i} = strtok(hdr.label{i}, '-');
+  end
+  % also update the grad, elec and opto structure
+  if isfield(hdr, 'grad')
+    for i=1:numel(hdr.grad.label)
+      hdr.grad.label{i} = strtok(hdr.grad.label{i}, '-');
+    end
+  end
+  if isfield(hdr, 'elec')
+    for i=1:numel(hdr.elec.label)
+      hdr.elec.label{i} = strtok(hdr.elec.label{i}, '-');
+    end
+  end
+  if isfield(hdr, 'opto')
+    for i=1:numel(hdr.opto.label)
+      hdr.opto.label{i} = strtok(hdr.opto.label{i}, '-');
+    end
+  end
+end
 
 % ensure that these are double precision and not integers, otherwise
 % subsequent computations that depend on these might be messed up

--- a/fileio/private/ctf2grad.m
+++ b/fileio/private/ctf2grad.m
@@ -15,7 +15,7 @@ function [grad, elec] = ctf2grad(hdr, dewar, coilaccuracy, coildeffile)
 % See also BTI2GRAD, FIF2GRAD, MNE2GRAD, ITAB2GRAD, YOKOGAWA2GRAD,
 % FT_READ_SENS, FT_READ_HEADER
 
-% Copyright (C) 2004-2017, Robert Oostenveld
+% Copyright (C) 2004-2024, Robert Oostenveld
 %
 % This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
 % for the documentation and details.
@@ -83,17 +83,17 @@ if isfield(hdr, 'res4') && ~isempty(coilaccuracy)
   % use in additionthe coil definitions from the MNE coil_def.dat file
   % these allow for varying accuracy which is specified by coilaccuracy = 0, 1 or 2
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-  
+
   ft_hastoolbox('mne', 1);
   if isempty(coildeffile)
     [ftver, ftpath] = ft_version;
     coildeffile     = fullfile(ftpath, 'external', 'mne', 'coil_def.dat');
   end
   def = mne_load_coil_def(coildeffile);
-  
+
   k = 1;
   for i=1:length(hdr.res4.senres)
-    
+
     thissens = hdr.res4.senres(i);
     switch thissens.sensorTypeIndex
       case 5 % 5001
@@ -102,11 +102,11 @@ if isfield(hdr, 'res4') && ~isempty(coilaccuracy)
         thisdef = def([def.id]==5002 & [def.accuracy]==coilaccuracy);
       case 1 % 5003 or 5004
         % this is a reference gradiometer
-        delta = thissens.pos0*[-1;1]; 
+        delta = thissens.pos0*[-1;1];
 
         % determine whether the gradient is 'off' diagonal, comparing the
         % (cosine) of the angle between the line connecting the coils and
-        % the orientation of the first coil        % 
+        % the orientation of the first coil
         if abs((delta./norm(delta))'*thissens.ori0(:,1))<1e-2
           % it's an off diagonal channel
           thisdef = def([def.id]==5004 & [def.accuracy]==coilaccuracy);
@@ -117,38 +117,38 @@ if isfield(hdr, 'res4') && ~isempty(coilaccuracy)
         % do not add this as sensor to the gradiometer definition
         thisdef = [];
     end % case
-    
+
     if ~isempty(thisdef)
       if dewar
         pos = thissens.pos0;
         ori = thissens.ori0;
-      else 
+      else
         pos = thissens.pos;
         ori = thissens.ori;
       end
       pos   = pos./100;   % convert from cm to m
-      
+
       if thissens.numCoils==2 && thisdef.id~=5004
         % determine the direction from the relative position of the two coils
         %ez = pos(:,2)-pos(:,1);
         %ez = ez./norm(ez);
         ez  = -ori(:,1).*sign(thissens.properGain);
-        
+
         pos = pos(:,1)'; % take the first coil as local origin
         [ex, ey] = plane_unitvectors(ez);
-        
+
       elseif thissens.numCoils==2 && thisdef.id==5004
         % 'off' diagonal gradiometer, needs to be treated differently.
-        
+
         % the local origin is the average of the two coils, and the local
         % x-axis connects the coils
         ex  = pos*[1;-1]; % line between the coils
         pos = mean(pos,2)';
 
         ez  = -ori(:,1).*sign(thissens.properGain);
-        ex  = ex./norm(ex); 
+        ex  = ex./norm(ex);
         ey  = cross(ez,ex);
-        
+
         %thisdef.coildefs(:,2:4) = -thisdef.coildefs(:,2:4); % FIXME not sure about this
       else
         % magnetometer coil
@@ -157,14 +157,14 @@ if isfield(hdr, 'res4') && ~isempty(coilaccuracy)
         % determine the direction from the orientation of the magnetometer coil
         ez = -ori(:,1).*sign(thissens.properGain);
         [ex, ey] = plane_unitvectors(ez);
-        
+
       end
 
       for j=1:thisdef.num_points
         weight = thisdef.coildefs(j,1);
         pos1 = thisdef.coildefs(j,2:4);
         ori1 = thisdef.coildefs(j,5:7);
-        
+
         R = [ex(:) ey(:) ez(:) zeros(3,1);0 0 0 1];
         T = translate(pos);
         grad.tra(i,k)     = weight;
@@ -172,35 +172,33 @@ if isfield(hdr, 'res4') && ~isempty(coilaccuracy)
         grad.coilori(k,:) = ft_warp_apply(  R, ori1); % only the rotation
         k = k+1;
       end % for num_points
-      
+
       grad.chanpos(i,:) = pos;
       grad.chanori(i,:) = ez;
-      
-      % remove the site-specific numbers from each channel name, e.g. 'MZC01-1706' becomes 'MZC01'
-      grad.label{i} = strtok(hdr.res4.chanNames(i,:), '-');
+
     end % if MEG or MEGREF
   end % for each channel
-  
+
   grad.label = grad.label(:);
   grad.unit  = 'm'; % the coil_def.dat file is in meter
-  
+
   remove = cellfun(@isempty, grad.label);
   grad.label   = grad.label(~remove);
   grad.tra     = grad.tra(~remove,:);
   grad.chanpos = grad.chanpos(~remove,:);
   grad.chanori = grad.chanori(~remove,:);
-  
+
   if dewar
     grad.coordsys = 'dewar';
   else
     grad.coordsys = 'ctf';
   end
-  
+
 elseif isfield(hdr, 'res4') && isfield(hdr.res4, 'senres')
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   % the header was read using the CTF p-files, i.e. readCTFds
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-  
+
   sensType  = [hdr.res4.senres.sensorTypeIndex];
   selMEG    = find(sensType==4 | sensType==5 | sensType==6 | sensType==7);
   selREF    = find(sensType==0 | sensType==1 | sensType==2 | sensType==3);
@@ -211,7 +209,7 @@ elseif isfield(hdr, 'res4') && isfield(hdr.res4, 'senres')
   numMEG    = length(selMEG);
   numREF    = length(selREF);
   numEEG    = length(selEEG);
-  
+
   if numEEG>0
     for i=1:numEEG
       n = selEEG(i);
@@ -268,7 +266,7 @@ elseif isfield(hdr, 'res4') && isfield(hdr.res4, 'senres')
       grad.tra(chancount, coilcount) = 1;
     end
   end
- 
+
   % combine the coils of each reference channel
   for i=1:numREF
     n = selREF(i);
@@ -291,25 +289,21 @@ elseif isfield(hdr, 'res4') && isfield(hdr.res4, 'senres')
       grad.tra(chancount, coilcount) = 1;
     end
   end
-  
+
   label = cellstr(hdr.res4.chanNames);
-  for i=1:numel(label)
-    % remove the site-specific numbers from each channel name, e.g. 'MZC01-1706' becomes 'MZC01'
-    label{i} = strtok(label{i}, '-');
-  end
-  
+
   grad.label = label([selMEG selREF]);
   grad.unit  = 'cm'; % the res4 file represents it in centimeter
-  if ~isempty(elec)  
+  if ~isempty(elec)
     elec.unit  = 'cm';
   end
-  
+
   if dewar
     grad.coordsys = 'dewar';
   else
     grad.coordsys = 'ctf';
   end
-  
+
   % convert the balancing coefficients into a montage that can be used with the ft_apply_montage function
   if isfield(hdr.BalanceCoefs, 'G1BR')
     meglabel          = label(hdr.BalanceCoefs.G1BR.MEGlist);
@@ -321,7 +315,7 @@ elseif isfield(hdr, 'res4') && isfield(hdr.res4, 'senres')
     montage.tra       = [eye(nmeg, nmeg), -hdr.BalanceCoefs.G1BR.alphaMEG'; zeros(nref, nmeg), eye(nref, nref)];
     grad.balance.G1BR = montage;
   end
-  
+
   if isfield(hdr.BalanceCoefs, 'G2BR')
     meglabel          = label(hdr.BalanceCoefs.G2BR.MEGlist);
     reflabel          = label(hdr.BalanceCoefs.G2BR.Refindex);
@@ -332,7 +326,7 @@ elseif isfield(hdr, 'res4') && isfield(hdr.res4, 'senres')
     montage.tra       = [eye(nmeg, nmeg), -hdr.BalanceCoefs.G2BR.alphaMEG'; zeros(nref, nmeg), eye(nref, nref)];
     grad.balance.G2BR = montage;
   end
-  
+
   if isfield(hdr.BalanceCoefs, 'G3BR')
     meglabel          = label(hdr.BalanceCoefs.G3BR.MEGlist);
     reflabel          = label(hdr.BalanceCoefs.G3BR.Refindex);
@@ -343,7 +337,7 @@ elseif isfield(hdr, 'res4') && isfield(hdr.res4, 'senres')
     montage.tra       = [eye(nmeg, nmeg), -hdr.BalanceCoefs.G3BR.alphaMEG'; zeros(nref, nmeg), eye(nref, nref)];
     grad.balance.G3BR = montage;
   end
-  
+
   if isfield(hdr.BalanceCoefs, 'G3AR')
     meglabel          = label(hdr.BalanceCoefs.G3AR.MEGlist);
     reflabel          = label(hdr.BalanceCoefs.G3AR.Refindex);
@@ -354,7 +348,7 @@ elseif isfield(hdr, 'res4') && isfield(hdr.res4, 'senres')
     montage.tra       = [eye(nmeg, nmeg), -hdr.BalanceCoefs.G3AR.alphaMEG'; zeros(nref, nmeg), eye(nref, nref)];
     grad.balance.G3AR = montage;
   end
-  
+
   if     all([hdr.res4.senres(selMEG).grad_order_no]==0)
     grad.balance.current = 'none';
   elseif all([hdr.res4.senres(selMEG).grad_order_no]==1)
@@ -369,27 +363,27 @@ elseif isfield(hdr, 'res4') && isfield(hdr.res4, 'senres')
     ft_warning('cannot determine balancing of CTF gradiometers');
     grad = rmfield(grad, 'balance');
   end
-  
+
   % sofar the gradiometer definition was the ideal, non-balenced one
   if isfield(grad, 'balance') && ~strcmp(grad.balance.current, 'none')
     % apply the current balancing parameters to the gradiometer definition
     %grad = ft_apply_montage(grad, getfield(grad.balance, grad.balance.current));
     grad = ft_apply_montage(grad, getfield(grad.balance, grad.balance.current), 'keepunused', 'yes');
   end
-  
-  
+
+
 elseif isfield(hdr, 'sensType') && isfield(hdr, 'Chan')
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   % the header was read using the open-source MATLAB code that originates from CTF and that was modified by the FCDC
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-  
+
   selMEG = find(hdr.sensType==5);
   selREF = find(hdr.sensType==0 | hdr.sensType==1);
   selMEG = selMEG(:)';
   selREF = selREF(:)';
   numMEG = length(selMEG);
   numREF = length(selREF);
-  
+
   % combine the bottom and top coil of each MEG channel
   for i=1:numMEG
     n = selMEG(i);
@@ -415,7 +409,7 @@ elseif isfield(hdr, 'sensType') && isfield(hdr, 'Chan')
     grad.tra(i,i+numMEG) = 1;
   end
   numMEGcoils = size(grad.coilpos, 1);
-  
+
   % combine the coils of each reference channel
   for i=1:numREF
     n = selREF(i);
@@ -436,33 +430,33 @@ elseif isfield(hdr, 'sensType') && isfield(hdr, 'Chan')
       grad.tra(numMEG+i, numMEGcoils+i) = 1;
     end
   end
-  
+
   grad.label = hdr.label([selMEG selREF]);
   grad.unit  = 'cm'; % the res4 file represents it in centimeter
-  
+
   if dewar
     grad.coordsys = 'dewar';
   else
     grad.coordsys = 'ctf';
   end
-  
+
 elseif isfield(hdr, 'sensor') && isfield(hdr.sensor, 'info')
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   % the header was read using the CTF importer from the NIH and Daren Weber
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-  
+
   if dewar
     % this does not work for Daren Webers implementation
     ft_error('cannot return the gradiometer definition in dewar coordinates');
   end
-  
+
   % only work on the MEG channels
   if isfield(hdr.sensor.index, 'meg')
     sel = hdr.sensor.index.meg;
   else
     sel = hdr.sensor.index.meg_sens;
   end
-  
+
   for i=1:length(sel)
     pnt = hdr.sensor.info(sel(i)).location';
     ori = hdr.sensor.info(sel(i)).orientation';
@@ -477,12 +471,12 @@ elseif isfield(hdr, 'sensor') && isfield(hdr.sensor, 'info')
     else
       ft_error('do not know how to deal with higher order gradiometer hardware')
     end
-    
+
     % add this channels coil positions and orientations
     grad.coilpos = [grad.coilpos; pnt];
     grad.coilori = [grad.coilori; ori];
     grad.label{i} = hdr.sensor.info(sel(i)).label;
-    
+
     % determine the contribution of each coil to each channel's output signal
     if size(pnt,1)==1
       % one coil, assume that the orientation is correct, i.e. the weight is +1
@@ -496,11 +490,11 @@ elseif isfield(hdr, 'sensor') && isfield(hdr.sensor, 'info')
       ft_error('do not know how to deal with higher order gradiometer hardware')
     end
   end
-  
+
   % prefer to have the labels in a column vector
   grad.label = grad.label(:);
   grad.unit  = 'cm'; % the res4 file represents it in centimeter
-  
+
   % reorder the coils, such that the bottom coils are at the first N
   % locations and the top coils at the last N positions. This makes it
   % easier to use a selection of the coils for topographic plotting
@@ -511,7 +505,7 @@ elseif isfield(hdr, 'sensor') && isfield(hdr.sensor, 'info')
     grad.coilori = grad.coilori([bot top], :);
     grad.tra = grad.tra(:, [bot top]);
   end
-  
+
 else
   ft_error('unknown header to contruct gradiometer definition');
 end


### PR DESCRIPTION
The default remains the same, but by making it more generic and moving it to the end of the function, it now also works for BIDS datasets where the channels.tsv contains the labels with "-xxxx" extension. 

This fixes #2395.
