### PR TITLE
Stop cfg.README from being used in data sidecar json files

### DIFF
--- a/data2bids.m
+++ b/data2bids.m
@@ -1080,6 +1080,7 @@ dataset_description_settings = keepfields(cfg.dataset_description, fn);
 fn = fieldnames(cfg);
 fn = fn(~cellfun(@isempty, regexp(fn, '^[A-Z].*')));
 generic_settings = keepfields(cfg, fn);
+generic_settings = removefields(generic_settings, 'README'); % should not be used as a property in data json files
 
 % make the relevant selection, all json fields start with a capital letter
 fn = fieldnames(cfg.mri);


### PR DESCRIPTION
Currently, the content of cfg.README is written into each data file sidecar json. This violates BIDS format (according to the OpenNeuro validator). The cfg.README field should only be used for creating the README file, not as a property for the each data file sidecar json.