### PR TITLE
Prevent MATLAB crash on Windows due to sparse matrix in read_trigger function

### DIFF
--- a/fileio/ft_read_data.m
+++ b/fileio/ft_read_data.m
@@ -1253,9 +1253,7 @@ switch dataformat
     ft_hastoolbox('mne', 1);
     if (hdr.orig.iscontinuous)
       dat = fiff_read_raw_segment(hdr.orig.raw,begsample+hdr.orig.raw.first_samp-1,endsample+hdr.orig.raw.first_samp-1,chanindx);
-      if ispc
-        dat = full(dat); % prevent MATLAB crash on Windows due to 'dat' being a sparse matrix, see issue 2451
-      end
+      dat = full(dat); % prevent MATLAB crash on Windows due to 'dat' being a sparse matrix, see issue 2451
       dimord = 'chans_samples';
     elseif (hdr.orig.isepoched)
       % permutation of the data matrix is time consuming, and offsets the time gained by not 

--- a/fileio/ft_read_data.m
+++ b/fileio/ft_read_data.m
@@ -1253,6 +1253,9 @@ switch dataformat
     ft_hastoolbox('mne', 1);
     if (hdr.orig.iscontinuous)
       dat = fiff_read_raw_segment(hdr.orig.raw,begsample+hdr.orig.raw.first_samp-1,endsample+hdr.orig.raw.first_samp-1,chanindx);
+      if ispc
+        dat = full(dat); % prevent MATLAB crash on Windows due to 'dat' being a sparse matrix, see issue 2451
+      end
       dimord = 'chans_samples';
     elseif (hdr.orig.isepoched)
       % permutation of the data matrix is time consuming, and offsets the time gained by not 

--- a/test/test_bug1404.m
+++ b/test/test_bug1404.m
@@ -3,7 +3,7 @@ function test_bug1404
 % MEM 1gb
 % WALLTIME 00:10:00
 % DEPENDENCY ft_read_header ft_read_data ft_read_spike
-% DATA no
+% DATA private
 
 % this is only available on the DCCN mentat cluster
 dataset = '/home/common/matlab/fieldtrip/data/test/original/neurosim/signals';


### PR DESCRIPTION
To prevent crash of MATLAB on Windows, we force `dat` to be a full matrix instead of a sparse double.

As an external contributor, I could only run one test for `read_trigger` and none for `ft_read_data`. The one test passed.

Also, when we add my OPM data in the FT download server, I can write a test  `test_issue2451`.

This closes #2451. 