### PR TITLE
fixed missing preproc in ft_badsegment, ft_badchannel and ft_baddata

### DIFF
--- a/ft_badchannel.m
+++ b/ft_badchannel.m
@@ -151,8 +151,8 @@ if contains(cfg.metric, 'zvalue')
   runsum = zeros(nchan, 1);
   runss  = zeros(nchan, 1);
   runnum = 0;
-  for chan=1:ntrl
-    dat = preproc(data.trial{chan}, data.label, data.time{chan}, cfg.preproc);
+  for trl=1:ntrl
+    dat = preproc(data.trial{trl}, data.label, data.time{trl}, cfg.preproc);
     runsum = runsum + nansum(dat, 2);
     runss  = runss  + nansum(dat.^2, 2);
     runnum = runnum + sum(isfinite(dat), 2);
@@ -174,7 +174,8 @@ end
 
 for trl=1:ntrl
   % compute the artifact value for each channel in this trial
-  level = artifact_level(data.trial{trl}, cfg.metric, mval, sd, connectivity);
+  dat = preproc(data.trial{trl}, data.label, data.time{trl}, cfg.preproc);
+  level = artifact_level(dat, cfg.metric, mval, sd, connectivity);
   
   if isvector(level)
     % find channels with a value that exceeds the threshold

--- a/ft_baddata.m
+++ b/ft_baddata.m
@@ -127,8 +127,8 @@ if contains(cfg.metric, 'zvalue')
   runsum = zeros(nchan, 1);
   runss  = zeros(nchan, 1);
   runnum = 0;
-  for chan=1:ntrl
-    dat = preproc(data.trial{chan}, data.label, data.time{chan}, cfg.preproc);
+  for trl=1:ntrl
+    dat = preproc(data.trial{trl}, data.label, data.time{trl}, cfg.preproc);
     runsum = runsum + nansum(dat, 2);
     runss  = runss  + nansum(dat.^2, 2);
     runnum = runnum + sum(isfinite(dat), 2);
@@ -151,7 +151,8 @@ end
 % compute the artifact value for each trial and each channel
 level = nan(nchan, ntrl);
 for trl=1:ntrl
-  level(:,trl) = artifact_level(data.trial{trl}, cfg.metric, mval, sd, connectivity);
+  dat = preproc(data.trial{trl}, data.label, data.time{trl}, cfg.preproc);
+  level(:,trl) = artifact_level(dat, cfg.metric, mval, sd, connectivity);
 end
 
 % find channels and trials with a value that exceeds the threshold

--- a/ft_badsegment.m
+++ b/ft_badsegment.m
@@ -150,8 +150,8 @@ if contains(cfg.metric, 'zvalue')
   runsum = zeros(nchan, 1);
   runss  = zeros(nchan, 1);
   runnum = 0;
-  for chan=1:ntrl
-    dat = preproc(data.trial{chan}, data.label, data.time{chan}, cfg.preproc);
+  for trl=1:ntrl
+    dat = preproc(data.trial{trl}, data.label, data.time{trl}, cfg.preproc);
     runsum = runsum + nansum(dat, 2);
     runss  = runss  + nansum(dat.^2, 2);
     runnum = runnum + sum(isfinite(dat), 2);
@@ -173,7 +173,8 @@ end
 
 for trl=1:ntrl
   % compute the artifact value for each channel in this trial
-  level = artifact_level(data.trial{trl}, cfg.metric, mval, sd, connectivity);
+  dat = preproc(data.trial{trl}, data.label, data.time{trl}, cfg.preproc);
+  level = artifact_level(dat, cfg.metric, mval, sd, connectivity);
   
   if isvector(level)
     % find channels with a value that exceeds the threshold


### PR DESCRIPTION
Added missing preproc before level is calculated in ft_badsegment, ft_badchannel and ft_baddata. Also changed name of the index variable in the loop calculating std and mean for zvalue to better match its use.