### PR TITLE
Fix order in channels.tsv file for motion data

### DIFF
--- a/data2bids.m
+++ b/data2bids.m
@@ -1177,6 +1177,8 @@ if need_channels_tsv
   % columns should appear in a specific order
   if need_nirs_json
     required = {'name', 'type', 'source', 'detector', 'wavelength_nominal', 'units'};
+  elseif need_motion_json
+    required = {'name', 'component', 'type', 'tracked_point', 'units'};
   else
     required = {'name', 'type', 'units', 'low_cutoff', 'high_cutoff'};
   end

--- a/data2bids.m
+++ b/data2bids.m
@@ -292,7 +292,7 @@ for i=1:numel(fn)
 end
 
 if isempty(cfg.suffix)
-  modality = {'meg', 'eeg', 'ieeg', 'emg', 'motion', 'audio', 'video', 'eyetracker', 'physio', 'stim', 'motion', 'nirs'};
+  modality = {'meg', 'eeg', 'ieeg', 'emg', 'audio', 'video', 'eyetracker', 'physio', 'stim', 'motion', 'nirs'};
   for i=1:numel(modality)
     if isfield(cfg, modality{i}) && ~isempty(cfg.(modality{i}))
       % the user specified modality-specific options, assume that the datatype matches


### PR DESCRIPTION
This PR fixes https://github.com/fieldtrip/fieldtrip/issues/2455#event-16205738876. It ensures the order of the [`channels.tsv`](https://bids-specification.readthedocs.io/en/stable/modality-specific-files/motion.html#channels-description-_channelstsv) file for motion data is as expected to pass the validator.