### PR TITLE
bugfix in read_neuralynx_ncs

### DIFF
--- a/fileio/private/read_neuralynx_ncs.m
+++ b/fileio/private/read_neuralynx_ncs.m
@@ -217,7 +217,7 @@ if begrecord>=1 && endrecord>=begrecord
       NumValidSamp(k) = fread(fid,   1, 'int32');
       Samp(:,k)       = fread(fid, 512, 'int16');
       % mark the invalid samples
-      Samp((NumValidSamp+1):end,k) = nan;
+      Samp((NumValidSamp(k)+1):end,k) = nan;
     end
     
   end % if isMexv6


### PR DESCRIPTION
This PR fixes a bug where NumValidSamp was incorrectly used as a scalar index. Since NumValidSamp is a vector, it needs to be indexed before being used.