### PR TITLE
ENH - Inside the local copy, the directories should have a specific hierarchy.

### DIFF
--- a/utilities/dccnpath.m
+++ b/utilities/dccnpath.m
@@ -21,16 +21,16 @@ function filename = dccnpath(filename)
 % default location using
 %    global ft_default
 %    ft_default.dccnpath = '/your/copy';
-% Your local copy should include a directory named 'ftp'. Inside this
-% directory, the folder hierarchy should match the one on the FieldTrip download server 
-% (e.g. '/your/copy/ftp/test/ctf').
 %
-% If you do not have a local copy and do not define ft_default.dccnpath manually,
-% then dccnpath will automatically use a temporary directory and try to download the
-% data.
+% If you DO HAVE a local copy, it should contain a directory with the name 'ftp'. The 
+% content of the ftp directory should match that on the FieldTrip download server, 
+% for example '/your/copy/ftp/test/ctf'.
+%
+% If you DO NOT have a local copy and do not define ft_default.dccnpath manually,
+% then this function will automatically try to download the publicly available data 
+% to a temporary directory.
 %
 % See also WHICH, WEBSAVE
-
 % Copyright (C) 2012-2023, Donders Centre for Cognitive Neuroimaging, Nijmegen, NL
 %
 % This file is part of FieldTrip, see http://www.fieldtriptoolbox.org

--- a/utilities/dccnpath.m
+++ b/utilities/dccnpath.m
@@ -21,6 +21,9 @@ function filename = dccnpath(filename)
 % default location using
 %    global ft_default
 %    ft_default.dccnpath = '/your/copy';
+% Your local copy should include a directory named 'ftp'. Inside this
+% directory, the folder hierarchy should match the one on the FieldTrip download server 
+% (e.g. '/your/copy/ftp/test/ctf').
 %
 % If you do not have a local copy and do not define ft_default.dccnpath manually,
 % then dccnpath will automatically use a temporary directory and try to download the


### PR DESCRIPTION
Improved help documentation of `dccpath` to explain to external contributors (that have manually downloaded test data in their computer) how to structure the folders inside their local copy.