### PR TITLE
FIX - make ft_hastoolbox('signal') test robust

### DIFF
--- a/test/test_ft_defaults_signal.m
+++ b/test/test_ft_defaults_signal.m
@@ -1,0 +1,32 @@
+function test_ft_defaults_signal
+
+% MEM 1gb
+% WALLTIME 00:03:00
+% DEPENDENCY ft_hastoolbox ft_defaults
+% DATA no
+
+% external/signal must stay on the path when the Signal Processing Toolbox is
+% licensed but not installed, across repeated re-initialisation of ft_defaults
+
+origpath = path;
+cleanup  = onCleanup(@() path(origpath)); %#ok<NASGU>
+
+% simulate a toolbox that is licensed but not installed, as on CI runners
+sigroot = fullfile(matlabroot, 'toolbox', 'signal');
+p = strsplit(path, pathsep);
+p = p(~strncmpi(p, sigroot, numel(sigroot)));
+path(strjoin(p, pathsep));
+
+external_signal = fullfile(fileparts(which('ft_defaults')), 'external', 'signal');
+
+for k = 1:4
+  clear ft_defaults
+  ft_defaults;
+
+  if ~contains(path, external_signal)
+    error('external/signal is not on the path after %d ft_defaults call(s)', k);
+  end
+  if isempty(which('butter'))
+    error('butter is undefined after %d ft_defaults call(s)', k);
+  end
+end

--- a/utilities/ft_hastoolbox.m
+++ b/utilities/ft_hastoolbox.m
@@ -304,7 +304,7 @@ switch toolbox
   case 'COMM'
     dependency = {has_license('communication_toolbox'), 'de2bi', 'fskmod', 'pskmod'};       % also check the availability of a toolbox license
   case 'SIGNAL'
-    dependency = {has_license('signal_toolbox'), 'window', 'hanning'};                      % also check the availability of a toolbox license
+    dependency = {has_license('signal_toolbox'), 'medfilt1', 'freqz'};                      % these must not be functions that external/signal provides
   case 'IMAGES'
     dependency = {has_license('image_toolbox'), 'imerode', 'imdilate'};                     % also check the availability of a toolbox license
   case 'VISION'


### PR DESCRIPTION
## Summary

Issue #2605 explains the problem

The solution was to make the check for availability of the signal toolbox more robust by checking for functions that are not supplied in `external/signal`.

Change ft_hastoolbox('signal') to test for functions that are not provided in external/signal. It tested for window() and hanning(), both of which external/signal provides itself. Once ft_defaults had added that directory the check reported the MathWorks toolbox as present, so the next re-initialisation removed it again and butter, filtfilt and fir1 became undefined. has_license tests the entitlement rather than the installation, so the license half of the check passed even where the product was absent, which is the norm on hosted CI runners.

The same problem might also occur for other toolboxes and the same solution could apply

## Checklist

- [x] I added unit tests and integration tests for each feature (if applicable).
- [x] No error nor warning in the console.
- [ ] I joined a screenshot of the app before and after the fix.
