### PR TITLE
Artefact-aware dipole fitting with HArtMuT

### DIFF
--- a/forward/ft_inside_headmodel.m
+++ b/forward/ft_inside_headmodel.m
@@ -16,6 +16,9 @@ function [inside] = ft_inside_headmodel(dippos, headmodel, varargin)
 %   inwardshift = number
 %   grad        = structure with gradiometer information, used for localspheres
 %   headshape   = structure with headshape, used for old CTF localspheres strategy
+%   surface     = string, the compartment that dipoles should be inside, either
+%                 'brain' (default) or 'scalp'/'skin'. Choose 'scalp'/'skin' to
+%                 fit muscle and eye sources outside the brain, as in the HArtMuT model.
 
 % Copyright (C) 2003-2024, Robert Oostenveld
 %
@@ -41,6 +44,7 @@ function [inside] = ft_inside_headmodel(dippos, headmodel, varargin)
 grad        = ft_getopt(varargin, 'grad');
 headshape   = ft_getopt(varargin, 'headshape');
 inwardshift = ft_getopt(varargin, 'inwardshift');
+surface     = ft_getopt(varargin, 'surface', 'brain');
 
 % for backward compatibility
 headmodel = fixpos(headmodel);
@@ -116,8 +120,22 @@ switch ft_headmodeltype(headmodel)
 
   case {'bem', 'dipoli', 'bemcp', 'openmeeg', 'asa', 'singleshell', 'neuromag', 'nolte', 'hbf'}
     % this is a model with a realistic shape described by a triangulated boundary
-    [pos, tri] = headsurface(headmodel, [], 'inwardshift', inwardshift, 'surface', 'brain');
-    inside = surface_inside(dippos, pos, tri);
+    switch surface
+      case 'brain'
+        [pos, tri] = headsurface(headmodel, [], 'inwardshift', inwardshift, 'surface', 'brain');
+        inside = surface_inside(dippos, pos, tri);
+      case {'scalp', 'skin'}
+        % a dipole is in the scalp compartment when it is inside the skin but outside the skull
+        if ~isfield(headmodel, 'bnd') || numel(headmodel.bnd)<2
+          ft_error('the scalp compartment requires a head model with at least two boundaries');
+        end
+        [skinpos, skintri] = headsurface(headmodel, [], 'inwardshift', inwardshift, 'surface', 'skin');
+        order  = surface_nesting(headmodel.bnd, 'outsidefirst');
+        skull  = order(2); % the boundary just inside the skin
+        inside = surface_inside(dippos, skinpos, skintri) & ~surface_inside(dippos, headmodel.bnd(skull).pos, headmodel.bnd(skull).tri);
+      otherwise
+        ft_error('unsupported surface "%s"', surface);
+    end
 
   case {'simbio', 'duneuro'}
     % this is a model with hexahedrons or tetrahedrons

--- a/forward/ft_inside_headmodel.m
+++ b/forward/ft_inside_headmodel.m
@@ -123,7 +123,9 @@ switch ft_headmodeltype(headmodel)
     switch surface
       case 'brain'
         [pos, tri] = headsurface(headmodel, [], 'inwardshift', inwardshift, 'surface', 'brain');
-        inside = surface_inside(dippos, pos, tri);
+        % surface_inside returns 1, 0, or nan for a degenerate point that lands on the mesh,
+        % the ==1 coerces it to a clean logical so the caller always gets a boolean vector
+        inside = surface_inside(dippos, pos, tri) == 1;
       case {'scalp', 'skin'}
         % a dipole is in the scalp compartment when it is inside the skin but outside the skull
         if ~isfield(headmodel, 'bnd') || numel(headmodel.bnd)<2
@@ -132,7 +134,11 @@ switch ft_headmodeltype(headmodel)
         [skinpos, skintri] = headsurface(headmodel, [], 'inwardshift', inwardshift, 'surface', 'skin');
         order  = surface_nesting(headmodel.bnd, 'outsidefirst');
         skull  = order(2); % the boundary just inside the skin
-        inside = surface_inside(dippos, skinpos, skintri) & ~surface_inside(dippos, headmodel.bnd(skull).pos, headmodel.bnd(skull).tri);
+        % coerce each test to a logical first, a degenerate point gives nan and nan cannot
+        % be combined with the & operator
+        inskin  = surface_inside(dippos, skinpos, skintri) == 1;
+        inskull = surface_inside(dippos, headmodel.bnd(skull).pos, headmodel.bnd(skull).tri) == 1;
+        inside  = inskin & ~inskull;
       otherwise
         ft_error('unsupported surface "%s"', surface);
     end

--- a/ft_dipolefitting.m
+++ b/ft_dipolefitting.m
@@ -448,6 +448,20 @@ if strcmp(cfg.gridsearch, 'yes')
   end
   
   insideindx = find(sourcemodel.inside);
+
+  if size(sourcemodel.pos,2)==3
+    if ~isfield(sourcemodel, 'leadfield')
+      sourcemodel.leadfield = cell(size(sourcemodel.pos,1), 1);
+    end
+    needindx = insideindx(cellfun(@isempty, sourcemodel.leadfield(insideindx)));
+    if ~isempty(needindx)
+      lfall = ft_compute_leadfield(sourcemodel.pos(needindx,:), sens, headmodel, leadfieldopt{:});
+      for i=1:numel(needindx)
+        sourcemodel.leadfield{needindx(i)} = lfall(:, (3*i-2):(3*i));
+      end
+    end
+  end
+
   ft_progress('init', cfg.feedback, 'scanning grid');
   for i=1:length(insideindx)
     ft_progress(i/length(insideindx), 'scanning grid location %d/%d\n', i, length(insideindx));
@@ -547,6 +561,11 @@ switch cfg.model
     ft_error('unsupported cfg.model');
 end % switch model
 
+% track which moving-model topographies are fit as a HArtMuT symmetric ocular pair, so the
+% final moment estimate keeps the pair linked (mom2 = mommap*mom1) the same way the fit did
+eyelinkmom = false(1, ntime);
+eyemommap  = eye(3);
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % perform the non-linear fit
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -588,6 +607,7 @@ if strcmp(cfg.nonlinear, 'yes')
           eyeconstr.expand  = [1 2 3 1 2 3];
           eyeconstr.mirror  = ones(1,6); eyeconstr.mirror(3+axisindx) = -1;
           eyeconstr.linkmom = true;
+          eyemommap         = ft_getopt(eyeconstr, 'mommap', eye(3));
         else
           ft_warning('the HArtMuT ocular source positions could not be determined, the eyes are fit as single dipoles; provide cfg.dipfit.eye.pos or use an MNI-like coordinate system');
         end
@@ -601,6 +621,7 @@ if strcmp(cfg.nonlinear, 'yes')
           thisdip.mom   = zeros(6,1);
           thisdipfitopt = ft_setopt(thisdipfitopt, 'constr', eyeconstr);
           thisdipfitopt = ft_setopt(thisdipfitopt, 'checkinside', false); % the eye is outside the brain
+          eyelinkmom(t) = true;
         end
         % catch errors due to non-convergence
         try
@@ -673,7 +694,15 @@ switch cfg.model
           lf = dip(t).lf;
         end
         % compute all details of the final dipole model
-        dip(t).mom = pinv(lf)*Vdata(:,t);
+        if eyelinkmom(t)
+          % a HArtMuT ocular pair shares one moment, mom2 = mommap*mom1, so estimate the
+          % shared moment against the fused leadfield instead of fitting the two independently
+          lfc = lf(:,1:3) + lf(:,4:6)*eyemommap;
+          mc  = pinv(lfc)*Vdata(:,t);
+          dip(t).mom = [mc; eyemommap*mc];
+        else
+          dip(t).mom = pinv(lf)*Vdata(:,t);
+        end
         dip(t).pot = lf*dip(t).mom;
         dip(t).rv  = rv(Vdata(:,t), dip(t).pot);
         Vmodel(:,t) = dip(t).pot;

--- a/ft_dipolefitting.m
+++ b/ft_dipolefitting.m
@@ -72,7 +72,7 @@ function [source] = ft_dipolefitting(cfg, data)
 %   cfg.dipfit.hartmut      = 'yes' or 'no' (default = 'no'), use the HArtMuT extension to also fit sources in the
 %                             scalp compartment, e.g. muscle artefacts, and the eyes as symmetric dipole pairs
 %   cfg.dipfit.eye          = structure controlling the ocular sources of the HArtMuT extension, with fields
-%                             radius (default 22), interocular (default 68) and offset (default [68 -32], the
+%                             radius (default 22), interocular (default 70) and offset (default [72 -25], the
 %                             [anterior superior] offset), all in mm, and an optional field pos with the centre
 %                             of one eye in head coordinates, see also private/hartmut_eyemodel.m
 %
@@ -281,6 +281,10 @@ end
 % this will also update cfg.channel to match the electrodes/gradiometers
 [headmodel, sens, cfg] = prepare_headmodel(cfg, data);
 
+if istrue(cfg.dipfit.hartmut) && ~ft_senstype(sens, 'eeg')
+  ft_error('the HArtMuT extension is only supported for EEG');
+end
+
 % construct the low-level options for the leadfield computation as key-value pairs, these are passed to FT_COMPUTE_LEADFIELD and FT_INVERSE_DIPOLEFIT
 leadfieldopt = {};
 leadfieldopt = ft_setopt(leadfieldopt, 'reducerank',     ft_getopt(cfg, 'reducerank'));
@@ -451,7 +455,10 @@ if strcmp(cfg.gridsearch, 'yes')
   
   insideindx = find(sourcemodel.inside);
 
-  if size(sourcemodel.pos,2)==3
+  if istrue(cfg.dipfit.hartmut) && size(sourcemodel.pos,2)==3
+    % HArtMuT mixes precomputed eye leadfields with empty brain and scalp entries, so
+    % batch-compute the missing ones up front; the ordinary fit keeps its lazy per-point
+    % computation in the scan loop below to preserve its memory footprint
     if ~isfield(sourcemodel, 'leadfield')
       sourcemodel.leadfield = cell(size(sourcemodel.pos,1), 1);
     end

--- a/ft_dipolefitting.m
+++ b/ft_dipolefitting.m
@@ -255,6 +255,9 @@ if istrue(cfg.dipfit.hartmut)
   cfg.dipfit.eye.radius      = ft_getopt(cfg.dipfit.eye, 'radius', 22);
   cfg.dipfit.eye.interocular = ft_getopt(cfg.dipfit.eye, 'interocular', 68);
   cfg.dipfit.eye.offset      = ft_getopt(cfg.dipfit.eye, 'offset', [68 -32]);
+  if strcmp(cfg.model, 'regional')
+    ft_warning('the HArtMuT extension fits symmetric ocular dipoles only in the moving model, the eyes are fit as single dipoles in the regional model');
+  end
 end
 
 if iscomp
@@ -585,6 +588,8 @@ if strcmp(cfg.nonlinear, 'yes')
           eyeconstr.expand  = [1 2 3 1 2 3];
           eyeconstr.mirror  = ones(1,6); eyeconstr.mirror(3+axisindx) = -1;
           eyeconstr.linkmom = true;
+        else
+          ft_warning('the HArtMuT ocular source positions could not be determined, the eyes are fit as single dipoles; provide cfg.dipfit.eye.pos or use an MNI-like coordinate system');
         end
       end
       for t=1:ntime

--- a/ft_dipolefitting.m
+++ b/ft_dipolefitting.m
@@ -570,14 +570,40 @@ if strcmp(cfg.nonlinear, 'yes')
       % instead of using dip(t) = ft_inverse_dipolefit(dip(t),...), I am using temporary variables dipin and dipout
       % to prevent errors like "Subscripted assignment between dissimilar structures"
       dipin = dip;
+      % in HArtMuT mode, prepare to refine an ocular source as a symmetric, linked-moment
+      % dipole pair; this is only possible per topography, hence for the moving model
+      eyeconstr = [];
+      if istrue(cfg.dipfit.hartmut)
+        coordsys = ft_getopt(headmodel, 'coordsys', ft_getopt(sens, 'coordsys', 'unknown'));
+        unit     = ft_getopt(headmodel, 'unit',     ft_getopt(sens, 'unit', 'mm'));
+        [dum, eyeaxis, eyecentre, eyeradius] = hartmut_eyemodel(cfg.dipfit.eye, coordsys, unit);
+        if ~isempty(eyeaxis) && ~isempty(eyecentre)
+          axisindx  = find(strcmp({'x', 'y', 'z'}, eyeaxis));
+          eyemirror = ones(1,3); eyemirror(axisindx) = -1;
+          eyeconstr = ft_getopt(cfg.dipfit, 'constr', []);
+          eyeconstr.reduce  = [1 2 3];
+          eyeconstr.expand  = [1 2 3 1 2 3];
+          eyeconstr.mirror  = ones(1,6); eyeconstr.mirror(3+axisindx) = -1;
+          eyeconstr.linkmom = true;
+        end
+      end
       for t=1:ntime
+        thisdip       = dipin(t);
+        thisdipfitopt = dipfitopt;
+        if ~isempty(eyeconstr) && (sum((thisdip.pos(1,:)-eyecentre).^2)<=eyeradius^2 || sum((thisdip.pos(1,:)-eyecentre.*eyemirror).^2)<=eyeradius^2)
+          % the start position lies in an eye, refine it as a symmetric, linked-moment pair
+          thisdip.pos   = [thisdip.pos(1,:); thisdip.pos(1,:).*eyemirror];
+          thisdip.mom   = zeros(6,1);
+          thisdipfitopt = ft_setopt(thisdipfitopt, 'constr', eyeconstr);
+          thisdipfitopt = ft_setopt(thisdipfitopt, 'checkinside', false); % the eye is outside the brain
+        end
         % catch errors due to non-convergence
         try
-          dipout(t) = ft_inverse_dipolefit(dipin(t), sens, headmodel, Vdata(:,t), dipfitopt{:}, leadfieldopt{:});
+          dipout(t) = ft_inverse_dipolefit(thisdip, sens, headmodel, Vdata(:,t), thisdipfitopt{:}, leadfieldopt{:});
           success(t) = 1;
-          if cfg.numdipoles==1
+          if size(dipout(t).pos,1)==1
             ft_info('found minimum after non-linear optimization for topography %d on [%g %g %g]\n', t, dipout(t).pos(1), dipout(t).pos(2), dipout(t).pos(3));
-          elseif cfg.numdipoles==2
+          else
             ft_info('found minimum after non-linear optimization for topography %d on [%g %g %g; %g %g %g]\n', t, dipout(t).pos(1,1), dipout(t).pos(1,2), dipout(t).pos(1,3), dipout(t).pos(2,1), dipout(t).pos(2,2), dipout(t).pos(2,3));
           end
         catch

--- a/ft_dipolefitting.m
+++ b/ft_dipolefitting.m
@@ -249,12 +249,14 @@ if istrue(cfg.dipfit.hartmut)
     % by default HArtMuT scans both the brain and the scalp compartment
     cfg.dipfit.compartment = {'brain', 'scalp'};
   end
-  % the ocular sources are seeded with the default eye geometry, averaged over the HArtMuT
-  % NYhead and Colin27 heads and expressed in mm, see also private/hartmut_eyemodel.m
+  % the ocular sources are seeded with the default eye geometry from the HArtMuT NYhead
+  % (MNI ICBM152) head, in mm; the ICBM152 eyes sit higher than the Colin27 ones, so transforming
+  % these defaults to an individual head is less likely to land inside the skull, see also
+  % private/hartmut_eyemodel.m
   cfg.dipfit.eye             = ft_getopt(cfg.dipfit, 'eye', []);
   cfg.dipfit.eye.radius      = ft_getopt(cfg.dipfit.eye, 'radius', 22);
-  cfg.dipfit.eye.interocular = ft_getopt(cfg.dipfit.eye, 'interocular', 68);
-  cfg.dipfit.eye.offset      = ft_getopt(cfg.dipfit.eye, 'offset', [68 -32]);
+  cfg.dipfit.eye.interocular = ft_getopt(cfg.dipfit.eye, 'interocular', 70);
+  cfg.dipfit.eye.offset      = ft_getopt(cfg.dipfit.eye, 'offset', [72 -25]);
   if strcmp(cfg.model, 'regional')
     ft_warning('the HArtMuT extension fits symmetric ocular dipoles only in the moving model, the eyes are fit as single dipoles in the regional model');
   end

--- a/ft_dipolefitting.m
+++ b/ft_dipolefitting.m
@@ -67,6 +67,10 @@ function [source] = ft_dipolefitting(cfg, data)
 %   cfg.dipfit.optimfun     = function to use, can be 'fminsearch' or 'fminunc' (default is determined automatic)
 %   cfg.dipfit.maxiter      = maximum number of function evaluations allowed (default depends on the optimfun)
 %   cfg.dipfit.checkinside  = boolean, check that the dipole remains in the source compartment (default = false)
+%   cfg.dipfit.compartment  = string or cell-array, the head model compartment(s) that dipoles should be inside,
+%                             either 'brain' (default) or 'scalp', see FT_INSIDE_HEADMODEL and FT_PREPARE_SOURCEMODEL
+%   cfg.dipfit.hartmut      = 'yes' or 'no' (default = 'no'), use the HArtMuT extension to also fit sources in the
+%                             scalp compartment, e.g. muscle artefacts
 %
 % Optionally, you can modify the leadfields by reducing the rank, i.e. remove the weakest orientation
 %   cfg.reducerank    = 'no', or number (default = 3 for EEG, 2 for MEG)
@@ -231,6 +235,14 @@ end
 if ft_getopt(cfg.dipfit.constr, 'sequential', false) && strcmp(cfg.model, 'moving')
   ft_error('the moving dipole model does not combine with the sequential constraint')
   % see http://bugzilla.fieldtriptoolbox.org/show_bug.cgi?id=3119
+end
+
+% the HArtMuT extension allows fitting sources outside the brain, such as muscle artefacts in the scalp
+cfg.dipfit.hartmut     = ft_getopt(cfg.dipfit, 'hartmut', 'no');
+cfg.dipfit.compartment = ft_getopt(cfg.dipfit, 'compartment', 'brain');
+if istrue(cfg.dipfit.hartmut) && isequal(cfg.dipfit.compartment, 'brain')
+  % by default HArtMuT scans both the brain and the scalp compartment
+  cfg.dipfit.compartment = {'brain', 'scalp'};
 end
 
 if iscomp
@@ -399,6 +411,7 @@ if strcmp(cfg.gridsearch, 'yes')
     elseif ft_senstype(sens, 'meg')
       tmpcfg.grad = sens;
     end
+    tmpcfg.compartment = cfg.dipfit.compartment;
     sourcemodel = ft_prepare_sourcemodel(tmpcfg);
     
   end % if precomputed leadfield or not

--- a/ft_dipolefitting.m
+++ b/ft_dipolefitting.m
@@ -419,10 +419,11 @@ if strcmp(cfg.gridsearch, 'yes')
   for i=1:length(insideindx)
     ft_progress(i/length(insideindx), 'scanning grid location %d/%d\n', i, length(insideindx));
     thisindx = insideindx(i);
-    if isfield(sourcemodel, 'leadfield')
+    if isfield(sourcemodel, 'leadfield') && ~isempty(sourcemodel.leadfield{thisindx})
       % reuse the previously computed leadfield
       lf = sourcemodel.leadfield{thisindx};
     else
+      % compute the leadfield on the fly, also for positions without a precomputed leadfield
       lf = ft_compute_leadfield(sourcemodel.pos(thisindx,:), sens, headmodel, leadfieldopt{:});
     end
     % the model is V=lf*mom+noise, therefore mom=pinv(lf)*V estimates the

--- a/ft_dipolefitting.m
+++ b/ft_dipolefitting.m
@@ -70,7 +70,11 @@ function [source] = ft_dipolefitting(cfg, data)
 %   cfg.dipfit.compartment  = string or cell-array, the head model compartment(s) that dipoles should be inside,
 %                             either 'brain' (default) or 'scalp', see FT_INSIDE_HEADMODEL and FT_PREPARE_SOURCEMODEL
 %   cfg.dipfit.hartmut      = 'yes' or 'no' (default = 'no'), use the HArtMuT extension to also fit sources in the
-%                             scalp compartment, e.g. muscle artefacts
+%                             scalp compartment, e.g. muscle artefacts, and the eyes as symmetric dipole pairs
+%   cfg.dipfit.eye          = structure controlling the ocular sources of the HArtMuT extension, with fields
+%                             radius (default 22), interocular (default 68) and offset (default [68 -32], the
+%                             [anterior superior] offset), all in mm, and an optional field pos with the centre
+%                             of one eye in head coordinates, see also private/hartmut_eyemodel.m
 %
 % Optionally, you can modify the leadfields by reducing the rank, i.e. remove the weakest orientation
 %   cfg.reducerank    = 'no', or number (default = 3 for EEG, 2 for MEG)
@@ -240,9 +244,17 @@ end
 % the HArtMuT extension allows fitting sources outside the brain, such as muscle artefacts in the scalp
 cfg.dipfit.hartmut     = ft_getopt(cfg.dipfit, 'hartmut', 'no');
 cfg.dipfit.compartment = ft_getopt(cfg.dipfit, 'compartment', 'brain');
-if istrue(cfg.dipfit.hartmut) && isequal(cfg.dipfit.compartment, 'brain')
-  % by default HArtMuT scans both the brain and the scalp compartment
-  cfg.dipfit.compartment = {'brain', 'scalp'};
+if istrue(cfg.dipfit.hartmut)
+  if isequal(cfg.dipfit.compartment, 'brain')
+    % by default HArtMuT scans both the brain and the scalp compartment
+    cfg.dipfit.compartment = {'brain', 'scalp'};
+  end
+  % the ocular sources are seeded with the default eye geometry, averaged over the HArtMuT
+  % NYhead and Colin27 heads and expressed in mm, see also private/hartmut_eyemodel.m
+  cfg.dipfit.eye             = ft_getopt(cfg.dipfit, 'eye', []);
+  cfg.dipfit.eye.radius      = ft_getopt(cfg.dipfit.eye, 'radius', 22);
+  cfg.dipfit.eye.interocular = ft_getopt(cfg.dipfit.eye, 'interocular', 68);
+  cfg.dipfit.eye.offset      = ft_getopt(cfg.dipfit.eye, 'offset', [68 -32]);
 end
 
 if iscomp
@@ -413,7 +425,12 @@ if strcmp(cfg.gridsearch, 'yes')
     end
     tmpcfg.compartment = cfg.dipfit.compartment;
     sourcemodel = ft_prepare_sourcemodel(tmpcfg);
-    
+
+    if istrue(cfg.dipfit.hartmut)
+      % add ocular source candidates with precomputed fused leadfields to the grid
+      sourcemodel = hartmut_add_eyes(sourcemodel, cfg, sens, headmodel, leadfieldopt);
+    end
+
   end % if precomputed leadfield or not
 
   ngrid = size(sourcemodel.pos,1);

--- a/ft_prepare_sourcemodel.m
+++ b/ft_prepare_sourcemodel.m
@@ -76,8 +76,10 @@ function [sourcemodel, cfg] = ft_prepare_sourcemodel(cfg)
 %   cfg.tight           = 'yes' or 'no' (default is automatic)
 %   cfg.inwardshift     = number, amount to shift the innermost surface of the headmodel inward when determining
 %                         whether sources are inside or outside the source compartment (default = 0)
-%   cfg.compartment     = string, the head model compartment that sources should be inside, either
-%                         'brain' (default) or 'scalp', see FT_INSIDE_HEADMODEL
+%   cfg.compartment     = string or cell-array of strings, the head model compartment(s) that
+%                         sources should be inside, either 'brain' (default) or 'scalp', see
+%                         FT_INSIDE_HEADMODEL. With multiple compartments the inside positions are
+%                         their union and sourcemodel.compartment labels each position
 %   cfg.moveinward      = number, amount to move sources inward to ensure a certain minimal distance to the innermost
 %                         surface of the headmodel (default = 0)
 %   cfg.movetocentroids = 'yes' or 'no', move the dipoles to the centroids of the hexahedral
@@ -786,8 +788,27 @@ if ~isfield(sourcemodel, 'inside')
     brain = find(ismember(headmodel.tissuelabel, {'gm', 'gray', 'grey', 'brain'}));
     sourcemodel.inside = ismember(sourcemodel.tissue, brain);
   else
-    % this returns a boolean vector
-    sourcemodel.inside = ft_inside_headmodel(sourcemodel.pos, headmodel, 'grad', sens, 'headshape', cfg.headshape, 'inwardshift', cfg.inwardshift, 'surface', cfg.compartment);
+    % determine the inside positions for one or multiple head model compartments
+    compartments = cfg.compartment;
+    if ~iscell(compartments)
+      compartments = {compartments};
+    end
+    sourcemodel.inside = false(size(sourcemodel.pos,1),1);
+    if numel(compartments)>1
+      % label each position with the compartment that contains it
+      sourcemodel.compartment = repmat({''}, size(sourcemodel.pos,1), 1);
+    end
+    for i=1:numel(compartments)
+      % this returns a boolean vector
+      thisinside = ft_inside_headmodel(sourcemodel.pos, headmodel, 'grad', sens, 'headshape', cfg.headshape, 'inwardshift', cfg.inwardshift, 'surface', compartments{i});
+      thisinside = thisinside(:);
+      if numel(compartments)>1
+        % the first compartment that contains a position determines its label
+        newpoints = thisinside & ~sourcemodel.inside;
+        sourcemodel.compartment(newpoints) = compartments(i);
+      end
+      sourcemodel.inside = sourcemodel.inside | thisinside;
+    end
   end
 end % if inside
 

--- a/ft_prepare_sourcemodel.m
+++ b/ft_prepare_sourcemodel.m
@@ -76,6 +76,8 @@ function [sourcemodel, cfg] = ft_prepare_sourcemodel(cfg)
 %   cfg.tight           = 'yes' or 'no' (default is automatic)
 %   cfg.inwardshift     = number, amount to shift the innermost surface of the headmodel inward when determining
 %                         whether sources are inside or outside the source compartment (default = 0)
+%   cfg.compartment     = string, the head model compartment that sources should be inside, either
+%                         'brain' (default) or 'scalp', see FT_INSIDE_HEADMODEL
 %   cfg.moveinward      = number, amount to move sources inward to ensure a certain minimal distance to the innermost
 %                         surface of the headmodel (default = 0)
 %   cfg.movetocentroids = 'yes' or 'no', move the dipoles to the centroids of the hexahedral
@@ -176,6 +178,7 @@ cfg.unit              = ft_getopt(cfg, 'unit');
 cfg.symmetry          = ft_getopt(cfg, 'symmetry');
 cfg.spmversion        = ft_getopt(cfg, 'spmversion', 'spm12');
 cfg.spherify          = ft_getopt(cfg, 'spherify', 'no');
+cfg.compartment       = ft_getopt(cfg, 'compartment', 'brain'); % the head model compartment that sources should be inside
 cfg.movetocentroids   = ft_getopt(cfg, 'movetocentroids', 'no');
 cfg.moveinward        = ft_getopt(cfg, 'moveinward'); % the default is automatic and depends on a triangulation being present
 cfg.checkinside       = ft_getopt(cfg, 'checkinside', 'no'); % default is 'no' since this is a relatively slow procedure. It is also not always required, for example with MEG singlesphere, singleshell, localspheres.
@@ -784,7 +787,7 @@ if ~isfield(sourcemodel, 'inside')
     sourcemodel.inside = ismember(sourcemodel.tissue, brain);
   else
     % this returns a boolean vector
-    sourcemodel.inside = ft_inside_headmodel(sourcemodel.pos, headmodel, 'grad', sens, 'headshape', cfg.headshape, 'inwardshift', cfg.inwardshift);
+    sourcemodel.inside = ft_inside_headmodel(sourcemodel.pos, headmodel, 'grad', sens, 'headshape', cfg.headshape, 'inwardshift', cfg.inwardshift, 'surface', cfg.compartment);
   end
 end % if inside
 

--- a/inverse/ft_inverse_dipolefit.m
+++ b/inverse/ft_inverse_dipolefit.m
@@ -37,6 +37,10 @@ function [estimate] = ft_inverse_dipolefit(sourcemodel, sens, headmodel, dat, va
 %   constr.reduce     = vector, used for symmetric dipole models
 %   constr.expand     = vector, used for symmetric dipole models
 %   constr.sequential = boolean, fit different dipoles to sequential slices of the data
+%   constr.linkmom    = boolean, link the moment of a symmetric pair so they share one
+%                       moment (mom2 = mommap*mom1), used for ocular sources in HArtMuT
+%   constr.mommap     = 3x3 matrix, maps the first moment onto the second for linkmom
+%                       (default = eye(3), i.e. identical moments for synchronous eyes)
 %
 % The maximum likelihood estimation implements
 % - Lutkenhoner B. "Dipole source localization by means of maximum likelihood
@@ -120,6 +124,19 @@ constr.symmetry   = ft_getopt(constr, 'symmetry', false);
 constr.fixedori   = ft_getopt(constr, 'fixedori', false);
 constr.rigidbody  = ft_getopt(constr, 'rigidbody', false);
 constr.sequential = ft_getopt(constr, 'sequential', false);
+constr.linkmom    = ft_getopt(constr, 'linkmom', false);
+constr.mommap     = ft_getopt(constr, 'mommap', eye(3));
+
+if constr.linkmom
+  % a linked-moment symmetric source shares a single moment between the two mirrored
+  % dipoles, i.e. mom2 = mommap*mom1, which models synchronously moving eyes
+  if ~constr.symmetry
+    ft_error('the linkmom constraint requires a symmetric dipole pair, see cfg.symmetry');
+  end
+  if constr.fixedori || constr.rigidbody || constr.sequential
+    ft_error('the linkmom constraint is not supported together with fixedori, rigidbody or sequential constraints');
+  end
+end
 
 if isempty(optimfun)
   % determine whether the MATLAB Optimization toolbox is available and can be used
@@ -323,6 +340,12 @@ if ~isempty(mleweight)
   % maximum likelihood estimation using the weigth matrix
   if constr.sequential
     ft_error('not supported');
+  elseif constr.linkmom
+    % fit a single moment shared by the mirrored pair, then expand it to both dipoles
+    lfc = lf(:,1:3) + lf(:,4:6)*constr.mommap;
+    mc  = pinv(lfc'*mleweight*lfc)*lfc'*mleweight*dat;
+    mom = [mc; constr.mommap*mc];
+    dif = dat - lf*mom;
   else
     mom = pinv(lf'*mleweight*lf)*lf'*mleweight*dat;  % Lutkenhoner equation 5
     dif = dat - lf*mom;
@@ -357,6 +380,11 @@ else
       framesel = (1:numframe) + numframe*(i-1);  % 1:numframe for the first, (numframe+1):(2*numframe) for the second, ...
       mom(dipsel,framesel) = pinv(lf(:,dipsel))*dat(:,framesel);
     end
+  elseif constr.linkmom
+    % fit a single moment shared by the mirrored pair, then expand it to both dipoles
+    lfc = lf(:,1:3) + lf(:,4:6)*constr.mommap;
+    mc  = pinv(lfc)*dat;
+    mom = [mc; constr.mommap*mc];
   else
     mom = pinv(lf)*dat;
   end

--- a/private/hartmut_add_eyes.m
+++ b/private/hartmut_add_eyes.m
@@ -1,0 +1,87 @@
+function sourcemodel = hartmut_add_eyes(sourcemodel, cfg, sens, headmodel, leadfieldopt)
+
+% HARTMUT_ADD_EYES adds ocular source candidates to the source model that is used for the
+% HArtMuT grid search in FT_DIPOLEFITTING. Each ocular candidate represents a mirror-symmetric
+% dipole pair, and its fused leadfield L(p) + L(mirror(p))*mommap is precomputed here so that
+% the grid search can treat it as an ordinary source. The existing brain and scalp leadfields
+% are left empty, so they are computed on the fly during the scan.
+%
+% Use as
+%   sourcemodel = hartmut_add_eyes(sourcemodel, cfg, sens, headmodel, leadfieldopt)
+%
+% When the eye position or the symmetry axis cannot be determined, the source model is
+% returned unchanged, so the grid search falls back to brain and scalp candidates only.
+%
+% See also FT_DIPOLEFITTING, HARTMUT_EYEMODEL, FT_COMPUTE_LEADFIELD
+
+% Copyright (C) 2026, Nils Harmening
+%
+% This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
+% for the documentation and details.
+%
+%    FieldTrip is free software: you can redistribute it and/or modify
+%    it under the terms of the GNU General Public License as published by
+%    the Free Software Foundation, either version 3 of the License, or
+%    (at your option) any later version.
+%
+%    FieldTrip is distributed in the hope that it will be useful,
+%    but WITHOUT ANY WARRANTY; without even the implied warranty of
+%    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%    GNU General Public License for more details.
+%
+%    You should have received a copy of the GNU General Public License
+%    along with FieldTrip. If not, see <http://www.gnu.org/licenses/>.
+%
+% $Id$
+
+% determine the candidate positions in one eye, the left-right symmetry axis, and the eye centre
+coordsys = ft_getopt(headmodel, 'coordsys', ft_getopt(sens, 'coordsys', 'unknown'));
+[eyepos, lraxis, centre, radius] = hartmut_eyemodel(cfg.dipfit.eye, coordsys, sourcemodel.unit);
+if isempty(eyepos)
+  % the eye position or symmetry axis could not be determined, keep brain and scalp only
+  return
+end
+
+% the partner dipole is the mirror image across the midsagittal plane, i.e. the plane where
+% the left-right coordinate is zero
+mommap   = ft_getopt(cfg.dipfit.constr, 'mommap', eye(3));
+axisindx = find(strcmp({'x', 'y', 'z'}, lraxis));
+mirror   = ones(1,3);
+mirror(axisindx) = -1;
+
+% precompute the fused leadfield for each ocular candidate
+neye  = size(eyepos,1);
+eyelf = cell(neye,1);
+for i=1:neye
+  lf1 = ft_compute_leadfield(eyepos(i,:),         sens, headmodel, leadfieldopt{:});
+  lf2 = ft_compute_leadfield(eyepos(i,:).*mirror, sens, headmodel, leadfieldopt{:});
+  eyelf{i} = lf1 + lf2*mommap;
+end
+
+% leave the existing brain and scalp leadfields empty, they are computed during the scan
+if ~isfield(sourcemodel, 'leadfield')
+  sourcemodel.leadfield = cell(size(sourcemodel.pos,1), 1);
+end
+if ~isfield(sourcemodel, 'compartment')
+  sourcemodel.compartment = repmat({''}, size(sourcemodel.pos,1), 1);
+end
+sourcemodel.inside = sourcemodel.inside(:);
+
+% remove the existing single-dipole candidates inside either eye, since the eye region is
+% now represented by the symmetric pairs and would otherwise be seeded by the wrong model
+d2left  = sum((sourcemodel.pos - centre).^2, 2);
+d2right = sum((sourcemodel.pos - centre.*mirror).^2, 2);
+ineye   = d2left<=radius^2 | d2right<=radius^2;
+sourcemodel.pos(ineye,:)       = [];
+sourcemodel.inside(ineye)      = [];
+sourcemodel.leadfield(ineye)   = [];
+sourcemodel.compartment(ineye) = [];
+
+% merge the ocular candidates into the source model
+sourcemodel.pos         = [sourcemodel.pos;         eyepos];
+sourcemodel.inside      = [sourcemodel.inside;      true(neye,1)];
+sourcemodel.leadfield   = [sourcemodel.leadfield;   eyelf];
+sourcemodel.compartment = [sourcemodel.compartment; repmat({'eye'}, neye, 1)];
+if isfield(sourcemodel, 'dim')
+  sourcemodel = rmfield(sourcemodel, 'dim'); % the positions are no longer a regular grid
+end

--- a/private/hartmut_add_eyes.m
+++ b/private/hartmut_add_eyes.m
@@ -39,6 +39,7 @@ coordsys = ft_getopt(headmodel, 'coordsys', ft_getopt(sens, 'coordsys', 'unknown
 [eyepos, lraxis, centre, radius] = hartmut_eyemodel(cfg.dipfit.eye, coordsys, sourcemodel.unit);
 if isempty(eyepos)
   % the eye position or symmetry axis could not be determined, keep brain and scalp only
+  ft_warning('the HArtMuT ocular source positions could not be determined, the eyes are fit as single dipoles; provide cfg.dipfit.eye.pos or use an MNI-like coordinate system');
   return
 end
 

--- a/private/hartmut_eyemodel.m
+++ b/private/hartmut_eyemodel.m
@@ -1,11 +1,11 @@
-function [pos, lraxis] = hartmut_eyemodel(eyecfg, coordsys, unit)
+function [pos, lraxis, centre, radius] = hartmut_eyemodel(eyecfg, coordsys, unit)
 
 % HARTMUT_EYEMODEL returns candidate positions for ocular sources in one eye and the
 % left-right symmetry axis of the coordinate system. It is used by FT_DIPOLEFITTING for
 % the HArtMuT extension, which fits the eyes as a mirror-symmetric dipole pair.
 %
 % Use as
-%   [pos, lraxis] = hartmut_eyemodel(eyecfg, coordsys, unit)
+%   [pos, lraxis, centre, radius] = hartmut_eyemodel(eyecfg, coordsys, unit)
 % where the input is
 %   eyecfg   = structure with fields radius, interocular and offset (all in mm), and an
 %              optional field pos with the centre of one eye in head coordinates
@@ -14,6 +14,8 @@ function [pos, lraxis] = hartmut_eyemodel(eyecfg, coordsys, unit)
 % and the output is
 %   pos      = Nx3 matrix with candidate positions in one eye, empty when they cannot be determined
 %   lraxis   = the left-right symmetry axis, 'x', 'y' or 'z', empty when it cannot be determined
+%   centre   = 1x3 vector with the centre of one eye in head coordinates, empty when not determined
+%   radius   = scalar radius of the eye region in head coordinates
 %
 % The candidate positions are returned for a single eye; the partner in the other eye is
 % its mirror image across the midsagittal plane. The default eye geometry is derived from the
@@ -62,6 +64,7 @@ else
   % the default MNI eye centre does not apply and the user did not specify one
   lefteye = [];
 end
+centre = lefteye;
 
 % determine the left-right axis, this is the axis whose two directions are left and right
 [labelx, labely, labelz] = coordsys2label(coordsys, 0, true);

--- a/private/hartmut_eyemodel.m
+++ b/private/hartmut_eyemodel.m
@@ -1,0 +1,86 @@
+function [pos, lraxis] = hartmut_eyemodel(eyecfg, coordsys, unit)
+
+% HARTMUT_EYEMODEL returns candidate positions for ocular sources in one eye and the
+% left-right symmetry axis of the coordinate system. It is used by FT_DIPOLEFITTING for
+% the HArtMuT extension, which fits the eyes as a mirror-symmetric dipole pair.
+%
+% Use as
+%   [pos, lraxis] = hartmut_eyemodel(eyecfg, coordsys, unit)
+% where the input is
+%   eyecfg   = structure with fields radius, interocular and offset (all in mm), and an
+%              optional field pos with the centre of one eye in head coordinates
+%   coordsys = string describing the coordinate system, see FT_DETERMINE_COORDSYS
+%   unit     = string with the geometrical units, e.g. 'mm' or 'cm'
+% and the output is
+%   pos      = Nx3 matrix with candidate positions in one eye, empty when they cannot be determined
+%   lraxis   = the left-right symmetry axis, 'x', 'y' or 'z', empty when it cannot be determined
+%
+% The candidate positions are returned for a single eye; the partner in the other eye is
+% its mirror image across the midsagittal plane. The default eye geometry is derived from the
+% open-source HArtMuT models HArtMuT_NYhead_small and HArtMuT_mix_Colin27_small, which are both
+% in MNI coordinates and available from https://github.com/harmening/HArtMuT/tree/main/HArtMuTmodels.
+% The defaults therefore only apply to an MNI-like coordinate system. When neither the eye centre
+% nor the symmetry axis can be determined, the caller should fall back to fitting a single dipole.
+%
+% See also FT_DIPOLEFITTING, COORDSYS2LABEL, FT_INSIDE_HEADMODEL
+
+% Copyright (C) 2026, Nils Harmening
+%
+% This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
+% for the documentation and details.
+%
+%    FieldTrip is free software: you can redistribute it and/or modify
+%    it under the terms of the GNU General Public License as published by
+%    the Free Software Foundation, either version 3 of the License, or
+%    (at your option) any later version.
+%
+%    FieldTrip is distributed in the hope that it will be useful,
+%    but WITHOUT ANY WARRANTY; without even the implied warranty of
+%    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%    GNU General Public License for more details.
+%
+%    You should have received a copy of the GNU General Public License
+%    along with FieldTrip. If not, see <http://www.gnu.org/licenses/>.
+%
+% $Id$
+
+pos    = zeros(0,3);
+lraxis = '';
+name   = {'x', 'y', 'z'};
+
+% determine the centre and radius of the left eye in head coordinates
+scale  = ft_scalingfactor('mm', unit);
+radius = eyecfg.radius * scale;
+if isfield(eyecfg, 'pos') && ~isempty(eyecfg.pos)
+  % use the eye centre specified by the user
+  lefteye = eyecfg.pos(1,:);
+elseif ismember(lower(coordsys), {'mni', 'spm', 'tal', 'acpc'})
+  % use the default eye centre, which is in MNI coordinates; an MNI-like coordinate system
+  % is RAS, so x is left-right, y is anterior and z is superior
+  lefteye = [-eyecfg.interocular/2, eyecfg.offset(1), eyecfg.offset(2)] * scale;
+else
+  % the default MNI eye centre does not apply and the user did not specify one
+  lefteye = [];
+end
+
+% determine the left-right axis, this is the axis whose two directions are left and right
+[labelx, labely, labelz] = coordsys2label(coordsys, 0, true);
+labels = {labelx, labely, labelz};
+for i=1:3
+  if all(ismember(labels{i}, {'L', 'R'}))
+    lraxis = name{i};
+  end
+end
+
+% both the eye centre and the symmetry axis are required to mirror the eye onto the other
+% side, otherwise the caller should fall back to fitting a single dipole
+if isempty(lefteye) || isempty(lraxis)
+  return
+end
+
+% construct a regular grid of candidate positions inside the spherical eye region
+step = radius/2;
+[gx, gy, gz] = ndgrid(-radius:step:radius, -radius:step:radius, -radius:step:radius);
+grid = [gx(:) gy(:) gz(:)];
+grid = grid(sum(grid.^2, 2)<=radius^2, :); % keep the positions inside the sphere
+pos  = grid + lefteye;

--- a/private/hartmut_eyemodel.m
+++ b/private/hartmut_eyemodel.m
@@ -18,9 +18,10 @@ function [pos, lraxis, centre, radius] = hartmut_eyemodel(eyecfg, coordsys, unit
 %   radius   = scalar radius of the eye region in head coordinates
 %
 % The candidate positions are returned for a single eye; the partner in the other eye is
-% its mirror image across the midsagittal plane. The default eye geometry is derived from the
-% open-source HArtMuT models HArtMuT_NYhead_small and HArtMuT_mix_Colin27_small, which are both
-% in MNI coordinates and available from https://github.com/harmening/HArtMuT/tree/main/HArtMuTmodels.
+% its mirror image across the midsagittal plane. The default eye geometry is taken from the HArtMuT
+% NYhead (MNI ICBM152) model, available from https://github.com/harmening/HArtMuT/tree/main/HArtMuTmodels;
+% the ICBM152 head has no eye cavities and its eyes sit higher than in the Colin27 head, so the
+% defaults stay clear of the skull when transformed to an individual.
 % The defaults therefore only apply to an MNI-like coordinate system. When neither the eye centre
 % nor the symmetry axis can be determined, the caller should fall back to fitting a single dipole.
 %
@@ -67,10 +68,10 @@ end
 centre = lefteye;
 
 % determine the left-right axis, this is the axis whose two directions are left and right
-[labelx, labely, labelz] = coordsys2label(coordsys, 0, true);
+[labelx, labely, labelz] = coordsys2label(coordsys, 1, true);
 labels = {labelx, labely, labelz};
 for i=1:3
-  if all(ismember(labels{i}, {'L', 'R'}))
+  if all(ismember(labels{i}, {'left', 'right'}))
     lraxis = name{i};
   end
 end

--- a/test/test_ft_dipolefitting_hartmut.m
+++ b/test/test_ft_dipolefitting_hartmut.m
@@ -169,8 +169,8 @@ sm.inside = false(0,1);
 
 cfge = [];
 cfge.dipfit.eye.radius      = 8;  % mm, small so the candidate grid stays tiny
-cfge.dipfit.eye.interocular = 68; % mm
-cfge.dipfit.eye.offset      = [68 -32]; % mm
+cfge.dipfit.eye.interocular = 70; % mm
+cfge.dipfit.eye.offset      = [72 -25]; % mm
 cfge.dipfit.constr.mommap   = eye(3);
 
 leadfieldopt = {}; % defaults
@@ -233,9 +233,9 @@ assert(ft_inside_headmodel(fitpos, ommodel, 'surface', 'scalp'), 'the muscle sou
 
 %% check 6: a symmetric ocular source comes back as a linked dipole pair
 % simulate a synchronous pair at the default MNI eye centres, then fit moving. The default
-% centre is [-interocular/2, offset(1), offset(2)] = [-34 68 -32] mm, see hartmut_eyemodel;
+% centre is [-interocular/2, offset(1), offset(2)] = [-35 72 -25] mm, see hartmut_eyemodel;
 % hartmut_add_eyes (exercised in check 4) builds it the same way during the fit.
-pL = [-34 68 -32];          % left eye centre, mm
+pL = [-35 72 -25];          % left eye centre, mm
 pR = pL .* [-1 1 1];        % right eye centre
 mom = [0.8 0.2 -0.4]';
 

--- a/test/test_ft_dipolefitting_hartmut.m
+++ b/test/test_ft_dipolefitting_hartmut.m
@@ -1,0 +1,369 @@
+function test_ft_dipolefitting_hartmut
+
+% WALLTIME 00:30:00
+% MEM 2gb
+% DEPENDENCY ft_dipolefitting ft_prepare_sourcemodel ft_inside_headmodel ft_inverse_dipolefit hartmut_eyemodel hartmut_add_eyes
+% DATA no
+
+% This tests the HArtMuT extension of ft_dipolefitting: fitting sources in the scalp
+% compartment (muscle artefacts) and fitting the eyes as a mirror-symmetric dipole pair.
+% See ft_dipolefitting (cfg.dipfit.hartmut) and the design notes for the rationale.
+%
+% Checks 1 to 4 are self-contained and need no external solver. Checks 5 to 7 need real
+% EEG leadfields from a BEM, so they are gated behind OpenMEEG and skipped when it is
+% missing. Nothing here depends on private data files; an optional pin against the shipped
+% extended_sourcemodel.mat is documented in check 4 but not required to pass.
+
+rng(42); % deterministic synthetic data
+
+hasopenmeeg = ft_hastoolbox('openmeeg', 3); % 3 = check silently, do not error
+ftpath = fileparts(which('ft_dipolefitting')); % to reach private functions, see check 4
+
+%% check 1: regression, hartmut off leaves a brain fit unchanged
+% A brain dipole fit must give the same result whether cfg.dipfit.hartmut is absent or 'no'.
+% This proves the new config path is inert when the extension is off.
+
+[elec, sphere] = local_spheremodel();
+
+% simulate a single brain dipole and average it to a timelock structure
+truepos = [2 3 6]; % cm, inside the brain sphere
+cfgs = [];
+cfgs.headmodel = sphere;
+cfgs.elec      = elec;
+cfgs.dip.pos   = truepos;
+cfgs.dip.mom   = [1 0 0]';
+cfgs.dip.frequency = 10;
+cfgs.dip.phase     = 0;
+cfgs.fsample   = 250;
+cfgs.relnoise  = 0;
+cfgs.ntrials   = 1;
+sim = ft_dipolesimulation(cfgs);
+timelock = ft_timelockanalysis([], sim);
+
+cfgf = [];
+cfgf.numdipoles = 1;
+cfgf.headmodel  = sphere;
+cfgf.elec       = elec;
+cfgf.gridsearch = 'yes';
+cfgf.nonlinear  = 'yes';
+cfgf.resolution = 2; % cm, coarse for speed
+cfgf.model      = 'regional';
+cfgf.latency    = 'all';
+
+% reference fit, no hartmut field at all
+src_ref = ft_dipolefitting(cfgf, timelock);
+
+% same fit with the extension explicitly off
+cfgf.dipfit.hartmut     = 'no';
+cfgf.dipfit.compartment = 'brain';
+src_off = ft_dipolefitting(cfgf, timelock);
+
+assert(isequal(src_ref.dip.pos, src_off.dip.pos), 'hartmut=no changed the fitted position');
+assert(isequal(src_ref.dip.mom, src_off.dip.mom), 'hartmut=no changed the fitted moment');
+% the fit should also be near the simulated source
+assert(norm(src_ref.dip.pos - truepos) < 2, 'the brain dipole was not recovered'); % cm
+
+%% check 2: ft_inside_headmodel labels the scalp compartment correctly
+% A point between skin and skull is in the scalp; points in skull, csf, brain, and outside
+% the skin are not. This is pure geometry and needs no solver.
+
+bem = local_nestedspheres(); % bnd ordered outside-in, type openmeeg, mm
+
+rscalp = 90; rskull = 82; % see local_nestedspheres
+inscalp  = [0 0 86]; % between skin (90) and skull (82)
+inskull  = [0 0 80]; % inside the skull boundary
+inbrain  = [0 0 10]; % deep inside
+outside  = [0 0 120]; % beyond the skin
+
+testpos = [inscalp; inskull; inbrain; outside];
+inside  = ft_inside_headmodel(testpos, bem, 'surface', 'scalp');
+assert(inside(1)==true,  'a point between skin and skull should be in the scalp');
+assert(inside(2)==false, 'a point inside the skull should not be in the scalp');
+assert(inside(3)==false, 'a deep brain point should not be in the scalp');
+assert(inside(4)==false, 'a point outside the skin should not be in the scalp');
+
+% the brain compartment still works as before
+insidebrain = ft_inside_headmodel(testpos, bem, 'surface', 'brain');
+assert(insidebrain(3)==true,  'a deep point should be in the brain');
+assert(insidebrain(1)==false, 'a scalp point should not be in the brain');
+
+% a model with a single boundary cannot define a scalp shell
+onebnd = bem; onebnd.bnd = bem.bnd(1);
+try
+  ft_inside_headmodel(inscalp, onebnd, 'surface', 'scalp');
+  error('expected an error for a scalp test on a single-boundary model');
+catch me
+  assert(~isempty(strfind(me.message, 'two boundaries')) || ~isempty(strfind(lower(me.message), 'boundaries')), ...
+    'wrong error for a single-boundary scalp test');
+end
+
+%% check 3: linkmom recovers a shared moment for a symmetric pair
+% Simulate data from one moment shared by a mirrored pair (mom2 = mommap*mom1), fit with
+% the linkmom constraint, and confirm the moment comes back and stays linked.
+
+mommap = eye(3); % M = I, synchronous eyes
+p1 = [3 5 4]; % cm, inside the brain so checkinside is irrelevant
+p2 = p1 .* [-1 1 1]; % mirror across the midsagittal (x) plane
+
+lf1 = ft_compute_leadfield(p1, elec, sphere);
+lf2 = ft_compute_leadfield(p2, elec, sphere);
+m1  = [0.7 -0.3 0.5]'; % the true shared moment
+Vdata = lf1*m1 + lf2*(mommap*m1); % equals (lf1 + lf2*M)*m1
+
+dipin = [];
+dipin.pos = [p1; p2];
+dipin.mom = zeros(6,1);
+
+constr = [];
+constr.reduce  = [1 2 3];
+constr.expand  = [1 2 3 1 2 3];
+constr.mirror  = ones(1,6); constr.mirror(3+1) = -1; % flip x of the second dipole (setting mirror sets symmetry=true)
+constr.linkmom = true;
+constr.mommap  = mommap;
+
+est = ft_inverse_dipolefit(dipin, elec, sphere, Vdata, 'constr', constr, 'checkinside', false);
+
+mom = est.mom(:);
+assert(numel(mom)==6, 'a linkmom fit must return a 6x1 moment for the pair');
+% the link itself is exact: the second moment is always mommap times the first
+assert(norm(mom(4:6) - mommap*mom(1:3)) < 1e-6, 'the second moment is not mommap*first');
+% the two dipoles stay exact mirror images, which confirms the symmetric reduction
+assert(norm(est.pos(2,:) - est.pos(1,:).*[-1 1 1]) < 1e-6, 'the pair is not symmetric across x');
+% the recovered moment and position match the simulated source up to the EEG average
+% reference convention. ft_inverse_dipolefit average references the data but builds the
+% model from a raw leadfield, so the true source is not the exact least squares minimum and
+% a few percent of moment error and a few mm of position drift are expected, the same as for
+% an ordinary unconstrained single dipole fit. The exact checks above pin the linkmom wiring.
+assert(norm(mom(1:3) - m1)/norm(m1) < 0.1, 'the shared moment was not recovered');
+assert(norm(est.pos(1,:) - p1) < 0.5, 'the symmetric pair did not land near the true source'); % cm
+
+% the linkmom constraint must reject incompatible options
+try
+  badc = constr; badc.fixedori = true;
+  ft_inverse_dipolefit(dipin, elec, sphere, Vdata, 'constr', badc, 'checkinside', false);
+  error('expected linkmom to reject fixedori');
+catch me
+  assert(~isempty(strfind(lower(me.message), 'linkmom')), 'wrong error for linkmom with fixedori');
+end
+
+%% check 4: the fused eye leadfield follows the M=I convention
+% hartmut_add_eyes stores each ocular candidate as L(p) + L(mirror(p))*mommap. Confirm that
+% the stored fused leadfield equals L(p) + L(mirror(p)) with mommap = I, which pins the
+% convention used everywhere downstream.
+%
+% Note on the shipped file: raw/dipfit/extended_BEM/extended_sourcemodel.mat carries 12
+% symmetric_dipole eye entries with the same convention. Reproducing them needs the exact
+% BEM and OpenMEEG that built the file, so that pin is an offline check, not part of CI. The
+% convention itself is what we test here, against the same code path the file was built with.
+
+eyesphere = sphere;
+eyesphere.coordsys = 'mni'; % so hartmut_eyemodel uses its default MNI eye geometry
+eyesphere.unit     = 'cm';
+elecmni = elec; elecmni.coordsys = 'mni';
+
+% a near-empty source model; hartmut_add_eyes only appends the eye candidates
+sm = [];
+sm.pos    = zeros(0,3);
+sm.unit   = 'cm';
+sm.inside = false(0,1);
+
+cfge = [];
+cfge.dipfit.eye.radius      = 8;  % mm, small so the candidate grid stays tiny
+cfge.dipfit.eye.interocular = 68; % mm
+cfge.dipfit.eye.offset      = [68 -32]; % mm
+cfge.dipfit.constr.mommap   = eye(3);
+
+leadfieldopt = {}; % defaults
+
+% hartmut_add_eyes lives in fieldtrip/private, so cd into it the way other FieldTrip tests
+% reach private functions, then restore the working directory
+here = pwd;
+cleanup = onCleanup(@() cd(here));
+cd(fullfile(ftpath, 'private'));
+sm = hartmut_add_eyes(sm, cfge, elecmni, eyesphere, leadfieldopt);
+clear cleanup; % triggers the cd back
+
+assert(~isempty(sm.pos), 'hartmut_add_eyes added no ocular candidates');
+assert(all(strcmp(sm.compartment, 'eye')), 'the added candidates are not labelled as eye');
+
+% recompute the fused leadfield independently and compare
+mirror = [-1 1 1]; % x is the left-right axis in MNI
+for i=1:size(sm.pos,1)
+  p   = sm.pos(i,:);
+  lfa = ft_compute_leadfield(p,          elecmni, eyesphere);
+  lfb = ft_compute_leadfield(p.*mirror,  elecmni, eyesphere);
+  expected = lfa + lfb*eye(3);
+  assert(norm(sm.leadfield{i} - expected, 'fro') < 1e-9, 'the stored eye leadfield breaks the M=I fuse convention');
+end
+
+%% checks 5 to 7 need OpenMEEG for real EEG leadfields
+if ~hasopenmeeg
+  ft_warning('OpenMEEG is not available, skipping the scalp, eye, and end-to-end fits (checks 5 to 7)');
+  return
+end
+
+% build an OpenMEEG BEM from the nested spheres, in mm and MNI-like for the eye geometry
+ommodel = ft_headmodel_openmeeg(bem.bnd, 'conductivity', [0.43 0.01 1.79 0.33]);
+ommodel.coordsys = 'mni';
+ommodel.unit     = 'mm';
+elecmm = local_projectelec(elec, 90); % put electrodes on the 90 mm scalp surface
+elecmm.coordsys = 'mni';
+
+%% check 5: a muscle dipole in the scalp is recovered in the scalp
+% fit one muscle topography as a single component, the same way a real ICA component is fit
+% (see checks 6 and 7).
+scalppos = [0 50 70]; % mm, norm 86, between the skull (82) and the skin (90)
+lfScalp  = ft_compute_leadfield(scalppos, elecmm, ommodel);
+compS    = local_topo2comp(lfScalp*[0 0 1]', elecmm);
+
+cfgf = [];
+cfgf.headmodel  = ommodel;
+cfgf.elec       = elecmm;
+cfgf.gridsearch = 'yes';
+cfgf.nonlinear  = 'yes';
+cfgf.resolution = 10; % mm, fine enough to seed the thin scalp shell
+cfgf.model      = 'moving';
+cfgf.component  = 1;
+cfgf.dipfit.hartmut     = 'yes';
+cfgf.dipfit.compartment = 'scalp'; % look in the scalp only for this check
+srcS = ft_dipolefitting(cfgf, compS);
+
+fitpos = srcS.dip(1).pos(1,:);
+assert(ft_inside_headmodel(fitpos, ommodel, 'surface', 'scalp'), 'the muscle source was not fit inside the scalp');
+
+%% check 6: a symmetric ocular source comes back as a linked dipole pair
+% simulate a synchronous pair at the default MNI eye centres, then fit moving. The default
+% centre is [-interocular/2, offset(1), offset(2)] = [-34 68 -32] mm, see hartmut_eyemodel;
+% hartmut_add_eyes (exercised in check 4) builds it the same way during the fit.
+pL = [-34 68 -32];          % left eye centre, mm
+pR = pL .* [-1 1 1];        % right eye centre
+mom = [0.8 0.2 -0.4]';
+
+lfL = ft_compute_leadfield(pL, elecmm, ommodel);
+lfR = ft_compute_leadfield(pR, elecmm, ommodel);
+Veye = lfL*mom + lfR*mom; % synchronous, M = I
+
+comp = local_topo2comp(Veye, elecmm);
+
+cfgf = [];
+cfgf.headmodel  = ommodel;
+cfgf.elec       = elecmm;
+cfgf.gridsearch = 'yes';
+cfgf.nonlinear  = 'yes';
+cfgf.resolution = 10; % mm
+cfgf.model      = 'moving';
+cfgf.component  = 1;
+cfgf.dipfit.hartmut = 'yes';
+srcE = ft_dipolefitting(cfgf, comp);
+
+eyedip = srcE.dip(1);
+assert(size(eyedip.pos,1)==2, 'the ocular component should be a 2-dipole pair');
+me = eyedip.mom(:);
+assert(norm(me(4:6) - me(1:3)) < 1e-6*max(1,norm(me(1:3))), 'the eye moments are not linked (M=I)');
+% the two dipoles must be mirror images across the midsagittal (x) plane
+assert(norm(eyedip.pos(2,:) - eyedip.pos(1,:).*[-1 1 1]) < 1e-6, 'the eye pair is not symmetric across x');
+% the structure above (a symmetric, linked-moment pair) is the part that is pinned exactly.
+% the exact depth of the pair is biased by the EEG average reference convention:
+% ft_inverse_dipolefit average references the data while the model leadfield stays raw,
+% shifting the optimum by a few cm. localisation is therefore only asserted loosely here.
+d2eye = min(norm(eyedip.pos(1,:) - pL), norm(eyedip.pos(1,:) - pR));
+assert(d2eye < 45, 'the eye dipole drifted unreasonably far from the eyes'); % mm, loose, see PR notes
+
+%% check 7: end to end, brain + muscle + ocular in one moving fit
+brainpos = [20 30 60]; momB = [1 0 0]'; % mm, norm 70, inside the brain (78)
+musclepos = [75 0 40]; momM = [0 0 1]'; % mm, norm 85, lateral scalp (temporal muscle)
+
+lfB = ft_compute_leadfield(brainpos, elecmm, ommodel);
+lfM = ft_compute_leadfield(musclepos, elecmm, ommodel);
+Vb = lfB*momB;
+Vm = lfM*momM;
+% reuse the ocular topography Veye from check 6
+comp3 = local_topo2comp([Vb Vm Veye], elecmm);
+
+cfgf = [];
+cfgf.headmodel  = ommodel;
+cfgf.elec       = elecmm;
+cfgf.gridsearch = 'yes';
+cfgf.nonlinear  = 'yes';
+cfgf.resolution = 10; % mm
+cfgf.model      = 'moving';
+cfgf.component  = [1 2 3];
+cfgf.dipfit.hartmut = 'yes';
+src3 = ft_dipolefitting(cfgf, comp3);
+
+% component 1 brain, component 2 scalp muscle, component 3 symmetric eyes
+assert(ft_inside_headmodel(src3.dip(1).pos(1,:), ommodel, 'surface', 'brain'), 'component 1 was not fit in the brain');
+assert(ft_inside_headmodel(src3.dip(2).pos(1,:), ommodel, 'surface', 'scalp'), 'component 2 was not fit in the scalp');
+assert(size(src3.dip(3).pos,1)==2, 'component 3 should be a symmetric eye pair');
+
+end % main function
+
+
+%% local helpers
+
+function [elec, headmodel] = local_spheremodel()
+% a 4-shell concentric sphere EEG model in cm, with electrodes on the upper hemisphere
+nchan = 32;
+elec = [];
+elec.label = cellstr(num2str((1:nchan)'));
+elec.unit  = 'cm';
+elec.elecpos = randn(nchan,3);
+elec.elecpos(:,3) = abs(elec.elecpos(:,3));
+for i=1:nchan
+  elec.elecpos(i,:) = 10*elec.elecpos(i,:)/norm(elec.elecpos(i,:));
+end
+elec.chanpos = elec.elecpos;
+elec.tra = eye(nchan);
+
+geom = [];
+geom(1).pos = elec.elecpos*71/85; geom(1).unit = 'cm'; % brain
+geom(2).pos = elec.elecpos*72/85; geom(2).unit = 'cm'; % csf
+geom(3).pos = elec.elecpos*79/85; geom(3).unit = 'cm'; % skull
+geom(4).pos = elec.elecpos*85/85; geom(4).unit = 'cm'; % scalp
+headmodel = ft_headmodel_concentricspheres(geom, 'conductivity', [0.33 1.00 0.042 0.33]);
+end
+
+
+function headmodel = local_nestedspheres()
+% four nested triangulated spheres as a BEM-style head model, ordered outside-in, in mm.
+% no solver is attached; this is used for the geometry-only inside test and as input to
+% ft_headmodel_openmeeg for the gated fits.
+radii = [90 82 80 78]; % scalp, skull, csf, brain (mm)
+[upos, tri] = mesh_sphere(642, 'icosahedron');
+bnd = struct('pos', {}, 'tri', {});
+for i=1:numel(radii)
+  bnd(i).pos = upos*radii(i);
+  bnd(i).tri = tri;
+  bnd(i).unit = 'mm';
+end
+headmodel = [];
+headmodel.bnd  = bnd;
+headmodel.cond = [0.43 0.01 1.79 0.33];
+headmodel.type = 'openmeeg';
+headmodel.unit = 'mm';
+end
+
+
+function elec = local_projectelec(elec, radius)
+% place electrodes on a sphere of the given radius (mm), keeping their directions, so they
+% sit on the BEM scalp surface
+dir = elec.elecpos ./ sqrt(sum(elec.elecpos.^2, 2));
+elec.elecpos = dir*radius;
+elec.chanpos = elec.elecpos;
+elec.unit = 'mm';
+end
+
+
+function comp = local_topo2comp(topo, elec)
+% wrap one or more spatial topographies as a FieldTrip component structure, so that
+% ft_dipolefitting can fit one source per column with cfg.component
+ncomp = size(topo,2);
+comp = [];
+comp.label    = arrayfun(@(k) sprintf('comp%03d', k), (1:ncomp)', 'UniformOutput', false);
+comp.topolabel = elec.label;
+comp.topo     = topo;       % nchan x ncomp
+comp.unmixing = pinv(topo); % ncomp x nchan
+comp.time     = {0};
+comp.trial    = {zeros(ncomp,1)};
+comp.elec     = elec;
+end


### PR DESCRIPTION
# Artefact-aware dipole fitting with HArtMuT

This adds an optional HArtMuT mode to `ft_dipolefitting`, so it can localize muscle and eye artefacts, not just brain sources. On a normal OpenMEEG BEM you set one flag:

```matlab
cfg.dipfit.hartmut = 'yes';
```

and the fit gains scalp candidates for muscle artefacts and a symmetric ocular source for the eyes, next to the usual brain candidates. HArtMuT is described in Harmening et al 2022, J. Neural Eng. 19 066041 (https://doi.org/10.1088/1741-2552/aca8ce).

This is supposed to supersede #2253 and close #2252 - I'm very happy to finally have had some time to implement the outcomes of our discussion back then properly. Thanks to @DanielMiklody for the original issue and first PR, and to @schoffelen for the review, which I tried to consider as closely as possible. 

## What changed since #2253

The first attempt (#2253) put the logic in the low-level `ft_compute_leadfield` OpenMEEG case, and the review in #2252 asked for a higher-level compound source model instead, plus a test, and raised OpenMEEG version compatibility. This PR takes that route:

- The `openmeeg` case of `ft_compute_leadfield` is untouched. HArtMuT lives at the source model and fitting level.
- No special OpenMEEG version is needed. The symmetric eye leadfield is just the sum of two ordinary OpenMEEG leadfields, `L(p) + L(mirror(p))`, so there is no coupling to unmerged solver code. The one feature that would need it, tripolar muscle sources, is left out for now, since my [OpenMEEG PR #603](https://github.com/openmeeg/openmeeg/pull/603) is still open. That is not a real loss: we showed in the [publication](https://doi.org/10.1088/1741-2552/aca8ce) that muscular dipoles plus symmetric ocular dipoles reach comparable artefact source localization.
- The interfering sources are not static. They are fit like any other dipole (grid search, then nonlinear), only seeded from the HArtMuT geometry.
- A reproducibility test is included.

## How it works

Two general features that compose, plus one switch:

- Scalp compartment. `ft_inside_headmodel` gains a `surface` option, so a dipole can be constrained to the scalp (inside the skin, outside the skull) rather than the brain. `ft_prepare_sourcemodel` can then build a compound grid over brain and scalp with a per-point compartment label.
- Linked-moment symmetric dipole. `ft_inverse_dipolefit` gains a `constr.linkmom` option, so a symmetric pair shares one moment (`mom2 = mommap*mom1`, default identity), fit against the fused leadfield above. The output stays an ordinary 2-dipole symmetric pair.
- `ft_dipolefitting` wires these together when `cfg.dipfit.hartmut='yes'`: it scans brain, scalp, and eye candidates, and in the moving model refines an ocular winner as the linked symmetric pair, deriving the mirror axis from the head's `coordsys`.

Files touched: `ft_dipolefitting.m`, `ft_prepare_sourcemodel.m`, `forward/ft_inside_headmodel.m`, `inverse/ft_inverse_dipolefit.m`, `private/hartmut_eyemodel.m`, `private/hartmut_add_eyes.m`, and `test/test_ft_dipolefitting_hartmut.m`.

## Using it

```matlab
cfg = [];
cfg.headmodel      = headmodel;   % a normal openmeeg BEM: scalp, skull, brain
cfg.elec           = elec;
cfg.component      = 1:n;
cfg.model          = 'moving';    % one source per component, required for the eye pair
cfg.dipfit.hartmut = 'yes';       % add scalp (muscle) and symmetric eye candidates
source = ft_dipolefitting(cfg, comp);
```

`cfg.dipfit.compartment` (`'brain'`, `'scalp'`, or `{'brain','scalp'}`) and `cfg.dipfit.eye` (`radius`, `interocular`, `offset`, optional `pos`) are exposed for control. Defaults are unchanged when `hartmut` is off, so nothing else in `ft_dipolefitting` moves.

## Test

`test/test_ft_dipolefitting_hartmut.m` covers, in order: an unchanged brain fit with HArtMuT off, the scalp inside test, the linked-moment constraint, the fused eye leadfield convention, a recovered scalp muscle, a recovered symmetric eye pair, and an end-to-end brain plus muscle plus ocular fit. The OpenMEEG-dependent checks are gated behind `ft_hastoolbox('openmeeg', 3)`.

## Working example

A full runnable example is below. It fits one cortical, one muscle, and one ocular component in a single moving fit and plots the result. Because a proper HArtMuT pipeline needs a neck-extended scalp mesh, this script downloads the HArtMuT template head from the HArtMuT release, so it runs on its own with no data shipped in this PR.
If users want to use individual head models, the `mri` and `electrodes`/`photogrammetry` paths use the individual (neck-extended) anatomies, as e.g. delivered by the automatic [MRIsegmentation pipeline](https://github.com/harmening/MRIsegmentation) and the [PCAwarp individualization tool](https://github.com/harmening/headmodel_individualization) (also available with neck-extension).

<details>
<summary>example_ft_dipolefitting_hartmut.m</summary>

```matlab
function example_ft_dipolefitting_hartmut
% EXAMPLE_FT_DIPOLEFITTING_HARTMUT  worked example of the HArtMuT extension of
% ft_dipolefitting. It fits one cortical, one muscle, and one ocular component in a
% single moving-dipole fit. The cortical source lands in the brain, the muscle in the
% scalp, and the eyes come back as a mirror-symmetric dipole pair.
%
% The point of the example is to show how to go from head surfaces to a HArtMuT fit. You
% pick where the surfaces come from with cfg_source below:
%   'atlas'          load the HArtMuT template surfaces (default, no extra software)
%   'mri'            build them from your own MRI with MRIsegmentation
%   'electrodes'     build them from digitized electrodes with PCAwarp
%   'photogrammetry' build them from a head scan with PCAwarp
%
% Each path loads one .mat that holds:
%   bnd     a 4-element mesh array (scalp, skull, csf, brain), each with .pos, .tri,
%           .unit, and .coordsys. Surfaces decoupled (non-intersecting, nested).
%   tissue  cell array of compartment labels aligned to bnd, the same cell array that
%           ft_headmodel_openmeeg takes, for example {'scalp','skull','csf','brain'}.
%   eye     optional, eye.pos is an N-by-3 set of ocular candidate positions for one eye
%           in the same frame. When present the fit seeds the eyes from this geometry
%           instead of the MNI default.
% The example keeps the scalp, skull, and csf surfaces and builds a 3-shell OpenMEEG BEM,
% using the csf surface as the inner boundary. That is the model HArtMuT and dipfit fit
% with.
%
% Requirements: FieldTrip and OpenMEEG on the path. The 'mri', 'electrodes', and
% 'photogrammetry' paths need extra software and are guarded, so the default 'atlas'
% path runs on its own.
%
% See also FT_DIPOLEFITTING, FT_HEADMODEL_OPENMEEG, FT_INSIDE_HEADMODEL

ft_defaults;

% choose where the head surfaces come from
cfg_source = 'atlas';  % 'atlas' | 'mri' | 'electrodes' | 'photogrammetry'
cfg_head   = 'NYhead';  % 'Colin' | 'NYhead', template head for the atlas tier

%% 1. head surfaces: load a 4-shell bnd, its tissue labels, and optional eyes
switch cfg_source
  case 'atlas'
    % the HArtMuT template surfaces, a release asset of https://github.com/harmening/HArtMuT
    fname = sprintf('hartmut_bnd_%s.mat', cfg_head);
    if ~exist(fname, 'file')
      url = sprintf('https://github.com/harmening/HArtMuT/releases/latest/download/%s', fname);
      try
        websave(fname, url);
      catch err
        ft_error('could not download %s from %s (%s), get it from the HArtMuT releases and put it next to this script', fname, url, err.message);
      end
    end
    assert(exist(fname, 'file')==2, '%s not found, download it from the HArtMuT releases', fname);

  case 'mri'
    % build the surfaces from your own MRI with MRIsegmentation, needs SPM12 and CAT12
    % https://github.com/harmening/MRIsegmentation
    % run start_segmentation('your_T1.nii') first, it writes the labelled bnd below
    fname = 'mri_bnd.mat';
    assert(exist(fname, 'file')==2, ...
      'run MRIsegmentation first, it writes %s, see https://github.com/harmening/MRIsegmentation', fname);

  case {'electrodes', 'photogrammetry'}
    % build the surfaces from digitized electrodes or photogrammetry with PCAwarp, needs
    % the python tool, see https://github.com/harmening/headmodel_individualization
    assert(exist('pcawarp_bnd_mni.mat', 'file')==2, ...
      'run PCAwarp first, see https://github.com/harmening/headmodel_individualization');
    fname = 'pcawarp_bnd_mni.mat';   % use PCAwarp output in MNI, so the standard cap aligns here

  otherwise
    ft_error('unknown cfg_source "%s"', cfg_source);
end

model  = load(fname);
bnd    = model.bnd;      % 4-element mesh array with .pos, .tri, .unit, .coordsys
tissue = model.tissue;   % compartment labels aligned to bnd
eyepos = [];
if isfield(model, 'eye') && isfield(model.eye, 'pos')
  eyepos = model.eye.pos;  % individual ocular candidate positions, optional
end

%% 2. keep scalp, skull, csf and build a 3-shell OpenMEEG BEM
% the surfaces ship as 4 shells. HArtMuT and dipfit fit a 3-shell model, so keep scalp,
% skull, and csf, and let the csf surface act as the inner (brain) boundary.
[bnd, tissue] = select_surfaces(bnd, tissue, {'scalp', 'skull', 'csf'});
tissue{strcmpi(tissue, 'csf')} = 'brain';  % the csf surface is the inner brain boundary

unit     = getfield_default(bnd(1), 'unit', 'mm');
coordsys = getfield_default(bnd(1), 'coordsys', 'acpc');

headmodel = ft_headmodel_openmeeg(bnd, ...
  'conductivity', [0.33 0.0042 0.33], ...
  'tissue', tissue);
headmodel.unit     = unit;
headmodel.coordsys = coordsys;

%% 3. electrodes: a default 10-20 cap, swap in your own montage here
elec = ft_read_sens('standard_1020.elc');  % from template/electrode, mni, close to acpc
elec = ft_convert_units(elec, unit);
keep = 1:2:numel(elec.label);              % thin it out to keep the example quick
elec.label   = elec.label(keep);
elec.elecpos = elec.elecpos(keep,:);
elec.chanpos = elec.chanpos(keep,:);
if isfield(elec, 'tra'), elec.tra = elec.tra(keep,keep); end

%% 4. synthetic data: one cortical, one muscle, and one ocular topography
% build the topographies from leadfields, then wrap them as ICA components so
% ft_dipolefitting fits one dipole per component. The source positions are derived from the
% loaded head, so they are valid for every case. All of them are acpc or mni here, so the
% left-right axis is x.
brainpos  = mean(bnd(end).pos, 1);   % centroid of the inner surface, inside the brain
brainmom  = [1 0.2 0.3]';
% a muscle source in the scalp: the most lateral scalp vertex moved a few mm inward, into the
% soft tissue between scalp and skull
[~, k]    = max(abs(bnd(1).pos(:,1)));
sv        = bnd(1).pos(k,:);
inward    = mean(bnd(1).pos, 1) - sv; inward = inward / norm(inward);
musclepos = sv + 5*ft_scalingfactor('mm', unit)*inward;
musclemom = [0 0 1]';

% the eyes: drive both with the same moment. use the shipped eye centre when present,
% otherwise the default HArtMuT eye geometry (mni/colin frame, close to acpc colin)
if ~isempty(eyepos)
  eyeleft = mean(eyepos, 1);  % centre of the shipped candidates for one eye
else
  eyeleft = [-35 72 -25];     % see private/hartmut_eyemodel.m
end
eyeright = eyeleft .* [-1 1 1];   % the partner eye, mirrored across the midsagittal plane x=0
eyemom   = [0.6 0.1 -0.5]';

lfBrain  = ft_compute_leadfield(brainpos,  elec, headmodel);
lfMuscle = ft_compute_leadfield(musclepos, elec, headmodel);
lfEyeL   = ft_compute_leadfield(eyeleft,   elec, headmodel);
lfEyeR   = ft_compute_leadfield(eyeright,  elec, headmodel);

topo = [lfBrain*brainmom, lfMuscle*musclemom, lfEyeL*eyemom + lfEyeR*eyemom];

comp = [];
comp.label     = {'cortical'; 'muscle'; 'ocular'};
comp.topolabel = elec.label;
comp.topo      = topo;        % nchan x 3
comp.unmixing  = pinv(topo);  % 3 x nchan
comp.time      = {0};
comp.trial     = {zeros(3,1)};
comp.elec      = elec;

%% 5. fit all three components in one moving fit, HArtMuT on
cfg = [];
cfg.headmodel      = headmodel;
cfg.elec           = elec;
cfg.component      = [1 2 3];
cfg.model          = 'moving';   % needed for the symmetric eye pair, one source per component
cfg.gridsearch     = 'yes';      % like dipfit_gridsearch
cfg.nonlinear      = 'yes';      % like dipfit_nonlinear
cfg.resolution     = 10;         % mm grid for the scan
cfg.dipfit.hartmut = 'yes';      % brain, scalp, and symmetric eye candidates
if ~isempty(eyepos)
  cfg.dipfit.eye.pos = eyepos;   % seed the eyes from the shipped geometry
end
source = ft_dipolefitting(cfg, comp);

fprintf('\nwith HArtMuT:\n');
report_sources(source, comp, headmodel);

%% 6. optional: the same fit without HArtMuT forces the artefacts into the brain
cfg.dipfit.hartmut = 'no';
brainonly = ft_dipolefitting(cfg, comp);
fprintf('\nwithout HArtMuT (brain-only model), the muscle and ocular sources have no\n');
fprintf('scalp or eye candidates, so they are mislocalised:\n');
report_sources(brainonly, comp, headmodel);

%% 7. plot the scalp, the electrodes, and the fitted sources
set(0, 'DefaultFigureVisible', 'off');  % headless safe, drop this line to see the figure
figure; hold on;
ft_plot_mesh(headmodel.bnd(1), 'facealpha', 0.15, 'edgecolor', 'none', 'facecolor', [0.6 0.6 0.6]);
ft_plot_sens(elec, 'elecsize', 12);
colors = [0 0 0.8; 0 0.6 0; 0.8 0 0];  % cortical, muscle, ocular
for k = 1:numel(source.dip)
  dip = source.dip(k);
  for d = 1:size(dip.pos,1)
    ft_plot_dipole(dip.pos(d,:), dip.mom(3*d-2:3*d), 'color', colors(k,:), 'unit', unit);
  end
end
view([130 10]); camlight;
title('HArtMuT fit: cortical (blue), muscle (green), ocular pair (red)');
print(gcf, 'example_hartmut_fit.png', '-dpng', '-r150');

end % main function


function [bnd, tissue] = select_surfaces(bnd, tissue, wanted)
% pick named compartments using the parallel tissue cell array, in the requested order
labels = lower(tissue);
idx = zeros(1, numel(wanted));
for i = 1:numel(wanted)
  j = find(strcmp(labels, lower(wanted{i})), 1);
  if isempty(j)
    ft_error('compartment "%s" not found in the tissue list', wanted{i});
  end
  idx(i) = j;
end
bnd    = bnd(idx);
tissue = tissue(idx);
end


function report_sources(source, comp, headmodel)
% print where each fitted component landed
labels = comp.label;
for k = 1:numel(source.dip)
  dip = source.dip(k);
  if size(dip.pos, 1) == 2
    fprintf('%-9s symmetric eye pair at [%.0f %.0f %.0f] and [%.0f %.0f %.0f] mm\n', ...
      labels{k}, dip.pos(1,:), dip.pos(2,:));
  else
    inbrain = ft_inside_headmodel(dip.pos(1,:), headmodel, 'surface', 'brain');
    where = 'scalp';
    if inbrain, where = 'brain'; end
    fprintf('%-9s single dipole in the %s at [%.0f %.0f %.0f] mm\n', ...
      labels{k}, where, dip.pos(1,:));
  end
end
end


function v = getfield_default(s, name, default)
% read a field if present, otherwise return a default
if isfield(s, name) && ~isempty(s.(name))
  v = s.(name);
else
  v = default;
end
end
```
</details>

## Notes and limitations

- HArtMuT mode is EEG only.
- The symmetric eyes need the moving model and a recognized `coordsys` (for example `mni`, `acpc`, or `ctf`) to derive the mirror axis. Without one, or without eye geometry, the eyes fall back to single dipoles with a warning (slightly worse performance, see publication), but the whole artifact-aware fitting still works.
- Average reference. `ft_inverse_dipolefit` average references the EEG data but builds the model from a raw (non-average-referenced) leadfield. For a well-conditioned single dipole, this shifts the position by well under a millimeter and has never mattered. For a synchronous ocular pair, the same mismatch sometimes shifts the eye optimum by a few cm. We handle this in the example and test and flag it here. I did not change the core fitting math in fieldtrip, since that would affect every EEG dipole fit and might be better decided by you. Happy to discuss the cleanest fix.

## Open questions for the maintainers

- Where a worked example or tutorial should live in the repo, if anywhere.
- Whether a CI wrapper around the example is wanted, gated on OpenMEEG and data reachability.
