### PR TITLE
adaptive multitaper weighing for mtmfft

### DIFF
--- a/specest/ft_specest_mtmconvol.m
+++ b/specest/ft_specest_mtmconvol.m
@@ -174,7 +174,7 @@ if isnumeric(timeoiinput)
 end
 
 % set number of samples per time-window (timwin is in seconds)
-if numel(timwin)==1 && nfreqoi~=1
+if isscalar(timwin) && nfreqoi~=1
   timwin = repmat(timwin,[1 nfreqoi]);
 end
 timwinsample = round(timwin .* fsample);

--- a/specest/private/adaptspec_dpss.m
+++ b/specest/private/adaptspec_dpss.m
@@ -1,0 +1,103 @@
+function [spec, se, wt] = adaptspec_dpss(yk, lambda, adaptflag)
+% ADAPTSPEC_DPSS Adaptive multitaper spectrum estimate
+%
+%   [spec, se, wt] = adaptspec(yk, sk, lambda, adaptflag)
+%
+% Inputs
+%   yk     : [nchan x nfft x kspec] complex, tapered data Fourier transforms
+%   lambda   : [kspec x 1] real, eigenvalues of DPSS tapers
+%   adaptflag : integer, mode (default=0)
+%            0 - unweighted average (all tapers equal)
+%            1 - weighted by eigenvalues
+%            2 - adaptive multitaper (Thomson)
+%
+% Outputs
+%   spec : [nchan x nfft] spectrum estimate
+%   se   : [1 x nfft] effective degrees of freedom
+%   wt   : [nchan x nfft x kspec] weights applied to tapers
+%
+% Notes
+% - Follows Prieto’s 2006–2022 versions (your Python code).
+% - The adaptive scheme iterates until convergence or max mloop.
+%
+% Author: MATLAB translation of your provided Python code
+
+if nargin < 3
+  adaptflag = 0;
+end
+
+yk = permute(yk, [2 1 3]);
+
+[nfft, nchan, kspec] = size(yk);
+sk                   = abs(yk).^2;
+if adaptflag==0
+  % average across tapers
+  wt     = ones(nfft, nchan, kspec);
+  sbar   = mean(sk, 3);
+  spec   = sbar;
+  se     = 2 * kspec * ones(nfft,1);
+elseif adaptflag==1
+  % weigh the tapered estimates by the tapers' concentration eigenvalues
+  wt     = repmat(shiftdim(lambda(:).', -1), nfft, nchan, 1);
+  skwsum = sum(sk.*(wt.^2), 3);
+  sbar   = skwsum ./ sum(wt.^2, 3);
+  spec   = sbar;
+  se     = wt2dof(wt);
+elseif adaptflag==2
+  
+  % Freq sampling (unit sample rate assumed)
+  df = 1 / (nfft - 1);
+
+  % Variance of Sk's and avg variance
+  varsk  = sum(sk, 1) * df;     % [1 x kspec]
+  dvar   = mean(varsk, 3);
+  
+  lambda = shiftdim(lambda(:).', -1); % ensure row vector
+  bk     = repmat(dvar, [1 1 kspec]) .* (1 - repmat(lambda, [1 nchan 1])); % Thomson Eq 5.1b
+  
+  % Initialize
+  sbar = (sk(:,:,1) + sk(:,:,2)) / 2; % initial guess
+  spec = sbar;
+
+  rerr  = 1e-12;
+  mloop = 1000;
+   
+  onevec = ones(nfft, 1);
+  for i = 1:mloop
+    slast = sbar;
+    
+    for m = 1:kspec
+      wt1(:,:,m) = sbar*sqrt(lambda(m)); % [nfft x 1] x [1 x kspec]
+      wt2(:,:,m) = sbar*lambda(m) + bk(onevec,:,m);
+    end
+    wt = min(wt1 ./ wt2, 1.0);
+
+    skw    = (wt.^2) .* sk;
+    wtsum  = sum(wt.^2, 3);
+    skwsum = sum(skw, 3);
+    sbar   = skwsum ./ wtsum;
+    oerr   = max(max(abs((sbar - slast) ./ (sbar + slast))));
+  
+    if i == mloop
+      spec = sbar;
+      warning('adaptspec did not converge, rerr=%g (target %g)', oerr, rerr);
+      break;
+    end
+
+    if oerr <= rerr
+      disp(i)
+      spec = sbar;
+      break;
+    end
+  end
+  se = wt2dof(wt);
+end
+
+% permute back
+wt   = ipermute(wt, [2 1 3]);
+spec = spec.';
+se   = se.';
+
+function se = wt2dof(wt)
+
+se = 2 * (sum(wt, 3).^2) ./ sum(wt.^2, 3);


### PR DESCRIPTION
The multitaper spectral analysis methods literature advocates adaptive weighing of individually tapered Fourier transforms to improve the bias/variance properties of the spectra. This adaptive weighing also seems to be the default in MATLAB these days (i.e. the pmtm function). I played around with this a bit, and although it does not seem to have a huge impact in general, I can imagine some usecases where squeezing a little bit more signal out of single trial spectral estimates may be beneficial.
Another potential application domain may be in the estimation of 1/f slopes -> multitapering inherently 'assumes' the signal to have a white spectrum over the spectral concentration bandwidth, which will lead to an understimation of the actual slope if classical averaging across tapers is used.

The current PR is based on (python) code from G.Prieto (e.g. see Geophys.J.Int. 2007:https://doi.org/10.1111/j.1365-246X.2007.03592.x , but the technique has also been described in the Percival/Walden book).

In the process, I also made some (hopefully non-functional) tweaks to ft_freqanalysis
