### PR TITLE
FIX - preserve Matlab path order in qsubfeval > getcustompath

### DIFF
--- a/qsub/private/getcustompath.m
+++ b/qsub/private/getcustompath.m
@@ -38,6 +38,7 @@ if ispc
 else
   p = tokenize(path, ':');
 end
+
 % remove the matlab specific directories
 if ispc
   s = false(size(p));
@@ -49,11 +50,13 @@ else
 end
 d = p(~s);
 p = p( s);
+
 % remove the directory containing the peer code, the worker should use its own
 f = mfilename('fullpath'); % this is .../peer/private/getcustompath.m
 f = fileparts(f);          % this is .../peer/private
 f = fileparts(f);          % this is .../peer
-p = setdiff(p, f);
+p = p(~strcmp(p, f));      % alternative: p = setdiff(p, f, 'stable');  % NB: The 'stable' option was introduced in R2012a -- critical to preserve the order of the path!
+
 % concatenate the path, using the platform specific seperator
 if ispc
   p = sprintf('%s;', p{:});


### PR DESCRIPTION
This line in getcustompath erroneously reordered the Matlab path into alphabetical order:
```matlab
setdiff(p, f)
```
Proof of concept:
```matlab
p={'ccc','bb','a'};
f='bb';
>> setdiff(p, f)

ans =

  1×2 cell array

    {'a'}    {'ccc'}
```

There are two simple solutions:

1. Use 'stable' option that was introduced in R2012
```matlab
>> setdiff(p, f, 'stable')

ans =

  1×2 cell array

    {'ccc'}    {'a'}
```

2. Use:
```matlab
>> p(~strcmp(p, f))

ans =

  1×2 cell array

    {'ccc'}    {'a'}
```
I have chosen option 2, but either one is good to me...