### PR TITLE
Warn about uncorrected two-sided testing for any alpha

### DIFF
--- a/ft_statistics_montecarlo.m
+++ b/ft_statistics_montecarlo.m
@@ -219,7 +219,7 @@ if isfield(cfg,'correctp') && strcmp(cfg.correctp,'yes')
 elseif isfield(cfg,'correctp') && strcmp(cfg.correctp,'no')
   cfg = ft_checkconfig(cfg, 'renamed', {'correctp', 'correcttail'});
 end
-if strcmp(cfg.correcttail,'no') && cfg.tail==0 && cfg.alpha==0.05
+if strcmp(cfg.correcttail,'no') && cfg.tail==0
   ft_warning('Doing a two-sided test without correcting p-values or alpha-level, p-values and alpha-level will reflect one-sided tests per tail. See http://bit.ly/2YQ1Hm8')
 end
 


### PR DESCRIPTION
`ft_statistics_montecarlo` warns that a two-sided test with `cfg.correcttail='no'` evaluates each tail at the full alpha, but only when `cfg.alpha==0.05` exactly. A user who sets alpha to 0.01 or 0.1 is in the same situation and gets no warning. This drops the alpha condition so the warning is issued whenever `cfg.tail==0` and `cfg.correcttail=='no'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012d2sJAD5EUp4GqAStqoBX7