### PR TITLE
Fix unreachable code blocks for collecting qsub jobs

### DIFF
--- a/qsub/qsublist.m
+++ b/qsub/qsublist.m
@@ -194,7 +194,7 @@ switch cmd
           % there is no way polling the batch execution system
           retval = 1;
       end
-    elseif isempty(logout) && isempty(logerr) && isempty(pbsid)
+    elseif ~isempty(logout) && ~isempty(logerr) && isempty(pbsid)
       % we cannot locate the job in the PBS/torque backend (weird, but it happens), hence we have to rely on the e and o files
       % note that the mat file still might be missing, e.g. when the job was killed due to a resource violation
       retval = 1;


### PR DESCRIPTION
The logfile and error file were specified with wildcards and checked for existence, without ever expanding the wildcards. Potentially (presumable), this is causing qsubcellfun to sometimes wait forever for jobs (a decade-old bug that rendered it pretty useless)