### PR TITLE
removed ambiguous behavior of nearest

### DIFF
--- a/ft_topoplotCC.m
+++ b/ft_topoplotCC.m
@@ -8,7 +8,7 @@ function [cfg] = ft_topoplotCC(cfg, freq)
 % The configuration should contain:
 %   cfg.feedback      = string (default = 'textbar')
 %   cfg.layout        = specification of the layout, see FT_PREPARE_LAYOUT
-%   cfg.foi           = the frequency of interest which is to be plotted (default is the first frequency bin)
+%   cfg.foi           = scalar, the frequency of interest which is to be plotted (default is the first frequency bin)
 %   cfg.widthparam    = string, parameter to be used to control the line width (see below)
 %   cfg.alphaparam    = string, parameter to be used to control the opacity (see below)
 %   cfg.colorparam    = string, parameter to be used to control the line color

--- a/preproc/ft_preproc_dftfilter.m
+++ b/preproc/ft_preproc_dftfilter.m
@@ -188,7 +188,8 @@ elseif strcmp(dftreplace,'neighbour')
   beta = 2*dat(:, sel)/tmp(:, sel);  % estimated amplitude of complex sin and cos on integer number of cycles
   
   % boolean variable that indicates which frequency bins are to be replaced
-  stopband = nearest(freqs - Fl, dftbandwidth.*[-1 1]);
+  stopband(1) = nearest(freqs - Fl, -dftbandwidth);
+  stopband(2) = nearest(freqs - Fl,  dftbandwidth);
   stopbool = false(1,numel(freqs));
   stopbool(stopband(1):stopband(2)) = true;
   

--- a/test/test_ft_spiketriggeredspectrum.m
+++ b/test/test_ft_spiketriggeredspectrum.m
@@ -7,139 +7,118 @@ function test_ft_spiketriggeredspectrum()
 
 % create the data, in which spikes fall at known phases, and in which our spike times
 % fall precicely on the samples. In this case there is no phase error
-data = [];
-label{1} = 'lfp1';
-label{2} = 'lfp2';
-label{3} = 'spk';
-data.label = label;
-cfg.timwin = [-0.1 0.1];
-cfg.foilim = [10 90];
+data         = [];
+label{1}     = 'lfp1';
+label{2}     = 'lfp2';
+label{3}     = 'spk';
+data.label   = label;
+cfg.timwin   = [-0.1 0.1];
+cfg.foilim   = [10 90];
 data.fsample = 1000;
 
-% time: use multiple trials, each from 0 to 2 seconds
-% fs = 1000;
-NTRIALS = 20;
-time(1:NTRIALS) = {(0:0.001:2)};
-
+% use multiple trials, each from 0 to 2 seconds
 % enter a sinusoid with a known phase, without noise for now
-SINFREQ  = 50; %hz
-SINFREQ2 = 10; 
-trial(1:NTRIALS) = {[rand(1,length(time{1}))+cos(SINFREQ*2*pi*time{1});rand(1,length(time{1}))+sin(SINFREQ*2*pi*time{1})]}; % so a spike at t = 0 should mean a phase of 0. 
+ntrials          = 20;
+sinfreq          = 50; %Hz
+time(1:ntrials)  = {(0:0.001:2)};
+trial(1:ntrials) = {[rand(1,length(time{1}))+cos(sinfreq*2*pi*time{1});rand(1,length(time{1}))+sin(sinfreq*2*pi*time{1})]}; % so a spike at t = 0 should mean a phase of 0.
 
 % enter spikes with known phases, use a different phase for every trial
 Spike = [];
 [Spike.trial{1},Spike.time{1}, Spike.timestamp{1}] = deal([]);
-rho = linspace(0,1,NTRIALS);
-for iTrial = 1:NTRIALS
-    SPKFREQ = SINFREQ;
-    isi = 1/SPKFREQ; % in that way we will have a perfect phase.
-    
-    % in cycles
-    phase = rho(iTrial);
-    nSpikes = 2/isi; % 95 spikes per trials
-    spikeSteps = ones(1,nSpikes)*isi; % + 2*rand(1,nSpikes)
-    spikeTim = 0 + cumsum(spikeSteps) + phase*isi;
-    % find the number of samples
-    spikesamples = round(spikeTim/(1/data.fsample))+1; 
-    
-    spikesamples - (spikeTim/(1/data.fsample)+1) 
-   
-    spikesamples(spikesamples>length(time{iTrial})) = [];
-    trial{iTrial}(3,:) = 0;
-    trial{iTrial}(3,spikesamples) = 1;
-    
-    Spike.time{1}                = [Spike.time{1} spikeTim];
-    Spike.trial{1}               = [Spike.trial{1}; iTrial*ones(length(spikeTim),1)];
-    Spike.trialtime(iTrial,:)         = [time{1}(1) time{1}(end)];
-    Spike.timestamp{1}           = [Spike.timestamp{1} spikeTim*1000000];
+rho = linspace(0,1,ntrials);
+for iTrial = 1:ntrials
+  spkfreq = sinfreq;
+  isi = 1/spkfreq; % in that way we will have a perfect phase.
+
+  % in cycles
+  phase = rho(iTrial);
+  nSpikes = 2/isi; % 95 spikes per trials
+  spikeSteps = ones(1,nSpikes)*isi; % + 2*rand(1,nSpikes)
+  spikeTim = 0 + cumsum(spikeSteps) + phase*isi;
+  % find the number of samples
+  spikesamples = round(spikeTim/(1/data.fsample))+1;
+
+  spikesamples(spikesamples>length(time{iTrial})) = [];
+  trial{iTrial}(3,:) = 0;
+  trial{iTrial}(3,spikesamples) = 1;
+
+  Spike.time{1}                = [Spike.time{1} spikeTim];
+  Spike.trial{1}               = [Spike.trial{1}; iTrial*ones(length(spikeTim),1)];
+  Spike.trialtime(iTrial,:)    = [time{1}(1) time{1}(end)];
+  Spike.timestamp{1}           = [Spike.timestamp{1} spikeTim*1000000];
 end
 
-Spike.label = {'spk1'};
+Spike.label    = {'spk1'};
 Spike.waveform = {'spk1'};
-data.time = time;
-data.trial = trial;
-data.cfg = cfg;
-data.hdr = struct([]);
-
-%
+data.time      = time;
+data.trial     = trial;
+data.cfg       = cfg;
+data.hdr       = struct([]);
 
 % test with a simple data structure as the input
-cfg = [];
+cfg              = [];
 cfg.spikechannel = 3;
 cfg.timwin       = [-0.1 0.1];
-tic
-freq1 = ft_spiketriggeredspectrum(cfg,data);
-toc
-%
-cfg = [];
-cfg.method = 'convol';
-cfg.foi = [SINFREQ];
-cfg.t_ftimwin = 10./cfg.foi;
-cfg.taper = 'hanning';
+freq1            = ft_spiketriggeredspectrum(cfg,data);
+
+cfg              = [];
+cfg.method       = 'convol';
+cfg.foi          = sinfreq;
+cfg.t_ftimwin    = 10./cfg.foi;
+cfg.taper        = 'hanning';
 cfg.borderspikes = 'yes';
-tic
-freq2 = ft_spiketriggeredspectrum(cfg,data);
-toc
-foi = nearest(freq2.freq,SINFREQ);
-%
-foi = nearest(freq1.freq,SINFREQ);
+freq2            = ft_spiketriggeredspectrum(cfg,data);
+
+% visualize results
+figure; hold on;
+foi     = nearest(freq1.freq,sinfreq);
 inTrial = freq1.trial{1}>0;
 phases1 = angle(freq1.fourierspctrm{1}(inTrial,1,foi));
-figure, plot(freq1.time{1}(inTrial),phases1,'bx')
-%
-foi = nearest(freq2.freq,SINFREQ);
+plot(freq1.time{1}(inTrial),phases1,'bx')
+
+foi     = nearest(freq2.freq,sinfreq);
 inTrial = freq2.trial{1}>0;
 phases1 = angle(freq2.fourierspctrm{1}(inTrial,1,foi));
-hold on
 plot(freq2.time{1}(inTrial),phases1,'ro-')
 title('phase estimation using _FFT and _CONVOL gives identical results')
 
-%
 % test with a simple data structure as the input
-cfg = [];
+cfg              = [];
 cfg.spikechannel = 3;
 cfg.timwin       = [-0.1 0.1];
-tic
-freq1 = ft_spiketriggeredspectrum(cfg,data);
-toc
-%
-cfg = [];
-cfg.method = 'convol';
-cfg.foi = [SINFREQ];
-cfg.t_ftimwin = 10./cfg.foi;
-cfg.taper = 'hanning';
-cfg.borderspikes = 'no';
-tic
-freq2 = ft_spiketriggeredspectrum(cfg,data);
-toc
-%
-cfg = [];
-cfg.method = 'convol';
-cfg.foi = [SINFREQ];
-cfg.t_ftimwin = 10./cfg.foi;
-cfg.taper = 'hanning';
-cfg.borderspikes = 'no';
-cfg.channel = data.label(1:2);
-tic
-freq3 = ft_spiketriggeredspectrum(cfg,data,Spike);
-toc
-%
+freq1            = ft_spiketriggeredspectrum(cfg,data);
 
+cfg              = [];
+cfg.method       = 'convol';
+cfg.foi          = sinfreq;
+cfg.t_ftimwin    = 10./cfg.foi;
+cfg.taper        = 'hanning';
+cfg.borderspikes = 'no';
+freq2            = ft_spiketriggeredspectrum(cfg,data);
 
-foi = nearest(freq2.freq,SINFREQ);
+cfg              = [];
+cfg.method       = 'convol';
+cfg.foi          = sinfreq;
+cfg.t_ftimwin    = 10./cfg.foi;
+cfg.taper        = 'hanning';
+cfg.borderspikes = 'no';
+cfg.channel      = data.label(1:2);
+freq3            = ft_spiketriggeredspectrum(cfg,data,Spike);
+
 %
-foi = nearest(freq1.freq,SINFREQ);
+figure; hold on;
+foi     = nearest(freq1.freq,sinfreq);
 inTrial = freq1.trial{1}>0;
 phases1 = angle(freq1.fourierspctrm{1}(inTrial,1,foi));
-figure, plot(freq1.time{1}(inTrial),phases1,'bx')
-%
-foi = nearest(freq2.freq,SINFREQ);
+plot(freq1.time{1}(inTrial),phases1,'bx')
+
+foi     = nearest(freq2.freq,sinfreq);
 inTrial = freq2.trial{1}>0;
 phases1 = angle(freq2.fourierspctrm{1}(inTrial,1,foi));
-hold on
 plot(freq2.time{1}(inTrial),phases1,'ro-')
-hold on
-foi = nearest(freq3.freq,SINFREQ);
+
+foi     = nearest(freq3.freq,sinfreq);
 inTrial = freq3.trial{1}>0;
 phases1 = angle(freq3.fourierspctrm{1}(inTrial,1,foi));
 plot(freq3.time{1}(inTrial),phases1,'gd-')
@@ -149,139 +128,118 @@ title('shows phases are equivalent for one trial, though generally more reliable
 
 % create the data, in which spikes fall at known phases, and in which our spike times
 % fall precicely on the samples. In this case there is no phase error
-data = [];
-label{1} = 'lfp1';
-label{2} = 'lfp2';
-label{3} = 'spk';
+data       = [];
+label{1}   = 'lfp1';
+label{2}   = 'lfp2';
+label{3}   = 'spk';
 data.label = label;
 cfg.timwin = [-0.1 0.1];
 cfg.foilim = [10 90];
 data.fsample = 1000;
 
 % time: use multiple trials, each from 0 to 2 seconds
-% fs = 1000;
-NTRIALS = 20;
-time(1:NTRIALS) = {(0:0.001:2)};
-
 % enter a sinusoid with a known phase, without noise for now
-SINFREQ  = 50; %hz
-SINFREQ2 = 10; 
-trial(1:NTRIALS) = {[5 + time{1} + rand(1,length(time{1}))+cos(SINFREQ*2*pi*time{1});rand(1,length(time{1}))+sin(SINFREQ*2*pi*time{1})]}; % so a spike at t = 0 should mean a phase of 0. 
+ntrials          = 20;
+sinfreq          = 50; %hz
+time(1:ntrials)  = {(0:0.001:2)};
+trial(1:ntrials) = {[5 + time{1} + rand(1,length(time{1}))+cos(sinfreq*2*pi*time{1});rand(1,length(time{1}))+sin(sinfreq*2*pi*time{1})]}; % so a spike at t = 0 should mean a phase of 0.
 
 % enter spikes with known phases, use a different phase for every trial
 Spike = [];
 [Spike.trial{1},Spike.time{1}, Spike.timestamp{1}] = deal([]);
-rho = linspace(0,1,NTRIALS);
-for iTrial = 1:NTRIALS
-    SPKFREQ = SINFREQ;
-    isi = 1/SPKFREQ; % in that way we will have a perfect phase.
-    
-    % in cycles
-    phase = rho(iTrial);
-    nSpikes = 2/isi; % 95 spikes per trials
-    spikeSteps = ones(1,nSpikes)*isi; % + 2*rand(1,nSpikes)
-    spikeTim = 0 + cumsum(spikeSteps) + phase*isi;
-    % find the number of samples
-    spikesamples = round(spikeTim/(1/data.fsample))+1; 
-    
-    spikesamples - (spikeTim/(1/data.fsample)+1) 
-   
-    spikesamples(spikesamples>length(time{iTrial})) = [];
-    trial{iTrial}(3,:) = 0;
-    trial{iTrial}(3,spikesamples) = 1;
-    
-    Spike.time{1}                = [Spike.time{1} spikeTim];
-    Spike.trial{1}               = [Spike.trial{1}; iTrial*ones(length(spikeTim),1)];
-    Spike.trialtime(iTrial,:)         = [time{1}(1) time{1}(end)];
-    Spike.timestamp{1}           = [Spike.timestamp{1} spikeTim*1000000];
+rho = linspace(0,1,ntrials);
+for iTrial = 1:ntrials
+  spkfreq = sinfreq;
+  isi = 1/spkfreq; % in that way we will have a perfect phase.
+
+  % in cycles
+  phase = rho(iTrial);
+  nSpikes = 2/isi; % 95 spikes per trials
+  spikeSteps = ones(1,nSpikes)*isi; % + 2*rand(1,nSpikes)
+  spikeTim = 0 + cumsum(spikeSteps) + phase*isi;
+  % find the number of samples
+  spikesamples = round(spikeTim/(1/data.fsample))+1;
+
+  spikesamples(spikesamples>length(time{iTrial})) = [];
+  trial{iTrial}(3,:) = 0;
+  trial{iTrial}(3,spikesamples) = 1;
+
+  Spike.time{1}                = [Spike.time{1} spikeTim];
+  Spike.trial{1}               = [Spike.trial{1}; iTrial*ones(length(spikeTim),1)];
+  Spike.trialtime(iTrial,:)    = [time{1}(1) time{1}(end)];
+  Spike.timestamp{1}           = [Spike.timestamp{1} spikeTim*1000000];
 end
 
-Spike.label = {'spk1'};
+Spike.label    = {'spk1'};
 Spike.waveform = {'spk1'};
-data.time = time;
-data.trial = trial;
-data.cfg = cfg;
-data.hdr = struct([]);
-
-%
+data.time      = time;
+data.trial     = trial;
+data.cfg       = cfg;
+data.hdr       = struct([]);
 
 % test with a simple data structure as the input
-cfg = [];
+cfg              = [];
 cfg.spikechannel = 3;
 cfg.timwin       = [-0.1 0.1];
-tic
-freq1 = ft_spiketriggeredspectrum(cfg,data);
-toc
-%
-cfg = [];
-cfg.method = 'convol';
-cfg.foi = [SINFREQ];
-cfg.t_ftimwin = 10./cfg.foi;
-cfg.taper = 'hanning';
+freq1            = ft_spiketriggeredspectrum(cfg,data);
+
+cfg              = [];
+cfg.method       = 'convol';
+cfg.foi          = sinfreq;
+cfg.t_ftimwin    = 10./cfg.foi;
+cfg.taper        = 'hanning';
 cfg.borderspikes = 'yes';
-tic
-freq2 = ft_spiketriggeredspectrum(cfg,data);
-toc
-foi = nearest(freq2.freq,SINFREQ);
+freq2            = ft_spiketriggeredspectrum(cfg,data);
+
 %
-foi = nearest(freq1.freq,SINFREQ);
+figure; hold on;
+foi     = nearest(freq1.freq,sinfreq);
 inTrial = freq1.trial{1}>0;
 phases1 = angle(freq1.fourierspctrm{1}(inTrial,1,foi));
-figure, plot(freq1.time{1}(inTrial),phases1,'bx')
-%
-foi = nearest(freq2.freq,SINFREQ);
+plot(freq1.time{1}(inTrial),phases1,'bx')
+
+foi     = nearest(freq2.freq,sinfreq);
 inTrial = freq2.trial{1}>0;
 phases1 = angle(freq2.fourierspctrm{1}(inTrial,1,foi));
-hold on
 plot(freq2.time{1}(inTrial),phases1,'ro-')
 title('phase estimation using _FFT and _CONVOL gives identical results')
 
-%
 % test with a simple data structure as the input
-cfg = [];
+cfg              = [];
 cfg.spikechannel = 3;
 cfg.timwin       = [-0.1 0.1];
-tic
-freq1 = ft_spiketriggeredspectrum(cfg,data);
-toc
-%
-cfg = [];
-cfg.method = 'convol';
-cfg.foi = [SINFREQ];
-cfg.t_ftimwin = 10./cfg.foi;
-cfg.taper = 'hanning';
-cfg.borderspikes = 'no';
-tic
-freq2 = ft_spiketriggeredspectrum(cfg,data);
-toc
-%
-cfg = [];
-cfg.method = 'convol';
-cfg.foi = [SINFREQ];
-cfg.t_ftimwin = 10./cfg.foi;
-cfg.taper = 'hanning';
-cfg.borderspikes = 'no';
-cfg.channel = data.label(1:2);
-tic
-freq3 = ft_spiketriggeredspectrum(cfg,data,Spike);
-toc
-%
+freq1            = ft_spiketriggeredspectrum(cfg,data);
 
+cfg              = [];
+cfg.method       = 'convol';
+cfg.foi          = sinfreq;
+cfg.t_ftimwin    = 10./cfg.foi;
+cfg.taper        = 'hanning';
+cfg.borderspikes = 'no';
+freq2            = ft_spiketriggeredspectrum(cfg,data);
 
-foi = nearest(freq2.freq,SINFREQ);
+cfg              = [];
+cfg.method       = 'convol';
+cfg.foi          = sinfreq;
+cfg.t_ftimwin    = 10./cfg.foi;
+cfg.taper        = 'hanning';
+cfg.borderspikes = 'no';
+cfg.channel      = data.label(1:2);
+freq3            = ft_spiketriggeredspectrum(cfg,data,Spike);
+
 %
-foi = nearest(freq1.freq,SINFREQ);
+figure; hold on;
+foi     = nearest(freq1.freq,sinfreq);
 inTrial = freq1.trial{1}>0;
 phases1 = angle(freq1.fourierspctrm{1}(inTrial,1,foi));
-figure, plot(freq1.time{1}(inTrial),phases1,'bx')
-%
-foi = nearest(freq2.freq,SINFREQ);
+plot(freq1.time{1}(inTrial),phases1,'bx')
+
+foi     = nearest(freq2.freq,sinfreq);
 inTrial = freq2.trial{1}>0;
 phases1 = angle(freq2.fourierspctrm{1}(inTrial,1,foi));
-hold on
 plot(freq2.time{1}(inTrial),phases1,'ro-')
-hold on
-foi = nearest(freq3.freq,SINFREQ);
+
+foi     = nearest(freq3.freq,sinfreq);
 inTrial = freq3.trial{1}>0;
 phases1 = angle(freq3.fourierspctrm{1}(inTrial,1,foi));
 plot(freq3.time{1}(inTrial),phases1,'gd-')
@@ -293,80 +251,73 @@ title('shows phases are equivalent for one trial, though generally more reliable
 
 % create the data, in which spikes fall at known phases, and in which our spike times
 % fall precicely on the samples. In this case there is no phase error
-data = [];
-label{1} = 'lfp1';
-label{2} = 'lfp2';
-label{3} = 'spk';
-data.label = label;
-cfg.timwin = [-0.1 0.1];
-cfg.foilim = [10 90];
+data         = [];
+label{1}     = 'lfp1';
+label{2}     = 'lfp2';
+label{3}     = 'spk';
+data.label   = label;
+cfg.timwin   = [-0.1 0.1];
+cfg.foilim   = [10 90];
 data.fsample = 1000;
 
 % time: use multiple trials, each from 0 to 2 seconds
-% fs = 1000;
-NTRIALS = 20;
-time(1:NTRIALS) = {(0:0.001:2)};
-
 % enter a sinusoid with a known phase, without noise for now
-SINFREQ  = 50; %hz
-SINFREQ2 = 10; 
-trial(1:NTRIALS) = {[10*cos(SINFREQ*2*pi*time{1});sin(SINFREQ*2*pi*time{1})]}; % so a spike at t = 0 should mean a phase of 0. 
+sinfreq          = 50; %hz
+ntrials          = 20;
+time(1:ntrials)  = {(0:0.001:2)};
+trial(1:ntrials) = {[10*cos(sinfreq*2*pi*time{1});sin(sinfreq*2*pi*time{1})]}; % so a spike at t = 0 should mean a phase of 0.
 
 % enter spikes with known phases, use a different phase for every trial
 Spike = [];
 [Spike.trial{1},Spike.time{1}, Spike.timestamp{1}] = deal([]);
-rho = linspace(0,1,NTRIALS);
-for iTrial = 1:NTRIALS
-    SPKFREQ = SINFREQ;
-    isi = 1/SPKFREQ; % in that way we will have a perfect phase.
-    
-    % in cycles
-    phase = rho(iTrial);
-    nSpikes = 2/isi; % 95 spikes per trials
-    spikeSteps = ones(1,nSpikes)*isi; % + 2*rand(1,nSpikes)
-    spikeTim = 0 + cumsum(spikeSteps) + phase*isi;
-    % find the number of samples
-    spikesamples = round(spikeTim/(1/data.fsample))+1; 
-    
-    spikesamples - (spikeTim/(1/data.fsample)+1) 
-   
-    spikesamples(spikesamples>length(time{iTrial})) = [];
-    trial{iTrial}(3,:) = 0;
-    trial{iTrial}(3,spikesamples) = 1;
-    
-    Spike.time{1}                = [Spike.time{1} spikeTim];
-    Spike.trial{1}               = [Spike.trial{1}; iTrial*ones(length(spikeTim),1)];
-    Spike.trialtime(iTrial,:)         = [time{1}(1) time{1}(end)];
-    Spike.timestamp{1}           = [Spike.timestamp{1} spikeTim*1000000];
+rho = linspace(0,1,ntrials);
+for iTrial = 1:ntrials
+  spkfreq = sinfreq;
+  isi = 1/spkfreq; % in that way we will have a perfect phase.
+
+  % in cycles
+  phase      = rho(iTrial);
+  nSpikes    = 2/isi; % 95 spikes per trials
+  spikeSteps = ones(1,nSpikes)*isi; % + 2*rand(1,nSpikes)
+  spikeTim   = 0 + cumsum(spikeSteps) + phase*isi;
+  % find the number of samples
+  spikesamples = round(spikeTim/(1/data.fsample))+1;
+
+  spikesamples(spikesamples>length(time{iTrial})) = [];
+  trial{iTrial}(3,:) = 0;
+  trial{iTrial}(3,spikesamples) = 1;
+
+  Spike.time{1}                = [Spike.time{1} spikeTim];
+  Spike.trial{1}               = [Spike.trial{1}; iTrial*ones(length(spikeTim),1)];
+  Spike.trialtime(iTrial,:)    = [time{1}(1) time{1}(end)];
+  Spike.timestamp{1}           = [Spike.timestamp{1} spikeTim*1000000];
 end
 
-Spike.label = {'spk1'};
+Spike.label    = {'spk1'};
 Spike.waveform = {'spk1'};
-data.time = time;
-data.trial = trial;
-data.cfg = cfg;
-data.hdr = struct([]);
+data.time      = time;
+data.trial     = trial;
+data.cfg       = cfg;
+data.hdr       = struct([]);
 
 %
-
-cfg = [];
-cfg.method = 'convol';
-cfg.foi = [SINFREQ];
-cfg.t_ftimwin = 10./cfg.foi;
-cfg.taper = 'hanning';
+cfg              = [];
+cfg.method       = 'convol';
+cfg.foi          = sinfreq;
+cfg.t_ftimwin    = 10./cfg.foi;
+cfg.taper        = 'hanning';
 cfg.borderspikes = 'yes';
-tic
-freq2_a = ft_spiketriggeredspectrum(cfg,data);
-toc
+freq2_a          = ft_spiketriggeredspectrum(cfg,data);
 
-cfg = [];
-cfg.method = 'convol';
-cfg.foi = [SINFREQ];
-cfg.t_ftimwin = 5./cfg.foi;
-cfg.taper = 'hanning';
+cfg              = [];
+cfg.method       = 'convol';
+cfg.foi          = sinfreq;
+cfg.t_ftimwin    = 5./cfg.foi;
+cfg.taper        = 'hanning';
 cfg.borderspikes = 'yes';
-tic
-freq2_b = ft_spiketriggeredspectrum(cfg,data);
-toc
- figure, plot(abs(freq2_a.fourierspctrm{1}(1:200,1))),  hold on, plot(abs(freq2_b.fourierspctrm{1}(1:200,1)),'r') % note rounding errors, but mag = 10 indeed
- title('shows equal power independent of window length')
+freq2_b          = ft_spiketriggeredspectrum(cfg,data);
+
+figure; hold on;
+plot(abs(freq2_a.fourierspctrm{1}(1:200,1)));
+plot(abs(freq2_b.fourierspctrm{1}(1:200,1)),'r'); % note rounding errors, but mag = 10 indeed
+title('shows equal power independent of window length');

--- a/test/test_nearest.m
+++ b/test/test_nearest.m
@@ -44,25 +44,11 @@ try
   error('this should have returned an error');
 end
 
-% new functionality of 'val' being a [minval maxval] input pair
-
-assert(all(nearest(.1:.1:1.0,[.1 .3])==[1 3]))
-assert(all(nearest(.1:.1:1.0,[.11 .3])==[2 3]))
-assert(all(nearest(.1:.1:1.0,[.1 .29])==[1 2]))
-assert(all(nearest(.1:.1:1.0,[0 .3])==[1 3]))
-assert(all(nearest(.1:.1:1.0,[.11 .29])==[2 2]))
-assert(all(nearest(.1:.1:1.0,[-inf 1])==[1 10]))
-assert(all(nearest(.1:.1:1.0,[.79 inf])==[8 10]))
-assert(all(nearest(.1:.1:1.0,[.8 10])==[8 10]))
-assert(all(nearest(.1:.1:1.0,[-2 8])==[1 10]))
-assert(all(nearest(.1:.1:1.0,[.79 .99])==[8 9]))
-assert(all(nearest(.001:.001:.01,[.002 .003])==[2 3]))
-assert(all(nearest(.001:.001:.1,[0 1])==[1 100]))
 
 try
   nearest(.1:.1:1.0,[3 8]);
 catch me
-  if ~strcmp(me.message,'The limits you selected are outside the range available in the data')
+  if ~strcmp(me.message,'The selected value should be a scalar')
     error('wrong error message in nearest')
   end
 end
@@ -95,10 +81,10 @@ for i=1:10
 end
 t2 = toc;
 
-fprintf('Time needed for nearest function: %.2s per 100 calls\n', t1/100);
-fprintf('Time needed for find function: %.2s per 100 calls\n', t2/100);
+fprintf('Time needed for nearest function: %.2g s per 100 calls\n', t1/100);
+fprintf('Time needed for find function: %.2g s per 100 calls\n', t2/100);
 
-if indx~=indx2, 
+if indx~=indx2
   error('nearest does not output the correct value');
   fprintf('nearest is off by %d samples', indx2-indx);
 end

--- a/utilities/ft_selectdata.m
+++ b/utilities/ft_selectdata.m
@@ -994,7 +994,7 @@ if isempty(cfg.latency)
     timeindx{k} = [];
   end
   
-elseif numel(cfg.latency)==1
+elseif isscalar(cfg.latency)
   % this single value should be within the time axis of each input data structure
   if numel(alltimevec)>1
     tbin = nearest(alltimevec, cfg.latency, true, true); % determine the numerical tolerance
@@ -1130,7 +1130,7 @@ if isfield(cfg, 'frequency')
       freqindx{k} = [];
     end
     
-  elseif numel(cfg.frequency)==1
+  elseif isscalar(cfg.frequency)
     % this single value should be within the frequency axis of each input data structure
     if numel(freqaxis)>1
       fbin = nearest(freqaxis, cfg.frequency, true, true); % determine the numerical tolerance

--- a/utilities/nearest.m
+++ b/utilities/nearest.m
@@ -5,8 +5,7 @@ function [indx] = nearest(array, val, insideflag, toleranceflag)
 % Use as
 %   [indx] = nearest(array, val, insideflag, toleranceflag)
 %
-% The second input val can be a scalar, or a [minval maxval] vector for
-% limits selection.
+% The second input val should be a scalar.
 %
 % If not specified or if left empty, the insideflag and the toleranceflag
 % will default to false.
@@ -25,7 +24,7 @@ function [indx] = nearest(array, val, insideflag, toleranceflag)
 %
 % See also FIND, DSEARCHN
 
-% Copyright (C) 2002-2012, Robert Oostenveld
+% Copyright (C) 2002-2025, Robert Oostenveld and Jan-Mathijs Schoffelen
 %
 % This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
 % for the documentation and details.
@@ -45,31 +44,12 @@ function [indx] = nearest(array, val, insideflag, toleranceflag)
 %
 % $Id$
 
+% input checks
 mbreal(array);
-mbreal(val);
-
 mbvector(array);
-assert(all(~isnan(val)), 'incorrect value (NaN)');
-
-if numel(val)==2
-  % interpret this as a range specification like [minval maxval]
-  % see also http://bugzilla.fieldtriptoolbox.org/show_bug.cgi?id=1431
-  intervaltol = eps;
-  sel = find(array>=val(1) & array<=val(2));
-  if isempty(sel)
-    ft_error('The limits you selected are outside the range available in the data');
-  end
-  indx = sel([1 end]);
-  if indx(1)>1 && abs(array(indx(1)-1)-val(1))<=intervaltol
-    indx(1) = indx(1)-1;
-  end
-  if indx(2)<length(array) && abs(array(indx(2)+1)-val(2))<=intervaltol
-    indx(2) = indx(2)+1;
-  end
-  return
-end
-
-mbscalar(val);
+mbreal(val);
+if ~isscalar(val), ft_error('The selected value should be a scalar, non-scalar value is not supported anymore due to ambiguity in functional behavior'); end
+if  isnan(val),    ft_error('The selected value should not be NaN');  end
 
 if nargin<3 || isempty(insideflag)
   insideflag = false;
@@ -90,7 +70,7 @@ maxarray = max(array);
 if insideflag
   if ~toleranceflag
     if val<minarray || val>maxarray
-      if numel(array)==1
+      if isscalar(array)
         ft_warning('the selected value %g should be within the range of the array from %g to %g', val, minarray, maxarray);
       else
         ft_error('the selected value %g should be within the range of the array from %g to %g', val, minarray, maxarray);
@@ -166,14 +146,6 @@ end
 function mbreal(a)
 if ~isreal(a)
   ft_error('Argument to mbreal must be real');
-end
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% SUBFUNCTION
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-function mbscalar(a)
-if ~all(size(a)==1)
-  ft_error('Argument to mbscalar must be scalar');
 end
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
the fieldtrip utility function nearest at some point was changed to support a 2-element vector as second input. This may have had its historical reasons, but led to ambiguous behavior, in the sense that the vector was treated as a range, within which the nearest indices should lie. This led to unexpected behavior. 

I did a sweep of the codebase - to identify potential locations where a 2-element input was used, and cleaned this up. I reverted the functional behavior of nearest back to supporting only a scalar second input argument. I think that I picked up most of the relevant code, and rely on the dashboard to catch any trailing occurrences.