### PR TITLE
set channels type from bids

### DIFF
--- a/fileio/ft_read_header.m
+++ b/fileio/ft_read_header.m
@@ -2875,7 +2875,8 @@ if (strcmp(readbids, 'yes') || strcmp(readbids, 'ifmakessense')) && isbids
       assert(length(channels_tsv.type)  == hdr.nChans, 'number of channels is not consistent with the BIDS channels.tsv');
       assert(length(channels_tsv.units) == hdr.nChans, 'number of channels is not consistent with the BIDS channels.tsv');
       hdr.label    = channels_tsv.name;
-      hdr.chantype = repmat({'unknown'}, [length(hdr.label), 1]);
+      hdr.chantype    = channels_tsv.type;
+      % hdr.chantype = repmat({'unknown'}, [length(hdr.label), 1]);
       hdr.chantype(contains(channels_tsv.type, 'NIRS')) = {'nirs'};
       hdr.chanunit = channels_tsv.units;
     end

--- a/fileio/ft_read_header.m
+++ b/fileio/ft_read_header.m
@@ -2875,9 +2875,7 @@ if (strcmp(readbids, 'yes') || strcmp(readbids, 'ifmakessense')) && isbids
       assert(length(channels_tsv.type)  == hdr.nChans, 'number of channels is not consistent with the BIDS channels.tsv');
       assert(length(channels_tsv.units) == hdr.nChans, 'number of channels is not consistent with the BIDS channels.tsv');
       hdr.label    = channels_tsv.name;
-      hdr.chantype    = channels_tsv.type;
-      % hdr.chantype = repmat({'unknown'}, [length(hdr.label), 1]);
-      hdr.chantype(contains(channels_tsv.type, 'NIRS')) = {'nirs'};
+      hdr.chantype    = lower(channels_tsv.type);
       hdr.chanunit = channels_tsv.units;
     end
     if exist('electrodes_tsv', 'var')


### PR DESCRIPTION
Not sure why, but channel types found in bids sidecar _channels.tsv isn't ported into hdr.
If that was a mistake, then this should fix it...