### PR TITLE
FIX  potential qsubget filesystem latency issue

### DIFF
--- a/qsub/qsublist.m
+++ b/qsub/qsublist.m
@@ -203,10 +203,8 @@ switch cmd
     end
 
     % if the job has completed without error, check if the output file is present (it may not yet be available due to file system latency)
-    if ~ismember(backend, {'local','system'}) && retval && isfile(logerr)
-      if dir(logerr).bytes == 0
+    if ~ismember(backend, {'local','system'}) && retval && isfile(logerr) && dir(logerr).bytes == 0
         retval = isfile(outputfile);
-      end
     end
 
   case 'list'


### PR DESCRIPTION
Check output file presence after job completion to handle file system latency. I believe this may prevent latency issues in `qsubget`, which is also supported by the comment in there (but which was not guaranteed):

>   if qsublist('completed', jobid)
    % the job has completed and the output file exist

I think `qsubcellfun` suffered from this in particular, because in there it checks `argout`, which can sometimes be empty due to filesystem latency