### PR TITLE
Fix typos in docs and messages

### DIFF
--- a/fileio/private/channelposition.m
+++ b/fileio/private/channelposition.m
@@ -165,7 +165,7 @@ switch ft_senstype(sens)
         refori(i,:) = weight(selc)*tmpori;
 
         % check whether the line between the coils is aligned with the
-        % oriention of the coils, in which case it's a diagonal reference,
+        % orientation of the coils, in which case it's a diagonal reference,
         % otherwise it's an off diagonal reference. For the diagonal
         % reference the chanpos should be one of the coils, for the off
         % diagonal reference it should be the average.

--- a/forward/private/channelposition.m
+++ b/forward/private/channelposition.m
@@ -165,7 +165,7 @@ switch ft_senstype(sens)
         refori(i,:) = weight(selc)*tmpori;
 
         % check whether the line between the coils is aligned with the
-        % oriention of the coils, in which case it's a diagonal reference,
+        % orientation of the coils, in which case it's a diagonal reference,
         % otherwise it's an off diagonal reference. For the diagonal
         % reference the chanpos should be one of the coils, for the off
         % diagonal reference it should be the average.

--- a/forward/private/mesh_sphere.m
+++ b/forward/private/mesh_sphere.m
@@ -253,7 +253,7 @@ end
 th  = storeM(i).th;
 phi = storeM(i).phi;
 
-% convert from spherical to cartehsian coordinates
+% convert from spherical to cartesian coordinates
 [x, y, z] = sph2cart(th, pi/2-phi, 1);
 pos = [x' y' z'];
 tri = convhulln(pos);

--- a/ft_analysispipeline.m
+++ b/ft_analysispipeline.m
@@ -164,7 +164,7 @@ end
 pipeline = tmp;
 
 if istrue(cfg.prune)
-  % prune the double occurences
+  % prune the double occurrences
   [dummy, indx] = unique({pipeline.this});
   pipeline = pipeline(sort(indx));
 end

--- a/ft_databrowser.m
+++ b/ft_databrowser.m
@@ -1949,7 +1949,7 @@ if strcmp(cfg.plotartifacts, 'yes')
     end
 
     for k=1:numel(artbeg)
-      i = i + 1; % it is not a simple loop, there are multiple types of artifacts, times multiple occurences
+      i = i + 1; % it is not a simple loop, there are multiple types of artifacts, times multiple occurrences
       artifacttime(i) = tim(artbeg(k)) + opt.hlim(1);
       xpos = [tim(artbeg(k)) tim(artend(k))];
 

--- a/loreta2fieldtrip.m
+++ b/loreta2fieldtrip.m
@@ -53,8 +53,8 @@ if ft_filetype(filename, 'loreta_slor') || is_txt && strcmp(filename(end-7:end-4
   voxnumber    = 6239;
   lorind       = getfield(load('loreta_ind.mat'), 'ind_sloreta');
   source.dim   = size(lorind);
-  %Note1, ingnie: this was the orriginal, but this can't be correct, since the x
-  %dimention, for instance, is 37, while -70:5:70 is only 29. I just left
+  %Note1, ingnie: this was the original, but this can't be correct, since the x
+  %dimension, for instance, is 37, while -70:5:70 is only 29. I just left
   %it here for reference.
   %   source.xgrid =  -70:5:70;
   %   source.ygrid = -100:5:65;

--- a/plotting/private/channelposition.m
+++ b/plotting/private/channelposition.m
@@ -165,7 +165,7 @@ switch ft_senstype(sens)
         refori(i,:) = weight(selc)*tmpori;
 
         % check whether the line between the coils is aligned with the
-        % oriention of the coils, in which case it's a diagonal reference,
+        % orientation of the coils, in which case it's a diagonal reference,
         % otherwise it's an off diagonal reference. For the diagonal
         % reference the chanpos should be one of the coils, for the off
         % diagonal reference it should be the average.

--- a/plotting/private/mesh_sphere.m
+++ b/plotting/private/mesh_sphere.m
@@ -253,7 +253,7 @@ end
 th  = storeM(i).th;
 phi = storeM(i).phi;
 
-% convert from spherical to cartehsian coordinates
+% convert from spherical to cartesian coordinates
 [x, y, z] = sph2cart(th, pi/2-phi, 1);
 pos = [x' y' z'];
 tri = convhulln(pos);

--- a/private/channelposition.m
+++ b/private/channelposition.m
@@ -165,7 +165,7 @@ switch ft_senstype(sens)
         refori(i,:) = weight(selc)*tmpori;
 
         % check whether the line between the coils is aligned with the
-        % oriention of the coils, in which case it's a diagonal reference,
+        % orientation of the coils, in which case it's a diagonal reference,
         % otherwise it's an off diagonal reference. For the diagonal
         % reference the chanpos should be one of the coils, for the off
         % diagonal reference it should be the average.

--- a/private/dimassign.m
+++ b/private/dimassign.m
@@ -5,7 +5,7 @@ function M=dimassign(A,dim,idx,B)
 % The purpose of the function is shown by the following example:
 % If A and B are multidimensional matrixes,
 % A=dimassign(A,4,23,B); is the same as A(:,:,:,23,:,:,...)=B;
-% The difference is that the dimention is selected by a scalar, not by
+% The difference is that the dimension is selected by a scalar, not by
 % the place between the brackets.
 % A(2,4,3)=B; will then be written as: A=dimassign(A,[1,2,3],[2,4,3],B);
 % In this last case B, of cource, must be a scalar.
@@ -38,7 +38,7 @@ function M=dimassign(A,dim,idx,B)
 if(~iscell(idx))
     if(~any(size(dim)==1)||~any(size(idx)==1)||ndims(dim)>2||ndims(idx)>2||...
         length(dim)~=length(idx))
-        ft_error('dim and idx must be both scalars oor both must have the same length');
+        ft_error('dim and idx must be both scalars or both must have the same length');
     end
     dummi=[];
     for(i=1:length(idx))
@@ -53,7 +53,7 @@ if(~any(size(dim)==1)||~any(size(idx)==1)||ndims(dim)>2||ndims(idx)>2||...
 end
 
 if(~isequal(unique(dim),sort(dim)))
-    ft_error('dim must be unique, every dimention can be addressed only once');
+    ft_error('dim must be unique, every dimension can be addressed only once');
 end
 
 Na=ndims(A);

--- a/private/dimnum.m
+++ b/private/dimnum.m
@@ -1,5 +1,5 @@
 function [num,dims]=dimnum(dimord, dim)
-% This function returns the number of the given dimention 'dim' in the dimord string.
+% This function returns the number of the given dimension 'dim' in the dimord string.
 %
 % Syntax: [num,dims]=dimnum(dimord, dim)
 %
@@ -8,7 +8,7 @@ function [num,dims]=dimnum(dimord, dim)
 % e.g. when dimord='rpt_chancmb_freq_time' and dim='chancmb', dimnum returns num=2
 %       and dims again contains {'rpt','chancmb','freq','tim'}.
 % 
-% For the known dimentiontypes dim can also be 'time' or 'frequency'.
+% For the known dimension types dim can also be 'time' or 'frequency'.
 % The known types are:
 % tim: 'time'
 % freq: 'frq', 'frequency'

--- a/private/isalmostequal.m
+++ b/private/isalmostequal.m
@@ -103,7 +103,7 @@ if isa(a, 'numeric') || isa(a, 'char') || isa(a, 'logical')
     return;
   end
   if ~all(isnan(a(:)) == isnan(b(:)))
-    message{end+1} = sprintf('different occurence of NaNs in %s', location);
+    message{end+1} = sprintf('different occurrence of NaNs in %s', location);
     return;
   end
   % replace the NaNs, since we cannot compare them numerically

--- a/private/lapcal.m
+++ b/private/lapcal.m
@@ -43,7 +43,7 @@ ntri = size(tri,1);
 % the matrix edge is the connectivity matric for all vertices
 edge = spalloc(npnt, npnt, 3*ntri);
 for i=1:ntri
-  % compute the lenght of all triangle edges
+  % compute the length of all triangle edges
   edge(tri(i,1), tri(i,2)) = norm(pnt(tri(i,1),:) - pnt(tri(i,2),:));
   edge(tri(i,2), tri(i,3)) = norm(pnt(tri(i,2),:) - pnt(tri(i,3),:));
   edge(tri(i,3), tri(i,1)) = norm(pnt(tri(i,3),:) - pnt(tri(i,1),:));

--- a/private/mesh_sphere.m
+++ b/private/mesh_sphere.m
@@ -253,7 +253,7 @@ end
 th  = storeM(i).th;
 phi = storeM(i).phi;
 
-% convert from spherical to cartehsian coordinates
+% convert from spherical to cartesian coordinates
 [x, y, z] = sph2cart(th, pi/2-phi, 1);
 pos = [x' y' z'];
 tri = convhulln(pos);

--- a/private/prepare_mesh_headshape.m
+++ b/private/prepare_mesh_headshape.m
@@ -155,7 +155,7 @@ end
 th  = storeM(i).th;
 phi = storeM(i).phi;
 
-% convert from spherical to cartehsian coordinates
+% convert from spherical to cartesian coordinates
 [x, y, z] = sph2cart(th, pi/2-phi, 1);
 pos = [x' y' z'];
 tri = convhulln(pos);

--- a/realtime/online_mri/ft_omri_info_from_header.m
+++ b/realtime/online_mri/ft_omri_info_from_header.m
@@ -35,14 +35,14 @@ if isfield(hdr,'nifti_1')
 	try
 		SNif = mri_info_from_nifti(hdr.nifti_1);
 	catch
-		warning('Errors occured while inspecting NIFTI-1 header.');
+                warning('Errors occurred while inspecting NIFTI-1 header.');
 	end
 end
 if isfield(hdr,'siemensap')
 	try
 		SSap = mri_info_from_sap(hdr.siemensap);
 	catch
-		warning('Errors occured while inspecting SiemensAP header.');
+                warning('Errors occurred while inspecting SiemensAP header.');
 	end
 end
 	

--- a/realtime/src/buffer/java/bufferserver/SystemOutMonitor.java
+++ b/realtime/src/buffer/java/bufferserver/SystemOutMonitor.java
@@ -5,21 +5,21 @@ import java.util.Date;
 import java.util.HashMap;
 
 public class SystemOutMonitor implements FieldtripBufferMonitor {
-	private final HashMap<Integer, String> adresses = new HashMap<Integer, String>();
+        private final HashMap<Integer, String> addresses = new HashMap<Integer, String>();
 	private int verbosity=0;
 	private int count = 0;
 	private final SimpleDateFormat sdf = new SimpleDateFormat(
 			"MMM dd,yyyy HH:mm");
 
 	public SystemOutMonitor(int level) {
-		adresses.put(-1, "Internal");
+                addresses.put(-1, "Internal");
 	}
 
 	@Override
 	public void clientClosedConnection(final int clientID, final long time) {
 		 if ( verbosity > 0 )
 		System.out.println(sdf.format(new Date(time)) + " Client "
-				+ adresses.get(clientID) + " closed connection now " + --count
+				+ addresses.get(clientID) + " closed connection now " + --count
 				+ " connections opened.");
 	}
 
@@ -27,7 +27,7 @@ public class SystemOutMonitor implements FieldtripBufferMonitor {
 	public void clientContinues(final int clientID, final long time) {
 		 if ( verbosity > 0 )
 		System.out.println(sdf.format(new Date(time)) + " Client "
-				+ adresses.get(clientID) + " has continued.");
+				+ addresses.get(clientID) + " has continued.");
 	}
 
 	@Override
@@ -35,13 +35,13 @@ public class SystemOutMonitor implements FieldtripBufferMonitor {
 			final long time) {
 		if (errorType == FieldtripBufferMonitor.ERROR_CONNECTION) {
 			System.out.println(sdf.format(new Date(time)) + " Lost client "
-					+ adresses.get(clientID) + " connection unexpectidly");
+                                        + addresses.get(clientID) + " connection unexpectedly");
 		} else if (errorType == FieldtripBufferMonitor.ERROR_PROTOCOL) {
 			System.out.println(sdf.format(new Date(time)) + " Client "
-					+ adresses.get(clientID) + " violates protocol");
+					+ addresses.get(clientID) + " violates protocol");
 		} else {
 			System.out.println(sdf.format(new Date(time)) + " Client "
-					+ adresses.get(clientID) + " has wrong version");
+					+ addresses.get(clientID) + " has wrong version");
 		}
 	}
 
@@ -49,14 +49,14 @@ public class SystemOutMonitor implements FieldtripBufferMonitor {
 	public void clientFlushedData(final int clientID, final long time) {
 		 if ( verbosity > 0 )
 		System.out.println(sdf.format(new Date(time)) + " Data Flushed by "
-				+ adresses.get(clientID));
+				+ addresses.get(clientID));
 	}
 
 	@Override
 	public void clientFlushedEvents(final int clientID, final long time) {
 		 if ( verbosity > 0 )
 		System.out.println(sdf.format(new Date(time)) + " Events Flushed by "
-				+ adresses.get(clientID));
+				+ addresses.get(clientID));
 
 	}
 
@@ -64,7 +64,7 @@ public class SystemOutMonitor implements FieldtripBufferMonitor {
 	public void clientFlushedHeader(final int clientID, final long time) {
 		 if ( verbosity > 0 )
 		System.out.println(sdf.format(new Date(time)) + " Header Flushed by "
-				+ adresses.get(clientID));
+				+ addresses.get(clientID));
 	}
 
 	@Override
@@ -72,7 +72,7 @@ public class SystemOutMonitor implements FieldtripBufferMonitor {
 			final long time) {
 		 if ( verbosity > 1 )
 		System.out.println(sdf.format(new Date(time)) + " Client "
-				+ adresses.get(clientID) + " has been sent " + count
+				+ addresses.get(clientID) + " has been sent " + count
 				+ " events.");
 
 	}
@@ -81,7 +81,7 @@ public class SystemOutMonitor implements FieldtripBufferMonitor {
 	public void clientGetHeader(final int clientID, final long time) {
 		 if ( verbosity > 1 )
 			  System.out.println(sdf.format(new Date(time)) + " Client "
-				+ adresses.get(clientID) + " has been sent the header.");
+				+ addresses.get(clientID) + " has been sent the header.");
 	}
 
 	@Override
@@ -89,25 +89,25 @@ public class SystemOutMonitor implements FieldtripBufferMonitor {
 			final long time) {
 		 if ( verbosity > 1 )	
 			  System.out.println(sdf.format(new Date(time)) + " Client "
-				+ adresses.get(clientID) + " has been sent " + count
+				+ addresses.get(clientID) + " has been sent " + count
 				+ " samples.");
 	}
 
 	@Override
-	public void clientOpenedConnection(final int clientID, final String adress,
+	public void clientOpenedConnection(final int clientID, final String address,
 			final long time) {
 		 if ( verbosity > 0 )
 			  System.out.println(sdf.format(new Date(time))
-				+ " Client opened connection at " + adress + " now " + ++count
+				+ " Client opened connection at " + address + " now " + ++count
 				+ " connections opened.");
-		adresses.put(clientID, adress);
+		addresses.put(clientID, address);
 	}
 
 	@Override
 	public void clientPolls(final int clientID, final long time) {
 		 if ( verbosity > 1 )	
 			  System.out.println(sdf.format(new Date(time)) + " Client "
-				+ adresses.get(clientID) + " polls the buffer.");
+				+ addresses.get(clientID) + " polls the buffer.");
 	}
 
 	@Override
@@ -115,7 +115,7 @@ public class SystemOutMonitor implements FieldtripBufferMonitor {
 			final int diff, final long time) {
 		 if ( verbosity > 1 )
 			  System.out.println(sdf.format(new Date(time)) + " Client "
-				+ adresses.get(clientID) + " added " + diff
+				+ addresses.get(clientID) + " added " + diff
 				+ " events, total now " + count);
 	}
 
@@ -124,7 +124,7 @@ public class SystemOutMonitor implements FieldtripBufferMonitor {
 			final int nChannels, final int clientID, final long time) {
 		 if ( verbosity > 0 )
 			  System.out.println(sdf.format(new Date(time)) + " Header added by "
-				+ adresses.get(clientID) + " datatype " + dataType
+				+ addresses.get(clientID) + " datatype " + dataType
 				+ " fSample " + fSample + " nChannels " + nChannels);
 	}
 
@@ -133,7 +133,7 @@ public class SystemOutMonitor implements FieldtripBufferMonitor {
 			final int diff, final long time) {
 		 if ( verbosity > 1 )
 			  System.out.print(sdf.format(new Date(time)) + " Client "
-				+ adresses.get(clientID) + " added " + diff
+				+ addresses.get(clientID) + " added " + diff
 				+ " samples, total now " + count + "\r");
 	}
 
@@ -142,8 +142,8 @@ public class SystemOutMonitor implements FieldtripBufferMonitor {
 			final int timeout, final int clientID, final long time) {
 		 if ( verbosity > 1 )
 			  System.out.println(sdf.format(new Date(time)) + " Client "
-				+ adresses.get(clientID)
-				+ " is now waiting, tresholds are sample count " + nSamples
+				+ addresses.get(clientID)
+                                + " is now waiting, thresholds are sample count " + nSamples
 				+ ", event count " + nEvents + " or timeout " + timeout);
 	}
 

--- a/test/private/isalmostequal.m
+++ b/test/private/isalmostequal.m
@@ -103,7 +103,7 @@ if isa(a, 'numeric') || isa(a, 'char') || isa(a, 'logical')
     return;
   end
   if ~all(isnan(a(:)) == isnan(b(:)))
-    message{end+1} = sprintf('different occurence of NaNs in %s', location);
+    message{end+1} = sprintf('different occurrence of NaNs in %s', location);
     return;
   end
   % replace the NaNs, since we cannot compare them numerically

--- a/trialfun/ft_trialfun_twoclass_classification.m
+++ b/trialfun/ft_trialfun_twoclass_classification.m
@@ -2,7 +2,7 @@ function [trl] = ft_trialfun_twoclass_classification(cfg)
 
 % FT_TRIALFUN_TWOCLASS_CLASSIFICATION can be used to train and test a real-time
 % classifier in offline and online mode. It selects pieces of data in the two classes
-% based on two trigger values. The first N occurences in each class are marked as
+% based on two trigger values. The first N occurrences in each class are marked as
 % training items. All subsequent occurrences are marked as test items.
 %
 % This function can be used in conjunction with FT_REALTIME_CLASSIFICATION. The

--- a/utilities/private/channelposition.m
+++ b/utilities/private/channelposition.m
@@ -165,7 +165,7 @@ switch ft_senstype(sens)
         refori(i,:) = weight(selc)*tmpori;
 
         % check whether the line between the coils is aligned with the
-        % oriention of the coils, in which case it's a diagonal reference,
+        % orientation of the coils, in which case it's a diagonal reference,
         % otherwise it's an off diagonal reference. For the diagonal
         % reference the chanpos should be one of the coils, for the off
         % diagonal reference it should be the average.

--- a/utilities/private/mesh_sphere.m
+++ b/utilities/private/mesh_sphere.m
@@ -253,7 +253,7 @@ end
 th  = storeM(i).th;
 phi = storeM(i).phi;
 
-% convert from spherical to cartehsian coordinates
+% convert from spherical to cartesian coordinates
 [x, y, z] = sph2cart(th, pi/2-phi, 1);
 pos = [x' y' z'];
 tri = convhulln(pos);


### PR DESCRIPTION
## Summary
- fix spelling of 'occurrence' in several files
- correct 'cartesian' spelling in mesh utilities
- repair error messages in ft_omri_info_from_header
- clean up comments in channelposition helpers
- improve SystemOutMonitor output strings

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68663569351c8325861a84b469217bdc