### PR TITLE
Tchaase fix/basedonmni options

### DIFF
--- a/ft_prepare_sourcemodel.m
+++ b/ft_prepare_sourcemodel.m
@@ -298,12 +298,12 @@ switch cfg.method
     cfg.tight       = ft_getopt(cfg, 'tight',      'no');
 
   case 'basedonmni'
-    cfg.tight       = ft_getopt(cfg.sourcemodel, 'tight',       'no');
-    cfg.nonlinear   = ft_getopt(cfg.sourcemodel, 'nonlinear',   'no');
+    cfg.tight       = ft_getopt(cfg, 'tight',       'no');
+    cfg.nonlinear   = ft_getopt(cfg, 'nonlinear',   'no');
 
   case 'basedoncentroids'
     fprintf('creating sourcemodel based on volumetric mesh centroids\n');
-    cfg.tight       = ft_getopt(cfg.sourcemodel, 'tight',       'no');
+    cfg.tight       = ft_getopt(cfg, 'tight',       'no');
     cfg.inwardshift = ft_getopt(cfg, 'inwardshift', 0); % in this case for inside detection
 end
 

--- a/utilities/ft_checkconfig.m
+++ b/utilities/ft_checkconfig.m
@@ -284,6 +284,7 @@ if ~isempty(createtopcfg)
           'tight'
           'warpmni'
           'template'
+          'nonlinear'
           };
 
       case {'dics' 'eloreta' 'harmony' 'lcmv' 'mne' 'music' 'mvl' 'pcc' 'rv' 'sam' 'sloreta'}


### PR DESCRIPTION
As per [issue-2518](https://github.com/fieldtrip/fieldtrip/issues/2518), I updated the `basedonmni` method case in the `ft_prepare_sourcemodel` to access the options + kept backwards comparability by having checkconfig check the config `nonlinear`. 

I should mention that one could also add "unit" as a variable to checkconfig, but doesn't change functionality at all (would just clean prepare_sourcemodel a bit and remove legacy code from there. 