### PR TITLE
added check for bootstrap to improve numeric behavior

### DIFF
--- a/private/resampledesign.m
+++ b/private/resampledesign.m
@@ -189,7 +189,7 @@ elseif isempty(cfg.uvar) && strcmp(cfg.resampling, 'bootstrap')
   % but the h1 test can be achieved using a control variable
   resample = zeros(cfg.numrandomization, Nrepl);
   for i=1:cfg.numrandomization
-    resample(i,:) = randsample(1:Nrepl, Nrepl, true);
+    resample(i,:) = randi(Nrepl, 1, Nrepl);
   end
   
 elseif ~isempty(cfg.uvar) && strcmp(cfg.resampling, 'permutation')
@@ -276,7 +276,7 @@ elseif length(cfg.uvar)==1 && strcmp(cfg.resampling, 'bootstrap') && isempty(cfg
   
   if ~checkunique
     for i=1:cfg.numrandomization
-      tmp           = randsample(1:Nrepl/Nrep(1), Nrepl/Nrep(1), true);
+      tmp           = randi(Nrepl/Nrep(1), 1, Nrepl/Nrep(1));
       for k=1:size(indx,1)
         resample(i,indx(k,:)) = indx(k,tmp);
       end
@@ -284,7 +284,7 @@ elseif length(cfg.uvar)==1 && strcmp(cfg.resampling, 'bootstrap') && isempty(cfg
   else
     tmp = zeros(cfg.numrandomization*10, Nrepl/Nrep(1));
     for i=1:cfg.numrandomization*10
-      tmp(i,:) = sort(randsample(1:Nrepl/Nrep(1), Nrepl/Nrep(1), true));
+      tmp(i,:) = sort(randi(Nrepl/Nrep(1), 1, Nrepl/Nrep(1)));
     end
     
     tmp = unique(tmp, 'rows');

--- a/private/resampledesign.m
+++ b/private/resampledesign.m
@@ -288,13 +288,26 @@ elseif length(cfg.uvar)==1 && strcmp(cfg.resampling, 'bootstrap') && isempty(cfg
     end
     
     tmp = unique(tmp, 'rows');
-    fprintf('found %d unique rows in bootstrap matrix of %d bootstraps', size(tmp,1), cfg.numrandomization*10);
+    fprintf('found %d unique rows in bootstrap matrix of %d bootstraps\n', size(tmp,1), cfg.numrandomization*10);
     
     if size(tmp,1)<cfg.numrandomization
       fprintf('using only %d unique bootstraps\n', size(tmp,1));
       cfg.numrandomization = size(tmp,1);
       index = 1:size(tmp,1);
     else
+      % do a quick check on the number of unique units per row
+      nunique = zeros(size(tmp,1),1);
+      for i=1:size(tmp,1)
+        nunique(i,1) = numel(unique(tmp(i,:)));
+      end
+      ununique = unique(nunique);
+      for i=1:numel(ununique)
+        nnunique(i,1) = sum(nunique==ununique(i));
+      end
+      fprintf('range of unique units across bootstraps is %d - %d\n', min(nunique), max(nunique));
+      fprintf('discarding bootstraps with <= 10 different units, selecting from %d bootstraps\n', sum(nunique>=10));
+      tmp = tmp(nunique>=10,:);
+
       index = randperm(size(tmp,1));
       index = index(1:cfg.numrandomization);
     end


### PR DESCRIPTION
This change is inspired by the fact that if the number of units is low, a bootstrap sample with very few unique units that computes a test statistic that depends on a measure of variance in the denominator (e.g. T-statistic) will become unstable numerically.