### PR TITLE
ENH - add identifiers to the message when reporting qsubget errors/warnings

### DIFF
--- a/qsub/private/fexec.m
+++ b/qsub/private/fexec.m
@@ -192,7 +192,7 @@ try
   fprintf('executing job took %f seconds and %d bytes\n', timused, memused);
   
   % collect the output options
-  optout = {'timused', timused, 'memused', memused, 'lastwarn', lastwarn, 'lasterr', '', 'diary', diarystring, 'release', version('-release'), 'pwd', pwd, 'path', path, 'hostname', getenv('HOSTNAME')};
+  optout = {'timused', timused, 'memused', memused, 'lastwarn', lastwarnmsg, 'lasterr', '', 'diary', diarystring, 'release', version('-release'), 'pwd', pwd, 'path', path, 'hostname', getenv('HOSTNAME')};
   
 catch
   % the "catch me" syntax is broken on MATLAB74, this fixes it
@@ -211,7 +211,7 @@ catch
   
   % the output options will include the error
   % note that the error cannot be sent as object, but has to be sent as struct
-  optout = {'lastwarn', lastwarn, 'lasterr', struct(feval_error), 'diary', diarystring, 'release', version('-release'), 'pwd', pwd, 'path', path};
+  optout = {'lastwarn', lastwarnmsg, 'lasterr', struct(feval_error), 'diary', diarystring, 'release', version('-release'), 'pwd', pwd, 'path', path};
   
   % an error was detected while executing the job
   warning('an error was detected during job execution');
@@ -249,3 +249,11 @@ if ~isempty(controllerid) || ~isempty(timallow) || ~isempty(memallow)
   watchdog(0,0,0); % this is required to unlock it from memory
 end
 
+
+function warnmsg = lastwarnmsg()
+% Construct a more elaborate lastwarn message string from the lastwarn identifier + message
+
+[warnmsg, warnid] = lastwarn;
+if ~isempty(warnmsg)
+  warnmsg = sprintf('%s:%s', warnid, warnmsg);
+end

--- a/qsub/qsubget.m
+++ b/qsub/qsubget.m
@@ -149,9 +149,9 @@ if completed
     if ischar(err)
       errmsg = err;
     elseif isstruct(err)
-      errmsg = err.message;
+      errmsg = sprintf('%s:%s', err.identifier, err.message);
     else
-      errmsg = err.message;
+      errmsg = sprintf('%s:%s', err.identifier, err.message);
       % convert the MEexception object into a structure to allow a rethrow further down in the code
       ws = warning('off', 'MATLAB:structOnObject');
       err = struct(err);


### PR DESCRIPTION
I would prefer to see the line numbers of the functions that evoked the errors/warnings, but this will at least add the warn/error identifier to the message that is printed by qsubget