### PR TITLE
Use batch mode to avoid writing huge amount of logfiles

### DIFF
--- a/qsub/qsubfeval.m
+++ b/qsub/qsubfeval.m
@@ -420,7 +420,7 @@ switch backend
     fprintf(fid, '# Condor submit script\n');
     fprintf(fid, '\n');
     fprintf(fid, 'Executable     = %s\n', matlabcmd);
-    fprintf(fid, 'Arguments      = -batch "%s"\n', matlabscript);
+    fprintf(fid, 'Arguments      = %s "%s"\n', batchflag, matlabscript);
     % the timreq and memrequ should be inserted here
     fprintf(fid, 'Requirements   = Memory >= 32 && OpSys == "LINUX" && Arch =="INTEL"\n');
     fprintf(fid, 'Rank           = Memory >= 64\n');
@@ -466,7 +466,7 @@ switch backend
       cmdline = sprintf('%s %s %s', compiledfun, matlabroot, jobid);
     else
       % create the shell commands to execute matlab
-      cmdline = sprintf('%s -batch \\"%s\\"', matlabcmd, matlabscript);
+      cmdline = sprintf('%s %s \\"%s\\"', matlabcmd, batchflag, matlabscript);
     end
 
     % pass the command to qsub with all requirements

--- a/qsub/qsubfeval.m
+++ b/qsub/qsubfeval.m
@@ -281,7 +281,7 @@ switch backend
       cmdline = sprintf('%s %s %s', compiledfun, matlabroot, jobid);
     else
       % create the shell commands to execute matlab
-      cmdline = sprintf('%s -r "%s"', matlabcmd, matlabscript);
+      cmdline = sprintf('%s -batch "%s"', matlabcmd, matlabscript);
     end
 
   case 'sge'
@@ -309,7 +309,7 @@ switch backend
       cmdline = sprintf('%s %s %s', compiledfun, matlabroot, jobid);
     else
       % create the shell commands to execute matlab
-      cmdline = sprintf('%s -r \\"%s\\"', matlabcmd, matlabscript);
+      cmdline = sprintf('%s -batch \\"%s\\"', matlabcmd, matlabscript);
     end
 
     % pass the command to qsub with all requirements
@@ -357,7 +357,7 @@ switch backend
       cmdline = sprintf('%s %s %s', compiledfun, matlabroot, jobid);
     else
       % create the shell commands to execute matlab
-      cmdline = sprintf('%s -r \\"%s\\"', matlabcmd, matlabscript);
+      cmdline = sprintf('%s -batch \\"%s\\"', matlabcmd, matlabscript);
     end
 
     if any(curPwd==' ')
@@ -397,7 +397,7 @@ switch backend
       % create the command line for the compiled application
       cmdline = sprintf('%s %s %s', compiledfun, matlabroot, jobid);
     else
-      cmdline = sprintf('%s -r \\"%s\\"', matlabcmd, matlabscript);
+      cmdline = sprintf('%s -batch \\"%s\\"', matlabcmd, matlabscript);
     end
     cmdline = sprintf('sbatch --parsable --job-name=%s %s --output=%s --error=%s --wrap "%s"', ...
                        jobid, submitoptions, logout, logerr, cmdline);
@@ -413,7 +413,7 @@ switch backend
     fprintf(fid, '# Condor submit script\n');
     fprintf(fid, '\n');
     fprintf(fid, 'Executable     = %s\n', matlabcmd);
-    fprintf(fid, 'Arguments      = -r "%s"\n', matlabscript);
+    fprintf(fid, 'Arguments      = -batch "%s"\n', matlabscript);
     % the timreq and memrequ should be inserted here
     fprintf(fid, 'Requirements   = Memory >= 32 && OpSys == "LINUX" && Arch =="INTEL"\n');
     fprintf(fid, 'Rank           = Memory >= 64\n');
@@ -459,7 +459,7 @@ switch backend
       cmdline = sprintf('%s %s %s', compiledfun, matlabroot, jobid);
     else
       % create the shell commands to execute matlab
-      cmdline = sprintf('%s -r \\"%s\\"', matlabcmd, matlabscript);
+      cmdline = sprintf('%s -batch \\"%s\\"', matlabcmd, matlabscript);
     end
 
     % pass the command to qsub with all requirements

--- a/qsub/qsubfeval.m
+++ b/qsub/qsubfeval.m
@@ -117,6 +117,13 @@ if ~isempty(optbeg)
   varargin = varargin(1:(optbeg-1));
 end
 
+% as of matlab R2019a the -batch is a flag to be preferred over -r if running in non-interactive mode
+if ft_platform_supports('matlabversion', -inf, '2018b')
+  batchflag = '-r';
+else
+  batchflag = '-batch';
+end
+
 if isempty(backend)
   % use the system default backend
   backend = defaultbackend;
@@ -281,7 +288,7 @@ switch backend
       cmdline = sprintf('%s %s %s', compiledfun, matlabroot, jobid);
     else
       % create the shell commands to execute matlab
-      cmdline = sprintf('%s -batch "%s"', matlabcmd, matlabscript);
+      cmdline = sprintf('%s %s "%s"', matlabcmd, batchflag, matlabscript);
     end
 
   case 'sge'
@@ -309,7 +316,7 @@ switch backend
       cmdline = sprintf('%s %s %s', compiledfun, matlabroot, jobid);
     else
       % create the shell commands to execute matlab
-      cmdline = sprintf('%s -batch \\"%s\\"', matlabcmd, matlabscript);
+      cmdline = sprintf('%s %s \\"%s\\"', matlabcmd, batchflag, matlabscript);
     end
 
     % pass the command to qsub with all requirements
@@ -357,7 +364,7 @@ switch backend
       cmdline = sprintf('%s %s %s', compiledfun, matlabroot, jobid);
     else
       % create the shell commands to execute matlab
-      cmdline = sprintf('%s -batch \\"%s\\"', matlabcmd, matlabscript);
+      cmdline = sprintf('%s %s \\"%s\\"', matlabcmd, batchflag, matlabscript);
     end
 
     if any(curPwd==' ')
@@ -397,7 +404,7 @@ switch backend
       % create the command line for the compiled application
       cmdline = sprintf('%s %s %s', compiledfun, matlabroot, jobid);
     else
-      cmdline = sprintf('%s -batch \\"%s\\"', matlabcmd, matlabscript);
+      cmdline = sprintf('%s %s \\"%s\\"', matlabcmd, batchflag, matlabscript);
     end
     cmdline = sprintf('sbatch --parsable --job-name=%s %s --output=%s --error=%s --wrap "%s"', ...
                        jobid, submitoptions, logout, logerr, cmdline);


### PR DESCRIPTION
qsubfeval uses the `-r` option to execute the job-function. As mentioned in this thread (https://nl.mathworks.com/matlabcentral/answers/2121156-disable-matlabconnector-on-linux-cluster?s_tid=mlc_ans_email_view#answer_1568384) it is recommended to use the `-batch` option instead, so that the new Matlab version doesn't write enormous amounts of logfiles. I am not aware of people needing to run qsubfeval to run jobs interactively, but otherwise this PR needs to be changed such that it becomes an input option.

See also: https://nl.mathworks.com/help/matlab/matlab_env/commonly-used-startup-options.html

Run the specified statement non-interactively.
-batch "statement"  

Run the specified statement interactively.
-r "statement"