### PR TITLE
ENH - code change to suppress matlab2024b and up warning

### DIFF
--- a/fileio/private/read_ctf_res4.m
+++ b/fileio/private/read_ctf_res4.m
@@ -18,6 +18,7 @@ function [hdr] = read_ctf_res4(fname)
 %
 % modifications Copyright (C) 2002, Ole Jensen
 % modifications Copyright (C) 2003, Robert Oostenveld
+% modifications Copyright (C) 2025, Jan-Mathijs Schoffelen
 %
 % This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
 % for the documentation and details.
@@ -111,8 +112,8 @@ for i=1:no_channels,
   temp=fread(fid,32,'uint8')';
   temp(find(temp<32 )) = ' ';       % remove non-printable characters
   temp(find(temp>126)) = ' ';       % remove non-printable characters
-  endstr = strfind(temp, '-'); temp(endstr:end) = ' ';  % cut off at '-'
-  endstr = strfind(temp, ' '); temp(endstr:end) = ' ';  % cut off at ' '
+  endstr = strfind(temp, '-'); if ~isempty(endstr), temp(endstr(1):end) = ' '; end % cut off at '-'
+  endstr = strfind(temp, ' '); if ~isempty(endstr), temp(endstr(1):end) = ' '; end % cut off at ' '
   chan_name(i,:) = char(temp);      % as char array
   chan_label{i}  = deblank(char(temp)); % as cell-array
 end %for

--- a/qsub/qsubfeval.m
+++ b/qsub/qsubfeval.m
@@ -84,7 +84,8 @@ optbeg = optbeg | strcmp('whichfunction', strargin);
 optbeg = optbeg | strcmp('waitfor',       strargin);
 optbeg = find(optbeg);
 if ~isempty(optbeg)
-  optarg = varargin(optbeg(1):end);
+  optbeg = optbeg(1)
+  optarg = varargin(optbeg:end);
 else
   optarg = [];
 end

--- a/qsub/qsubfeval.m
+++ b/qsub/qsubfeval.m
@@ -83,7 +83,11 @@ optbeg = optbeg | strcmp('nargout',       strargin);
 optbeg = optbeg | strcmp('whichfunction', strargin);
 optbeg = optbeg | strcmp('waitfor',       strargin);
 optbeg = find(optbeg);
-optarg = varargin(optbeg:end);
+if ~isempty(optbeg)
+  optarg = varargin(optbeg(1):end);
+else
+  optarg = [];
+end
 
 % check the required input arguments
 ft_checkopt(optarg, 'memreq', 'numericscalar');

--- a/qsub/qsubfeval.m
+++ b/qsub/qsubfeval.m
@@ -84,7 +84,7 @@ optbeg = optbeg | strcmp('whichfunction', strargin);
 optbeg = optbeg | strcmp('waitfor',       strargin);
 optbeg = find(optbeg);
 if ~isempty(optbeg)
-  optbeg = optbeg(1)
+  optbeg = optbeg(1);
   optarg = varargin(optbeg:end);
 else
   optarg = [];


### PR DESCRIPTION
matlab2024b started throwing extensive warnings (when using read_ctf_res4):

```
Warning: Colon operands must be real scalars. This warning will become an error in a future release. 
```

This PR fixes it. I quickly grepped the read_ctf_* functions for similar syntax, but the guilty strfind was only of relevance for the updated function.