### PR TITLE
ft_statfun_depsamplesregrT: fix undefined variable in the cvar branch

### DIFF
--- a/statfun/ft_statfun_depsamplesregrT.m
+++ b/statfun/ft_statfun_depsamplesregrT.m
@@ -95,7 +95,7 @@ if strcmp(cfg.computestat,'yes')
     else
       designmat=zeros((nblocks+1),length(indvar));
       for blockindx=1:nblocks
-        blockselvec=find(design(cfg.cvar,unitselved)==condlabels(blockindx));
+        blockselvec=find(design(cfg.cvar,unitselvec)==condlabels(blockindx));
         designmat(blockindx,blockselvec)=1;
       end
       designmat((nblocks+1),:)=indvar;


### PR DESCRIPTION
The control-variable branch of `ft_statfun_depsamplesregrT` indexes `design(cfg.cvar, unitselved)`; the variable is `unitselvec`, so any call with a non-empty `cfg.cvar` fails with `'unitselved' undefined` (line 98). Reproduced on master: without `cfg.cvar` the statfun runs; with `cfg.cvar = 3` it errors. One-character fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012d2sJAD5EUp4GqAStqoBX7