### PR TITLE
ft_select_range allow for other line color etc.

### DIFF
--- a/ft_multiplotER.m
+++ b/ft_multiplotER.m
@@ -209,6 +209,9 @@ cfg.fontsize       = ft_getopt(cfg, 'fontsize',       8);
 cfg.fontweight     = ft_getopt(cfg, 'fontweight');
 cfg.interpreter    = ft_getopt(cfg, 'interpreter',    'none');  % none, tex or latex
 cfg.interactive    = ft_getopt(cfg, 'interactive',    'yes');
+cfg.interactivecolor = ft_getopt(cfg, 'interactivecolor', [0 0 0]); % linecolor of selection rectangle
+cfg.interactivestyle = ft_getopt(cfg, 'interactivestyle', '--');    % linestyle of selection rectangle
+cfg.interactivewidth = ft_getopt(cfg, 'interactivewidth', 1.5);     % linewidth of selection rectangle
 cfg.orient         = ft_getopt(cfg, 'orient',         'landscape');
 cfg.maskparameter  = ft_getopt(cfg, 'maskparameter');
 cfg.linecolor      = ft_getopt(cfg, 'linecolor',      []); % the default is handled somewhere else
@@ -667,13 +670,15 @@ if strcmp(cfg.interactive, 'yes')
   guidata(gcf, info);
   
   if isequal(cfg.viewmode, 'butterfly')
-    set(gcf, 'windowbuttonupfcn',     {@ft_select_range, 'multiple', false, 'yrange', false, 'callback', {@select_topoplotER}, 'event', 'windowbuttonupfcn'});
-    set(gcf, 'windowbuttondownfcn',   {@ft_select_range, 'multiple', false, 'yrange', false, 'callback', {@select_topoplotER}, 'event', 'windowbuttondownfcn'});
-    set(gcf, 'windowbuttonmotionfcn', {@ft_select_range, 'multiple', false, 'yrange', false, 'callback', {@select_topoplotER}, 'event', 'windowbuttonmotionfcn'});
+    cb_options = {'multiple', false, 'yrange', false, 'callback', {@select_topoplotER}, 'linecolor', cfg.interactivecolor, 'linestyle', cfg.interactivestyle, 'linewidth', cfg.interactivewidth};
+    set(gcf, 'WindowButtonUpFcn',     [{@ft_select_range, 'event', 'WindowButtonUpFcn'}      cb_options]);
+    set(gcf, 'WindowButtonDownFcn',   [{@ft_select_range, 'event', 'WindowButtonDownFcn'},   cb_options]);
+    set(gcf, 'WindowButtonMotionFcn', [{@ft_select_range, 'event', 'WindowButtonMotionFcn'}, cb_options]);
   else
-    set(gcf, 'WindowButtonUpFcn',     {@ft_select_channel, 'multiple', true, 'callback', {@select_singleplotER}, 'event', 'WindowButtonUpFcn'});
-    set(gcf, 'WindowButtonDownFcn',   {@ft_select_channel, 'multiple', true, 'callback', {@select_singleplotER}, 'event', 'WindowButtonDownFcn'});
-    set(gcf, 'WindowButtonMotionFcn', {@ft_select_channel, 'multiple', true, 'callback', {@select_singleplotER}, 'event', 'WindowButtonMotionFcn'});
+    cb_options = {'multiple', true, 'callback', {@select_singleplotER}, 'linecolor', cfg.interactivecolor, 'linestyle', cfg.interactivestyle, 'linewidth', cfg.interactivewidth};
+    set(gcf, 'WindowButtonUpFcn',     [{@ft_select_channel, 'event', 'WindowButtonUpFcn'}      cb_options]);
+    set(gcf, 'WindowButtonDownFcn',   [{@ft_select_channel, 'event', 'WindowButtonDownFcn'},   cb_options]);
+    set(gcf, 'WindowButtonMotionFcn', [{@ft_select_channel, 'event', 'WindowButtonMotionFcn'}, cb_options]);
   end
 end
 % do the general cleanup and bookkeeping at the end of the function

--- a/ft_multiplotTFR.m
+++ b/ft_multiplotTFR.m
@@ -210,6 +210,9 @@ cfg.channel        = ft_getopt(cfg, 'channel',      'all');
 cfg.fontsize       = ft_getopt(cfg, 'fontsize',      8);
 cfg.fontweight     = ft_getopt(cfg, 'fontweight');
 cfg.interactive    = ft_getopt(cfg, 'interactive',  'yes');
+cfg.interactivecolor = ft_getopt(cfg, 'interactivecolor', [0 0 0]); % linecolor of selection rectangle
+cfg.interactivestyle = ft_getopt(cfg, 'interactivestyle', '--');    % linestyle of selection rectangle
+cfg.interactivewidth = ft_getopt(cfg, 'interactivewidth', 1.5);     % linewidth of selection rectangle
 cfg.hotkeys        = ft_getopt(cfg, 'hotkeys',      'yes');
 cfg.orient         = ft_getopt(cfg, 'orient',       'landscape');
 cfg.maskalpha      = ft_getopt(cfg, 'maskalpha',     1);
@@ -518,25 +521,21 @@ for k=1:length(selchan)
   if ~isempty(cfg.maskparameter)
     mdata = shiftdim(maskmatrix(k, :, :));
   end
-  
+ 
   % Draw plot (and mask Nan's with maskfield if requested)
+  plotopts = {'clim', [zmin zmax], 'tag', 'cip', 'hpos', chanX(k), 'vpos', chanY(k), 'width', chanWidth(k), 'height', chanHeight(k)};
   if isequal(cfg.masknans, 'yes') && isempty(cfg.maskparameter)
-    nans_mask = ~isnan(cdata);
-    mask = double(nans_mask);
-    ft_plot_matrix(cdata, 'clim', [zmin zmax], 'tag', 'cip', 'highlightstyle', cfg.maskstyle, 'highlight', mask, 'hpos', chanX(k), 'vpos', chanY(k), 'width', chanWidth(k), 'height', chanHeight(k))
+    mask     = double(~isnan(cdata));
+    plotopts = cat(2, plotopts, {'highlightstyle', cfg.maskstyle, 'highlight', mask});
   elseif isequal(cfg.masknans, 'yes') && ~isempty(cfg.maskparameter)
-    nans_mask = ~isnan(cdata);
-    mask = nans_mask .* mdata;
-    mask = double(mask);
-    ft_plot_matrix(cdata, 'clim', [zmin zmax], 'tag', 'cip', 'highlightstyle', cfg.maskstyle, 'highlight', mask, 'hpos', chanX(k), 'vpos', chanY(k), 'width', chanWidth(k), 'height', chanHeight(k))
+    mask     = double((~isnan(cdata)) .* mdata);
+    plotopts = cat(2, plotopts, {'highlightstyle', cfg.maskstyle, 'highlight', mask});
   elseif isequal(cfg.masknans, 'no') && ~isempty(cfg.maskparameter)
-    mask = mdata;
-    mask = double(mask);
-    ft_plot_matrix(cdata, 'clim', [zmin zmax], 'tag', 'cip', 'highlightstyle', cfg.maskstyle, 'highlight', mask, 'hpos', chanX(k), 'vpos', chanY(k), 'width', chanWidth(k), 'height', chanHeight(k))
-  else
-    ft_plot_matrix(cdata, 'clim', [zmin zmax], 'tag', 'cip', 'hpos', chanX(k), 'vpos', chanY(k), 'width', chanWidth(k), 'height', chanHeight(k))
+    mask     = double(mdata);
+    plotopts = cat(2, plotopts, {'highlightstyle', cfg.maskstyle, 'highlight', mask});
   end
-  
+  ft_plot_matrix(cdata, plotopts{:})
+
   % Currently the handle isn't being used below, this is here for possible use in the future
   h = findobj('tag', 'cip');
 end % plot channels
@@ -583,22 +582,18 @@ if istrue(cfg.showscale)
     cdata = shiftdim(mean(datamatrix, 1));
     
     % Draw plot (and mask Nan's with maskfield if requested)
+    plotopts = {'clim', [zmin zmax], 'tag', 'cip', 'hpos', cfg.layout.pos(k, 1), 'vpos', cfg.layout.pos(k, 2), 'width', cfg.layout.width(k), 'height', cfg.layout.height(k)};
     if isequal(cfg.masknans, 'yes') && isempty(cfg.maskparameter)
-      mask = ~isnan(cdata);
-      mask = double(mask);
-      ft_plot_matrix(cdata, 'clim', [zmin zmax], 'tag', 'cip', 'highlightstyle', cfg.maskstyle, 'highlight', mask, 'hpos', cfg.layout.pos(k, 1), 'vpos', cfg.layout.pos(k, 2), 'width', cfg.layout.width(k), 'height', cfg.layout.height(k))
+      mask     = double(~isnan(cdata));
+      plotopts = cat(2, plotopts, {'highlightstyle', cfg.maskstyle, 'highlight', mask});
     elseif isequal(cfg.masknans, 'yes') && ~isempty(cfg.maskparameter)
-      mask = ~isnan(cdata);
-      mask = mask .* mdata;
-      mask = double(mask);
-      ft_plot_matrix(cdata, 'clim', [zmin zmax], 'tag', 'cip', 'highlightstyle', cfg.maskstyle, 'highlight', mask, 'hpos', cfg.layout.pos(k, 1), 'vpos', cfg.layout.pos(k, 2), 'width', cfg.layout.width(k), 'height', cfg.layout.height(k))
+      mask     = double((~isnan(cdata)) .* mdata);
+      plotopts = cat(2, plotopts, {'highlightstyle', cfg.maskstyle, 'highlight', mask});
     elseif isequal(cfg.masknans, 'no') && ~isempty(cfg.maskparameter)
-      mask = mdata;
-      mask = double(mask);
-      ft_plot_matrix(cdata, 'clim', [zmin zmax], 'tag', 'cip', 'highlightstyle', cfg.maskstyle, 'highlight', mask, 'hpos', cfg.layout.pos(k, 1), 'vpos', cfg.layout.pos(k, 2), 'width', cfg.layout.width(k), 'height', cfg.layout.height(k))
-    else
-      ft_plot_matrix(cdata, 'clim', [zmin zmax], 'tag', 'cip', 'hpos', cfg.layout.pos(k, 1), 'vpos', cfg.layout.pos(k, 2), 'width', cfg.layout.width(k), 'height', cfg.layout.height(k))
+      mask     = double(mdata);
+      plotopts = cat(2, plotopts, {'highlightstyle', cfg.maskstyle, 'highlight', mask});
     end
+    ft_plot_matrix(cdata, plotopts{:})
   end
 end % show scale
 
@@ -643,9 +638,10 @@ if strcmp(cfg.interactive, 'yes')
   info.(ident).data     = data;
   info.(ident).commenth = comment_handle;
   guidata(gcf, info);
-  set(gcf, 'WindowButtonUpFcn', {@ft_select_channel, 'multiple', true, 'callback', {@select_singleplotTFR}, 'event', 'WindowButtonUpFcn'});
-  set(gcf, 'WindowButtonDownFcn', {@ft_select_channel, 'multiple', true, 'callback', {@select_singleplotTFR}, 'event', 'WindowButtonDownFcn'});
-  set(gcf, 'WindowButtonMotionFcn', {@ft_select_channel, 'multiple', true, 'callback', {@select_singleplotTFR}, 'event', 'WindowButtonMotionFcn'});
+  cb_options = {'multiple', true, 'callback', {@select_singleplotTFR}, 'linecolor', cfg.interactivecolor, 'linestyle', cfg.interactivestyle, 'linewidth', cfg.interactivewidth};
+  set(gcf, 'WindowButtonUpFcn',     [{@ft_select_channel, 'event', 'WindowButtonUpFcn'}      cb_options]);
+  set(gcf, 'WindowButtonDownFcn',   [{@ft_select_channel, 'event', 'WindowButtonDownFcn'},   cb_options]);
+  set(gcf, 'WindowButtonMotionFcn', [{@ft_select_channel, 'event', 'WindowButtonMotionFcn'}, cb_options]);
 end
 
 % do the general cleanup and bookkeeping at the end of the function

--- a/ft_singleplotER.m
+++ b/ft_singleplotER.m
@@ -180,6 +180,9 @@ cfg.fontsize        = ft_getopt(cfg, 'fontsize',       8);
 cfg.interpreter     = ft_getopt(cfg, 'interpreter',   'none');  % none, tex or latex
 cfg.hotkeys         = ft_getopt(cfg, 'hotkeys',       'yes');
 cfg.interactive     = ft_getopt(cfg, 'interactive',   'yes');
+cfg.interactivecolor = ft_getopt(cfg, 'interactivecolor', [0 0 0]); % linecolor of selection rectangle
+cfg.interactivestyle = ft_getopt(cfg, 'interactivestyle', '--');    % linestyle of selection rectangle
+cfg.interactivewidth = ft_getopt(cfg, 'interactivewidth', 1.5);     % linewidth of selection rectangle
 cfg.maskparameter   = ft_getopt(cfg, 'maskparameter',  []);
 cfg.colorgroups     = ft_getopt(cfg, 'colorgroups',   'condition'); % this is the only supported option
 cfg.linecolor       = ft_getopt(cfg, 'linecolor',     []);
@@ -548,7 +551,7 @@ end
 if ~isempty(cfg.title)
   t = cfg.title;
 else
-  if length(cfg.channel) == 1
+  if isscalar(cfg.channel)
     t = [char(cfg.channel) ' / ' num2str(selchan) ];
   else
     t = sprintf('mean(%0s)', join_str(', ', cfg.channel));
@@ -585,9 +588,10 @@ if strcmp(cfg.interactive, 'yes')
     info.(ident).linecolor   = linecolor;
   end
   guidata(gcf, info);
-  set(gcf, 'windowbuttonupfcn',     {@ft_select_range, 'multiple', false, 'yrange', false, 'callback', {@select_topoplotER}, 'event', 'windowbuttonupfcn'});
-  set(gcf, 'windowbuttondownfcn',   {@ft_select_range, 'multiple', false, 'yrange', false, 'callback', {@select_topoplotER}, 'event', 'windowbuttondownfcn'});
-  set(gcf, 'windowbuttonmotionfcn', {@ft_select_range, 'multiple', false, 'yrange', false, 'callback', {@select_topoplotER}, 'event', 'windowbuttonmotionfcn'});
+  cb_options = {'multiple', false, 'yrange', false, 'callback', {@select_topoplotER}, 'linecolor', cfg.interactivecolor, 'linestyle', cfg.interactivestyle, 'linewidth', cfg.interactivewidth};
+  set(gcf, 'WindowButtonUpFcn',     [{@ft_select_range, 'event', 'WindowButtonUpFcn'}      cb_options]);
+  set(gcf, 'WindowButtonDownFcn',   [{@ft_select_range, 'event', 'WindowButtonDownFcn'},   cb_options]);
+  set(gcf, 'WindowButtonMotionFcn', [{@ft_select_range, 'event', 'WindowButtonMotionFcn'}, cb_options]);
 end
 
 % do the general cleanup and bookkeeping at the end of the function

--- a/plotting/ft_select_channel.m
+++ b/plotting/ft_select_channel.m
@@ -97,10 +97,18 @@ multiple = ft_getopt(varargin, 'multiple', false);
 callback = ft_getopt(varargin, 'callback');
 
 if istrue(multiple)
+  % remove the following from the arguments, if present
+  remove = {'multiple' 'callback' 'event'};
+  for i=1:numel(remove)
+    if any(strcmp(varargin, remove{i}))
+      varargin(find(strcmp(varargin, remove{i}))+[0 1]) = [];
+    end
+  end
+
   % the selection is done using select_range, which will subsequently call select_channel_multiple
-  set(gcf, 'WindowButtonDownFcn',   {@ft_select_range, 'multiple', true, 'callback', {@select_channel_multiple, callback}, 'event', 'WindowButtonDownFcn'});
-  set(gcf, 'WindowButtonUpFcn',     {@ft_select_range, 'multiple', true, 'callback', {@select_channel_multiple, callback}, 'event', 'WindowButtonUpFcn'});
-  set(gcf, 'WindowButtonMotionFcn', {@ft_select_range, 'multiple', true, 'callback', {@select_channel_multiple, callback}, 'event', 'WindowButtonMotionFcn'});
+  set(gcf, 'WindowButtonDownFcn',   {@ft_select_range, 'multiple', true, 'callback', {@select_channel_multiple, callback}, 'event', 'WindowButtonDownFcn',   varargin{:}});
+  set(gcf, 'WindowButtonUpFcn',     {@ft_select_range, 'multiple', true, 'callback', {@select_channel_multiple, callback}, 'event', 'WindowButtonUpFcn',     varargin{:}});
+  set(gcf, 'WindowButtonMotionFcn', {@ft_select_range, 'multiple', true, 'callback', {@select_channel_multiple, callback}, 'event', 'WindowButtonMotionFcn', varargin{:}});
 else
   % the selection is done using select_channel_single
   pos = get(gca, 'CurrentPoint');
@@ -190,7 +198,7 @@ else % no subplots were used
   label  = info.label(:);
 end
 
-% determine which channels ly in the selected range
+% determine which channels lie in the selected range
 select = false(size(label));
 for i=1:size(range,1)
   select = select | (x>=range(i, 1) & x<=range(i, 2) & y>=range(i, 3) & y<=range(i, 4));

--- a/plotting/ft_select_range.m
+++ b/plotting/ft_select_range.m
@@ -74,6 +74,9 @@ xrange      = ft_getopt(varargin, 'xrange',   true);
 yrange      = ft_getopt(varargin, 'yrange',   true);
 clear       = ft_getopt(varargin, 'clear',    false);
 contextmenu = ft_getopt(varargin, 'contextmenu'); % this will be displayed following a right mouse click
+linecolor   = ft_getopt(varargin, 'linecolor', [0 0 0]);
+linestyle   = ft_getopt(varargin, 'linestyle', '--');
+linewidth   = ft_getopt(varargin, 'linewidth', 1.5);
 
 % convert 'yes/no' string to boolean value
 multiple  = istrue(multiple);
@@ -273,10 +276,10 @@ switch lower(event)
       yData = [y1 y1 y2 y2 y1];
       set(userData.box(end), 'xData', xData);
       set(userData.box(end), 'yData', yData);
-      set(userData.box(end), 'Color', [0 0 0]);
+      set(userData.box(end), 'Color', linecolor);
       %set(userData.box(end), 'EraseMode', 'xor');
-      set(userData.box(end), 'LineStyle', '--');
-      set(userData.box(end), 'LineWidth', 1.5);
+      set(userData.box(end), 'LineStyle', linestyle);
+      set(userData.box(end), 'LineWidth', linewidth);
       set(userData.box(end), 'Visible', 'on');
       set(userData.box(end), 'tag', 'selectedrange');
       

--- a/private/topoplot_common.m
+++ b/private/topoplot_common.m
@@ -105,6 +105,9 @@ cfg.fontweight        = ft_getopt(cfg, 'fontweight',       'normal');
 cfg.baseline          = ft_getopt(cfg, 'baseline',         'no'); % to avoid warning in timelock/freqbaseline
 cfg.trials            = ft_getopt(cfg, 'trials',           'all', 1);
 cfg.interactive       = ft_getopt(cfg, 'interactive',      'yes');
+cfg.interactivecolor  = ft_getopt(cfg, 'interactivecolor', [0 0 0]); % linecolor of selection rectangle
+cfg.interactivestyle  = ft_getopt(cfg, 'interactivestyle', '--');    % linestyle of selection rectangle
+cfg.interactivewidth  = ft_getopt(cfg, 'interactivewidth', 1.5);     % linewidth of selection rectangle
 cfg.hotkeys           = ft_getopt(cfg, 'hotkeys',          'yes');
 cfg.renderer          = ft_getopt(cfg, 'renderer',          []); % let MATLAB decide on the default
 cfg.marker            = ft_getopt(cfg, 'marker',           'on');
@@ -871,13 +874,15 @@ for indx=1:Ndata
     guidata(gcf, info);
 
     if any(strcmp(dimord, {'chan_time', 'chan_freq', 'subj_chan_time', 'rpt_chan_time', 'chan_chan_freq', 'chancmb_freq', 'rpt_chancmb_freq', 'subj_chancmb_freq'}))
-      set(gcf, 'WindowButtonUpFcn',     {@ft_select_channel, 'multiple', true, 'callback', {@select_singleplotER}, 'event', 'WindowButtonUpFcn'});
-      set(gcf, 'WindowButtonDownFcn',   {@ft_select_channel, 'multiple', true, 'callback', {@select_singleplotER}, 'event', 'WindowButtonDownFcn'});
-      set(gcf, 'WindowButtonMotionFcn', {@ft_select_channel, 'multiple', true, 'callback', {@select_singleplotER}, 'event', 'WindowButtonMotionFcn'});
+      cb_options = {'multiple', true, 'callback', {@select_singleplotER}, 'linecolor', cfg.interactivecolor, 'linestyle', cfg.interactivestyle, 'linewidth', cfg.interactivewidth};
+      set(gcf, 'WindowButtonUpFcn',     [{@ft_select_channel, 'event', 'WindowButtonUpFcn'}      cb_options]);
+      set(gcf, 'WindowButtonDownFcn',   [{@ft_select_channel, 'event', 'WindowButtonDownFcn'},   cb_options]);
+      set(gcf, 'WindowButtonMotionFcn', [{@ft_select_channel, 'event', 'WindowButtonMotionFcn'}, cb_options]);
     elseif any(strcmp(dimord, {'chan_freq_time', 'subj_chan_freq_time', 'rpt_chan_freq_time', 'rpttap_chan_freq_time', 'chan_chan_freq_time', 'chancmb_freq_time', 'rpt_chancmb_freq_time', 'subj_chancmb_freq_time'}))
-      set(gcf, 'WindowButtonUpFcn',     {@ft_select_channel, 'multiple', true, 'callback', {@select_singleplotTFR}, 'event', 'WindowButtonUpFcn'});
-      set(gcf, 'WindowButtonDownFcn',   {@ft_select_channel, 'multiple', true, 'callback', {@select_singleplotTFR}, 'event', 'WindowButtonDownFcn'});
-      set(gcf, 'WindowButtonMotionFcn', {@ft_select_channel, 'multiple', true, 'callback', {@select_singleplotTFR}, 'event', 'WindowButtonMotionFcn'});
+      cb_options = {'multiple', true, 'callback', {@select_singleplotTFR}, 'linecolor', cfg.interactivecolor, 'linestyle', cfg.interactivestyle, 'linewidth', cfg.interactivewidth};
+      set(gcf, 'WindowButtonUpFcn',     [{@ft_select_channel, 'event', 'WindowButtonUpFcn'}      cb_options]);
+      set(gcf, 'WindowButtonDownFcn',   [{@ft_select_channel, 'event', 'WindowButtonDownFcn'},   cb_options]);
+      set(gcf, 'WindowButtonMotionFcn', [{@ft_select_channel, 'event', 'WindowButtonMotionFcn'}, cb_options]);
     else
       ft_warning('unsupported dimord "%s" for interactive plotting', dimord);
     end


### PR DESCRIPTION
Given some colormaps, the current (default + fixed) rectangle that is drawn on top of a topography is poorly visible. The default is a black dotted line with a fixed with. This PR makes this configureable. I think it can end up in the docstring as an undocumented option, and my suggestion would be to call these options: 

cfg.interactivecolor
cfg.interactivewidth
cfg.interactivestyle

